### PR TITLE
Rewrite concat to start producers iteratively

### DIFF
--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -348,7 +348,7 @@ extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Err
 		func startNextIfNeeded() {
 			while let producer = state.modify({ $0.dequeue() }) {
 				producer.startWithSignal { signal, inner in
-					let handle = disposable?.add(inner) ?? nil
+					let handle = disposable?.add(inner)
 
 					signal.observe { event in
 						switch event {

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -442,7 +442,7 @@ extension SignalProducerProtocol {
 }
 
 private final class ConcatState<Value, Error: Swift.Error> {
-	typealias SignalProducer = ReactiveCocoa.SignalProducer<Value, Error>
+	typealias SignalProducer = ReactiveSwift.SignalProducer<Value, Error>
 	
 	/// The active producer, if any.
 	var active: SignalProducer? = nil

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -384,9 +384,7 @@ extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Err
 
 			case .completed:
 				state.modify { state in
-					state.queue.append(SignalProducer.empty.on(completed: {
-						observer.sendCompleted()
-					}))
+					state.queue.append(SignalProducer.empty.on(completed: observer.sendCompleted))
 				}
 				startNextIfNeeded()
 				


### PR DESCRIPTION
Recursively starting the inner producers can blow the stack if they
complete immediately.

Reopened from https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3161.