### PR TITLE
Rename `next` to `value`

### DIFF
--- a/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
@@ -37,11 +37,11 @@ is no random access to values of a signal.
 Signals can be manipulated by applying [primitives](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Documentation/BasicOperators.md) to them.
 Typical primitives to manipulate a single signal like `filter`, `map` and
 `reduce` are available, as well as primitives to manipulate multiple signals
-at once (`zip`). Primitives operate only on the `Next` events of a signal.
+at once (`zip`). Primitives operate only on the `value` events of a signal.
 
-The lifetime of a signal consists of any number of `Next` events, followed by
-one terminating event, which may be any one of `Failed`, `Completed`, or
-`Interrupted` (but not a combination).
+The lifetime of a signal consists of any number of `value` events, followed by
+one terminating event, which may be any one of `failed`, `completed`, or
+`interrupted` (but not a combination).
 Terminating events are not included in the signal’s values—they must be
 handled specially.
 */
@@ -55,15 +55,15 @@ scopedExample("Subscription") {
 	// Signal.pipe is a way to manually control a signal. the returned observer can be used to send values to the signal
 	let (signal, observer) = Signal<Int, NoError>.pipe()
 
-	let subscriber1 = Observer<Int, NoError>(next: { print("Subscriber 1 received \($0)") } )
-	let subscriber2 = Observer<Int, NoError>(next: { print("Subscriber 2 received \($0)") } )
+	let subscriber1 = Observer<Int, NoError>(value: { print("Subscriber 1 received \($0)") } )
+	let subscriber2 = Observer<Int, NoError>(value: { print("Subscriber 2 received \($0)") } )
 
 	print("Subscriber 1 subscribes to the signal")
 	signal.observe(subscriber1)
 
 	print("Send value `10` on the signal")
 	// subscriber1 will receive the value
-	observer.sendNext(10)
+	observer.send(value: 10)
 
 	print("Subscriber 2 subscribes to the signal")
 	// Notice how nothing happens at this moment, i.e. subscriber2 does not receive the previously sent value
@@ -71,7 +71,7 @@ scopedExample("Subscription") {
 
 	print("Send value `20` on the signal")
 	// Notice that now, subscriber1 and subscriber2 will receive the value
-	observer.sendNext(20)
+	observer.send(value: 20)
 }
 
 /*:
@@ -82,7 +82,7 @@ scopedExample("`empty`") {
 	let emptySignal = Signal<Int, NoError>.empty
 
 	let observer = Observer<Int, NoError>(
-		next: { _ in print("next not called") },
+		value: { _ in print("value not called") },
 		failed: { _ in print("error not called") },
 		completed: { print("completed not called") },
 		interrupted: { print("interrupted called") }
@@ -99,7 +99,7 @@ scopedExample("`never`") {
 	let neverSignal = Signal<Int, NoError>.never
 
 	let observer = Observer<Int, NoError>(
-		next: { _ in print("next not called") },
+		value: { _ in print("value not called") },
 		failed: { _ in print("error not called") },
 		completed: { print("completed not called") },
 		interrupted: { print("interrupted not called") }
@@ -120,17 +120,17 @@ the memory footprint.
 */
 scopedExample("`uniqueValues`") {
 	let (signal, observer) = Signal<Int, NoError>.pipe()
-	let subscriber = Observer<Int, NoError>(next: { print("Subscriber received \($0)") } )
+	let subscriber = Observer<Int, NoError>(value: { print("Subscriber received \($0)") } )
 	let uniqueSignal = signal.uniqueValues()
 
 	uniqueSignal.observe(subscriber)
-	observer.sendNext(1)
-	observer.sendNext(2)
-	observer.sendNext(3)
-	observer.sendNext(4)
-	observer.sendNext(3)
-	observer.sendNext(3)
-	observer.sendNext(5)
+	observer.send(value: 1)
+	observer.send(value: 2)
+	observer.send(value: 3)
+	observer.send(value: 4)
+	observer.send(value: 3)
+	observer.send(value: 3)
+	observer.send(value: 5)
 }
 
 /*:
@@ -139,12 +139,12 @@ Maps each value in the signal to a new value.
 */
 scopedExample("`map`") {
 	let (signal, observer) = Signal<Int, NoError>.pipe()
-	let subscriber = Observer<Int, NoError>(next: { print("Subscriber received \($0)") } )
+	let subscriber = Observer<Int, NoError>(value: { print("Subscriber received \($0)") } )
 	let mappedSignal = signal.map { $0 * 2 }
 
 	mappedSignal.observe(subscriber)
 	print("Send value `10` on the signal")
-	observer.sendNext(10)
+	observer.send(value: 10)
 }
 
 /*:
@@ -163,7 +163,7 @@ scopedExample("`mapError`") {
 
 	mappedErrorSignal.observe(subscriber)
 	print("Send error `NSError(domain: \"com.reactivecocoa.errordomain\", code: 4815, userInfo: nil)` on the signal")
-	observer.sendFailed(NSError(domain: "com.reactivecocoa.errordomain", code: 4815, userInfo: nil))
+	observer.send(error: NSError(domain: "com.reactivecocoa.errordomain", code: 4815, userInfo: nil))
 }
 
 /*:
@@ -172,16 +172,16 @@ Preserves only the values of the signal that pass the given predicate.
 */
 scopedExample("`filter`") {
 	let (signal, observer) = Signal<Int, NoError>.pipe()
-	let subscriber = Observer<Int, NoError>(next: { print("Subscriber received \($0)") } )
+	let subscriber = Observer<Int, NoError>(value: { print("Subscriber received \($0)") } )
 	// subscriber will only receive events with values greater than 12
 	let filteredSignal = signal.filter { $0 > 12 ? true : false }
 
 	filteredSignal.observe(subscriber)
-	observer.sendNext(10)
-	observer.sendNext(11)
-	observer.sendNext(12)
-	observer.sendNext(13)
-	observer.sendNext(14)
+	observer.send(value: 10)
+	observer.send(value: 11)
+	observer.send(value: 12)
+	observer.send(value: 13)
+	observer.send(value: 14)
 }
 
 /*:
@@ -193,13 +193,13 @@ scopedExample("`skipNil`") {
 	let (signal, observer) = Signal<Int?, NoError>.pipe()
 	// note that the signal is of type `Int?` and observer is of type `Int`, given we're unwrapping
 	// non-`nil` values
-	let subscriber = Observer<Int, NoError>(next: { print("Subscriber received \($0)") } )
+	let subscriber = Observer<Int, NoError>(value: { print("Subscriber received \($0)") } )
 	let skipNilSignal = signal.skipNil()
 
 	skipNilSignal.observe(subscriber)
-	observer.sendNext(1)
-	observer.sendNext(nil)
-	observer.sendNext(3)
+	observer.send(value: 1)
+	observer.send(value: nil)
+	observer.send(value: 3)
 }
 
 /*:
@@ -208,14 +208,14 @@ Returns a signal that will yield the first `count` values from `self`
 */
 scopedExample("`take(first:)`") {
 	let (signal, observer) = Signal<Int, NoError>.pipe()
-	let subscriber = Observer<Int, NoError>(next: { print("Subscriber received \($0)") } )
+	let subscriber = Observer<Int, NoError>(value: { print("Subscriber received \($0)") } )
 	let takeSignal = signal.take(first: 2)
 
 	takeSignal.observe(subscriber)
-	observer.sendNext(1)
-	observer.sendNext(2)
-	observer.sendNext(3)
-	observer.sendNext(4)
+	observer.send(value: 1)
+	observer.send(value: 2)
+	observer.send(value: 3)
+	observer.send(value: 4)
 }
 
 /*:
@@ -228,13 +228,9 @@ scopedExample("`collect`") {
 	let (signal, observer) = Signal<Int, NoError>.pipe()
 	// note that the signal is of type `Int` and observer is of type `[Int]` given we're "collecting"
 	// `Int` values for the lifetime of the signal
-	let subscriber = Observer<[Int], NoError>(next: { print("Subscriber received \($0)") } )
+	let subscriber = Observer<[Int], NoError>(value: { print("Subscriber received \($0)") } )
 	let collectSignal = signal.collect()
 
 	collectSignal.observe(subscriber)
-	observer.sendNext(1)
-	observer.sendNext(2)
-	observer.sendNext(3)
-	observer.sendNext(4)
-	observer.sendCompleted()
-}
+	observer.send(value: 1)
+	observer.send(value: 2)

--- a/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
@@ -234,3 +234,7 @@ scopedExample("`collect`") {
 	collectSignal.observe(subscriber)
 	observer.send(value: 1)
 	observer.send(value: 2)
+	observer.send(value: 3)
+	observer.send(value: 4)
+	observer.sendCompleted()
+}

--- a/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -53,12 +53,12 @@ This means that a subscriber will never miss any values sent by the SignalProduc
 scopedExample("Subscription") {
 	let producer = SignalProducer<Int, NoError> { observer, _ in
 		print("New subscription, starting operation")
-		observer.sendNext(1)
-		observer.sendNext(2)
+		observer.send(value: 1)
+		observer.send(value: 2)
 	}
 
-	let subscriber1 = Observer<Int, NoError>(next: { print("Subscriber 1 received \($0)") })
-	let subscriber2 = Observer<Int, NoError>(next: { print("Subscriber 2 received \($0)") })
+	let subscriber1 = Observer<Int, NoError>(value: { print("Subscriber 1 received \($0)") })
+	let subscriber2 = Observer<Int, NoError>(value: { print("Subscriber 2 received \($0)") })
 
 	print("Subscriber 1 subscribes to producer")
 	producer.start(subscriber1)
@@ -77,7 +77,7 @@ scopedExample("`empty`") {
 	let emptyProducer = SignalProducer<Int, NoError>.empty
 
 	let observer = Observer<Int, NoError>(
-		next: { _ in print("next not called") },
+		value: { _ in print("value not called") },
 		failed: { _ in print("error not called") },
 		completed: { print("completed called") }
 	)
@@ -93,7 +93,7 @@ scopedExample("`never`") {
 	let neverProducer = SignalProducer<Int, NoError>.never
 
 	let observer = Observer<Int, NoError>(
-		next: { _ in print("next not called") },
+		value: { _ in print("value not called") },
 		failed: { _ in print("error not called") },
 		completed: { print("completed not called") }
 	)
@@ -115,7 +115,7 @@ scopedExample("`startWithSignal`") {
 	var value: Int?
 
 	SignalProducer<Int, NoError>(value: 42)
-		.on(next: {
+		.on(value: {
 			value = $0
 		})
 		.startWithSignal { signal, disposable in
@@ -128,7 +128,7 @@ scopedExample("`startWithSignal`") {
 /*:
 ### `startWithResult`
 Creates a Signal from the producer, then adds exactly one observer to
-the Signal, which will invoke the given callback when `next` or `failed`
+the Signal, which will invoke the given callback when `value` or `failed`
 events are received.
 
 Returns a Disposable which can be used to interrupt the work associated
@@ -142,9 +142,9 @@ scopedExample("`startWithResult`") {
 }
 
 /*:
-### `startWithNext`
+### `startWithValues`
 Creates a Signal from the producer, then adds exactly one observer to
-the Signal, which will invoke the given callback when `next` events are
+the Signal, which will invoke the given callback when `value` events are
 received.
 
 This method is available only if the producer never emits error, or in
@@ -153,9 +153,9 @@ other words, has an error type of `NoError`.
 Returns a Disposable which can be used to interrupt the work associated
 with the Signal, and prevent any future callbacks from being invoked.
 */
-scopedExample("`startWithNext`") {
+scopedExample("`startWithValues`") {
 	SignalProducer<Int, NoError>(value: 42)
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -228,7 +228,7 @@ scopedExample("`lift`") {
 
 	SignalProducer<Int, NoError>(value: 0)
 		.lift(transform)
-		.startWithNext { _ in
+		.startWithValues { _ in
 			print(counter)
 		}
 }
@@ -240,7 +240,7 @@ Maps each value in the producer to a new value.
 scopedExample("`map`") {
 	SignalProducer<Int, NoError>(value: 1)
 		.map { $0 + 41 }
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -264,7 +264,7 @@ Preserves only the values of the producer that pass the given predicate.
 scopedExample("`filter`") {
 	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
 		.filter { $0 > 3 }
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -277,7 +277,7 @@ input producer.
 scopedExample("`take(first:)`") {
 	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
 		.take(first: 2)
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -305,14 +305,14 @@ Returns a producer that will yield an array of values until it completes.
 */
 scopedExample("`collect`") {
 	SignalProducer<Int, NoError> { observer, disposable in
-		observer.sendNext(1)
-		observer.sendNext(2)
-		observer.sendNext(3)
-		observer.sendNext(4)
+		observer.send(value: 1)
+		observer.send(value: 2)
+		observer.send(value: 3)
+		observer.send(value: 4)
 		observer.sendCompleted()
 	}
 		.collect()
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -323,14 +323,14 @@ Returns a producer that will yield an array of values until it reaches a certain
 */
 scopedExample("`collect(count:)`") {
 	SignalProducer<Int, NoError> { observer, disposable in
-		observer.sendNext(1)
-		observer.sendNext(2)
-		observer.sendNext(3)
-		observer.sendNext(4)
+		observer.send(value: 1)
+		observer.send(value: 2)
+		observer.send(value: 3)
+		observer.send(value: 4)
 		observer.sendCompleted()
 	}
 		.collect(count: 2)
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -346,14 +346,14 @@ values will sent an empty array of values.
 */
 scopedExample("`collect(_:)` matching values inclusively") {
 	SignalProducer<Int, NoError> { observer, disposable in
-		observer.sendNext(1)
-		observer.sendNext(2)
-		observer.sendNext(3)
-		observer.sendNext(4)
+		observer.send(value: 1)
+		observer.send(value: 2)
+		observer.send(value: 3)
+		observer.send(value: 4)
 		observer.sendCompleted()
 	}
 		.collect { values in values.reduce(0, +) == 3 }
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -369,14 +369,14 @@ values will sent an empty array of values.
 */
 scopedExample("`collect(_:)` matching values exclusively") {
 	SignalProducer<Int, NoError> { observer, disposable in
-		observer.sendNext(1)
-		observer.sendNext(2)
-		observer.sendNext(3)
-		observer.sendNext(4)
+		observer.send(value: 1)
+		observer.send(value: 2)
+		observer.send(value: 3)
+		observer.send(value: 4)
 		observer.sendCompleted()
 	}
 		.collect { values, next in next == 3 }
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -396,7 +396,7 @@ scopedExample("`combineLatest(with:)`") {
 
 	producer1
 		.combineLatest(with: producer2)
-		.startWithNext { value in
+		.startWithValues { value in
 			print("\(value)")
 		}
 }
@@ -409,7 +409,7 @@ everything afterward.
 scopedExample("`skip(first:)`") {
 	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
 		.skip(first: 2)
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -429,14 +429,14 @@ the resulting producer will send the Event itself and then interrupt.
 scopedExample("`materialize`") {
 	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
 		.materialize()
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
 
 /*:
 ### `sample(on:)`
-Forwards the latest value from `self` whenever `sampler` sends a Next
+Forwards the latest value from `self` whenever `sampler` sends a `value`
 event.
 
 If `sampler` fires before a value has been observed on `self`, nothing
@@ -453,7 +453,7 @@ scopedExample("`sample(on:)`") {
 
 	baseProducer
 		.sample(on: sampledOnProducer)
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -468,7 +468,7 @@ sends its first value.
 scopedExample("`combinePrevious`") {
 	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
 		.combinePrevious(42)
-		.startWithNext { value in
+		.startWithValues { value in
 			print("\(value)")
 		}
 }
@@ -484,7 +484,7 @@ first argument when the next value is emitted, and so on.
 scopedExample("`scan`") {
 	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
 		.scan(0, +)
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -496,7 +496,7 @@ Like `scan`, but sends only the final value and then immediately completes.
 scopedExample("`reduce`") {
 	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
 		.reduce(0, +)
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -509,7 +509,7 @@ respect to the previous value. The first value is always forwarded.
 scopedExample("`skipRepeats`") {
 	SignalProducer<Int, NoError>(values: [ 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 1, 1, 1, 2, 2, 2, 4 ])
 		.skipRepeats(==)
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -523,7 +523,7 @@ scopedExample("`skip(while:)`") {
 	// Note that trailing closure is used for `skip(while:)`.
 	SignalProducer<Int, NoError>(values: [ 3, 3, 3, 3, 1, 2, 3, 4 ])
 		.skip { $0 > 2 }
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -532,7 +532,7 @@ scopedExample("`skip(while:)`") {
 ### `take(untilReplacement:)`
 Forwards events from `self` until `replacement` begins sending events.
 
-Returns a producer which passes through `Next`, `Failed`, and `Interrupted`
+Returns a producer which passes through `value`, `failed`, and `interrupted`
 events from `self` until `replacement` sends an event, at which point the
 returned producer will send that event and switch to passing through events
 from `replacement` instead, regardless of whether `self` has sent events
@@ -542,20 +542,20 @@ scopedExample("`take(untilReplacement:)`") {
 	let (replacementSignal, incomingReplacementObserver) = Signal<Int, NoError>.pipe()
 
 	let baseProducer = SignalProducer<Int, NoError> { incomingObserver, _ in
-		incomingObserver.sendNext(1)
-		incomingObserver.sendNext(2)
-		incomingObserver.sendNext(3)
+		incomingObserver.send(value: 1)
+		incomingObserver.send(value: 2)
+		incomingObserver.send(value: 3)
 
-		incomingReplacementObserver.sendNext(42)
+		incomingReplacementObserver.send(value: 42)
 
-		incomingObserver.sendNext(4)
+		incomingObserver.send(value: 4)
 
-		incomingReplacementObserver.sendNext(42)
+		incomingReplacementObserver.send(value: 42)
 	}
 
 	baseProducer
 		.take(untilReplacement: replacementSignal)
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -568,7 +568,7 @@ on the returned producer.
 scopedExample("`take(last:)`") {
 	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
 		.take(last: 2)
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -581,7 +581,7 @@ values are dropped.
 scopedExample("`skipNil`") {
 	SignalProducer<Int?, NoError>(values: [ nil, 1, 2, nil, 3, 4, nil ])
 		.skipNil()
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -598,7 +598,7 @@ scopedExample("`zip(with:)`") {
 
 	baseProducer
 		.zip(with: zippedProducer)
-		.startWithNext { value in
+		.startWithValues { value in
 			print("\(value)")
 		}
 }
@@ -631,9 +631,9 @@ scopedExample("`retry(upTo:)`") {
 	SignalProducer<Int, NSError> { observer, disposable in
 		if tries == 0 {
 			tries += 1
-			observer.sendFailed(NSError(domain: "retry", code: 0, userInfo: nil))
+			observer.send(error: NSError(domain: "retry", code: 0, userInfo: nil))
 		} else {
-			observer.sendNext(42)
+			observer.send(value: 42)
 			observer.sendCompleted()
 		}
 	}
@@ -656,7 +656,7 @@ scopedExample("`then`") {
 
 	baseProducer
 		.then(thenProducer)
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -689,15 +689,15 @@ scopedExample("`replayLazily(upTo:)`") {
 	let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4, 42 ])
 		.replayLazily(upTo: 2)
 
-	baseProducer.startWithNext { value in
+	baseProducer.startWithValues { value in
 		print(value)
 	}
 
-	baseProducer.startWithNext { value in
+	baseProducer.startWithValues { value in
 		print(value)
 	}
 
-	baseProducer.startWithNext { value in
+	baseProducer.startWithValues { value in
 		print(value)
 	}
 }
@@ -714,7 +714,7 @@ will forward that failure immediately.
 scopedExample("`flatMap(.latest)`") {
 	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
 		.flatMap(.latest) { SignalProducer(value: $0 + 3) }
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -727,7 +727,7 @@ that starts in its place.
 scopedExample("`flatMapError`") {
 	SignalProducer<Int, NSError>(error: NSError(domain: "flatMapError", code: 42, userInfo: nil))
 		.flatMapError { SignalProducer<Int, NoError>(value: $0.code) }
-		.startWithNext { value in
+		.startWithValues { value in
 			print(value)
 		}
 }
@@ -735,7 +735,7 @@ scopedExample("`flatMapError`") {
 /*:
 ### `sample(with:)`
 Forwards the latest value from `self` with the value from `sampler` as a tuple,
-only when `sampler` sends a Next event.
+only when `sampler` sends a `value` event.
 
 If `sampler` fires before a value has been observed on `self`, nothing happens.
 Returns a producer that will send values from `self` and `sampler`,
@@ -748,7 +748,7 @@ scopedExample("`sample(with:)`") {
 
 	let result = producer.sample(with: sampler)
 
-	result.startWithNext { left, right in
+	result.startWithValues { left, right in
 		print("\(left) \(right)")
 	}
 }
@@ -759,9 +759,4 @@ Logs all events that the receiver sends.
 By default, it will print to the standard output.
 */
 scopedExample("`log events`") {
-	let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4, 42 ])
-
-	baseProducer
-		.logEvents(identifier: "Playground is fun!")
-		.start()
-}
+	let baseProducer = SignalProducer<Int, NoError

--- a/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -759,4 +759,9 @@ Logs all events that the receiver sends.
 By default, it will print to the standard output.
 */
 scopedExample("`log events`") {
-	let baseProducer = SignalProducer<Int, NoError
+	let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4, 42 ])
+	
+ 	baseProducer
+ 		.logEvents(identifier: "Playground is fun!")
+ 		.start()
+ }

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -119,7 +119,7 @@ public final class Action<Input, Output, Error: Swift.Error> {
 			}
 
 			if !startedExecuting {
-				observer.sendFailed(.disabled)
+				observer.send(error: .disabled)
 				return
 			}
 
@@ -128,7 +128,7 @@ public final class Action<Input, Output, Error: Swift.Error> {
 
 				signal.observe { event in
 					observer.action(event.mapError(ActionError.producerFailed))
-					self.eventsObserver.sendNext(event)
+					self.eventsObserver.send(value: event)
 				}
 			}
 

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -63,7 +63,7 @@ extension ActionProtocol {
 // Renamed Enum cases
 
 extension Event {
-	@available(*, unavailable, renamed:"next")
+	@available(*, unavailable, renamed:"value")
 	public static var Next: Event<Value, Error> { fatalError() }
 
 	@available(*, unavailable, renamed:"failed")
@@ -105,6 +105,24 @@ extension Bag {
 extension CompositeDisposable {
 	@available(*, unavailable, renamed:"add(_:)")
 	public func addDisposable(_ d: Disposable) -> DisposableHandle { fatalError() }
+}
+
+extension Observer {
+	@available(*, unavailable, renamed: "init(value:failed:completed:interrupted:)")
+	public convenience init(
+		next: ((Value) -> Void)? = nil,
+		failed: ((Error) -> Void)? = nil,
+		completed: (() -> Void)? = nil,
+		interrupted: (() -> Void)? = nil
+		) { fatalError() }
+}
+
+extension ObserverProtocol {
+	@available(*, unavailable, renamed: "send(value:)")
+	public func sendNext(_ value: Value) { fatalError() }
+	
+	@available(*, unavailable, renamed: "send(error:)")
+	public func sendFailed(_ error: Error) { fatalError() }
 }
 
 extension SignalProtocol {
@@ -151,6 +169,11 @@ extension SignalProtocol {
 extension SignalProtocol where Value: OptionalProtocol {
 	@available(*, unavailable, renamed:"skipNil()")
 	public func ignoreNil() -> SignalProducer<Value.Wrapped, Error> { fatalError() }
+}
+
+extension SignalProtocol where Error == NoError {
+	@available(*, unavailable, renamed: "observeValues")
+	public func observeNext(_ next: (Value) -> Void) -> Disposable? { fatalError() }
 }
 
 extension SignalProducerProtocol {
@@ -215,6 +238,11 @@ extension SignalProducerProtocol {
 extension SignalProducerProtocol where Value: OptionalProtocol {
 	@available(*, unavailable, renamed:"skipNil()")
 	public func ignoreNil() -> SignalProducer<Value.Wrapped, Error> { fatalError() }
+}
+
+extension SignalProducerProtocol where Error == NoError {
+	@available(*, unavailable, renamed: "startWithValues")
+	public func startWithNext(_ value: @escaping (Value) -> Void) -> Disposable { fatalError() }
 }
 
 extension SignalProducer {

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -9,10 +9,10 @@
 /// Represents a signal event.
 ///
 /// Signals must conform to the grammar:
-/// `next* (failed | completed | interrupted)?`
+/// `value* (failed | completed | interrupted)?`
 public enum Event<Value, Error: Swift.Error> {
 	/// A value provided by the signal.
-	case next(Value)
+	case value(Value)
 
 	/// The signal terminated because of an error. No further events will be
 	/// received.
@@ -32,7 +32,7 @@ public enum Event<Value, Error: Swift.Error> {
 	/// events will be received).
 	public var isTerminating: Bool {
 		switch self {
-		case .next:
+		case .value:
 			return false
 
 		case .failed, .completed, .interrupted:
@@ -42,17 +42,17 @@ public enum Event<Value, Error: Swift.Error> {
 
 	/// Lift the given closure over the event's value.
 	///
-	/// - important: The closure is called only on `next` type events.
+	/// - important: The closure is called only on `value` type events.
 	///
 	/// - parameters:
 	///   - f: A closure that accepts a value and returns a new value
 	///
 	/// - returns: An event with function applied to a value in case `self` is a
-	///            `next` type of event.
+	///            `value` type of event.
 	public func map<U>(_ f: (Value) -> U) -> Event<U, Error> {
 		switch self {
-		case let .next(value):
-			return .next(f(value))
+		case let .value(value):
+			return .value(f(value))
 
 		case let .failed(error):
 			return .failed(error)
@@ -77,8 +77,8 @@ public enum Event<Value, Error: Swift.Error> {
 	///            `self` is a `.Failed` type of event.
 	public func mapError<F>(_ f: (Error) -> F) -> Event<Value, F> {
 		switch self {
-		case let .next(value):
-			return .next(value)
+		case let .value(value):
+			return .value(value)
 
 		case let .failed(error):
 			return .failed(f(error))
@@ -91,9 +91,9 @@ public enum Event<Value, Error: Swift.Error> {
 		}
 	}
 
-	/// Unwrap the contained `next` value.
+	/// Unwrap the contained `value` value.
 	public var value: Value? {
-		if case let .next(value) = self {
+		if case let .value(value) = self {
 			return value
 		} else {
 			return nil
@@ -112,7 +112,7 @@ public enum Event<Value, Error: Swift.Error> {
 
 public func == <Value: Equatable, Error: Equatable> (lhs: Event<Value, Error>, rhs: Event<Value, Error>) -> Bool {
 	switch (lhs, rhs) {
-	case let (.next(left), .next(right)):
+	case let (.value(left), .value(right)):
 		return left == right
 
 	case let (.failed(left), .failed(right)):
@@ -132,8 +132,8 @@ public func == <Value: Equatable, Error: Equatable> (lhs: Event<Value, Error>, r
 extension Event: CustomStringConvertible {
 	public var description: String {
 		switch self {
-		case let .next(value):
-			return "NEXT \(value)"
+		case let .value(value):
+			return "VALUE \(value)"
 
 		case let .failed(error):
 			return "FAILED \(error)"

--- a/Sources/EventLogger.swift
+++ b/Sources/EventLogger.swift
@@ -11,18 +11,18 @@ import Foundation
 /// A namespace for logging event types.
 public enum LoggingEvent {
 	public enum Signal: String {
-		case next, completed, failed, terminated, disposed, interrupted
+		case value, completed, failed, terminated, disposed, interrupted
 
 		public static let allEvents: Set<Signal> = [
-			.next, .completed, .failed, .terminated, .disposed, .interrupted,
+			.value, .completed, .failed, .terminated, .disposed, .interrupted,
 		]
 	}
 
 	public enum SignalProducer: String {
-		case starting, started, next, completed, failed, terminated, disposed, interrupted
+		case starting, started, value, completed, failed, terminated, disposed, interrupted
 
 		public static let allEvents: Set<SignalProducer> = [
-			.starting, .started, .next, .completed, .failed, .terminated, .disposed, .interrupted,
+			.starting, .started, .value, .completed, .failed, .terminated, .disposed, .interrupted,
 		]
 	}
 }
@@ -67,7 +67,7 @@ extension SignalProtocol {
 			interrupted: log(.interrupted),
 			terminated: log(.terminated),
 			disposed: log(.disposed),
-			next: log(.next)
+			value: log(.value)
 		)
 	}
 }
@@ -102,7 +102,7 @@ extension SignalProducerProtocol {
 		return self.on(
 			starting: log(.starting),
 			started: log(.started),
-			next: log(.next),
+			value: log(.value),
 			failed: log(.failed),
 			completed: log(.completed),
 			interrupted: log(.interrupted),

--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -34,7 +34,7 @@ extension NotificationCenter {
 			}
 
 			let notificationObserver = self.addObserver(forName: name, object: object, queue: nil) { notification in
-				observer.sendNext(notification)
+				observer.send(value: notification)
 			}
 
 			disposable += {
@@ -64,10 +64,10 @@ extension URLSession {
 		return SignalProducer { observer, disposable in
 			let task = self.dataTask(with: request) { data, response, error in
 				if let data = data, let response = response {
-					observer.sendNext((data, response))
+					observer.send(value: (data, response))
 					observer.sendCompleted()
 				} else {
-					observer.sendFailed(error as NSError? ?? defaultSessionError)
+					observer.send(error: error as NSError? ?? defaultSessionError)
 				}
 			}
 

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -11,11 +11,11 @@ public protocol ObserverProtocol {
 	associatedtype Value
 	associatedtype Error: Swift.Error
 
-	/// Puts a `next` event into `self`.
-	func sendNext(_ value: Value)
+	/// Puts a `value` event into `self`.
+	func send(value: Value)
 
 	/// Puts a failed event into `self`.
-	func sendFailed(_ error: Error)
+	func send(error: Error)
 
 	/// Puts a `completed` event into `self`.
 	func sendCompleted()
@@ -44,7 +44,7 @@ public final class Observer<Value, Error: Swift.Error> {
 	/// An initializer that accepts closures for different event types.
 	///
 	/// - parameters:
-	///   - next: Optional closure executed when a `next` event is observed.
+	///   - value: Optional closure executed when a `value` event is observed.
 	///   - failed: Optional closure that accepts an `Error` parameter when a
 	///             failed event is observed.
 	///   - completed: Optional closure executed when a `completed` event is
@@ -52,15 +52,15 @@ public final class Observer<Value, Error: Swift.Error> {
 	///   - interruped: Optional closure executed when an `interrupted` event is
 	///                 observed.
 	public convenience init(
-		next: ((Value) -> Void)? = nil,
+		value: ((Value) -> Void)? = nil,
 		failed: ((Error) -> Void)? = nil,
 		completed: (() -> Void)? = nil,
 		interrupted: (() -> Void)? = nil
 	) {
 		self.init { event in
 			switch event {
-			case let .next(value):
-				next?(value)
+			case let .value(v):
+				value?(v)
 
 			case let .failed(error):
 				failed?(error)
@@ -76,19 +76,19 @@ public final class Observer<Value, Error: Swift.Error> {
 }
 
 extension Observer: ObserverProtocol {
-	/// Puts a `next` event into `self`.
+	/// Puts a `value` event into `self`.
 	///
 	/// - parameters:
-	///   - value: A value sent with the `next` event.
-	public func sendNext(_ value: Value) {
-		action(.next(value))
+	///   - value: A value sent with the `value` event.
+	public func send(value: Value) {
+		action(.value(value))
 	}
 
 	/// Puts a failed event into `self`.
 	///
 	/// - parameters:
 	///   - error: An error object sent with failed event.
-	public func sendFailed(_ error: Error) {
+	public func send(error: Error) {
 		action(.failed(error))
 	}
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -502,7 +502,7 @@ public final class Property<Value>: PropertyProtocol {
 		let producer = unsafeProducer.replayLazily(upTo: 1)
 
 		let atomic = Atomic<Value?>(nil)
-		disposable = producer.startWithNext { atomic.value = $0 }
+		disposable = producer.startWithValues { atomic.value = $0 }
 
 		// Verify that an initial is sent. This is friendlier than deadlocking
 		// in the event that one isn't.
@@ -575,10 +575,10 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 		return SignalProducer { [atomic, weak self] producerObserver, producerDisposable in
 			atomic.withValue { value in
 				if let strongSelf = self {
-					producerObserver.sendNext(value)
+					producerObserver.send(value: value)
 					producerDisposable += strongSelf.signal.observe(producerObserver)
 				} else {
-					producerObserver.sendNext(value)
+					producerObserver.send(value: value)
 					producerObserver.sendCompleted()
 				}
 			}
@@ -599,7 +599,7 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 		/// underlying producer prevents sending recursive events.
 		atomic = RecursiveAtomic(initialValue,
 		                          name: "org.reactivecocoa.ReactiveSwift.MutableProperty",
-		                          didSet: observer.sendNext)
+		                          didSet: observer.send(value:))
 	}
 
 	/// Atomically replaces the contents of the variable.

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -87,7 +87,7 @@ extension BindingTarget {
 	public static func <~ <Source: SignalProtocol>(target: Self, signal: Source) -> Disposable? where Source.Value == Value, Source.Error == NoError {
 		return signal
 			.take(during: target.lifetime)
-			.observeNext { [weak target] value in
+			.observeValues { [weak target] value in
 				target?.consume(value)
 			}
 	}

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -36,22 +36,22 @@ class ActionSpec: QuickSpec {
 						executionCount += 1
 
 						if number % 2 == 0 {
-							observer.sendNext("\(number)")
-							observer.sendNext("\(number)\(number)")
+							observer.send(value: "\(number)")
+							observer.send(value: "\(number)\(number)")
 
 							scheduler.schedule {
 								observer.sendCompleted()
 							}
 						} else {
 							scheduler.schedule {
-								observer.sendFailed(testError)
+								observer.send(error: testError)
 							}
 						}
 					}
 				}
 
-				action.values.observeNext { values.append($0) }
-				action.errors.observeNext { errors.append($0) }
+				action.values.observeValues { values.append($0) }
+				action.errors.observeValues { errors.append($0) }
 			}
 
 			it("should be disabled and not executing after initialization") {
@@ -92,7 +92,7 @@ class ActionSpec: QuickSpec {
 
 					action.apply(0)
 						.assumeNoErrors()
-						.startWithNext {
+						.startWithValues {
 							receivedValue = $0
 						}
 

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -40,7 +40,7 @@ class FlattenSpec: QuickSpec {
 
 					beforeEach {
 						disposed = false
-						pipe.observer.sendNext(SignalProducer<Int, TestError> { _, disposable in
+						pipe.observer.send(value: SignalProducer<Int, TestError> { _, disposable in
 							disposable += ActionDisposable {
 								disposed = true
 							}
@@ -53,7 +53,7 @@ class FlattenSpec: QuickSpec {
 					}
 
 					it("should dispose inner signals when outer signal failed") {
-						pipe.observer.sendFailed(.default)
+						pipe.observer.send(error: .default)
 						expect(disposed) == true
 					}
 
@@ -108,12 +108,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -128,12 +128,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -147,12 +147,12 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.latest)
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -167,12 +167,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -187,12 +187,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -207,12 +207,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -226,12 +226,12 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.latest)
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -246,12 +246,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -262,11 +262,11 @@ class FlattenSpec: QuickSpec {
 				
 				signal
 					.flatten(.concat)
-					.observeNext { value in
+					.observeValues { value in
 						observedValues.append(value)
 					}
 				
-				innerObserver.sendNext(sequence)
+				innerObserver.send(value: sequence)
 				expect(observedValues) == sequence
 			}
 		}
@@ -283,12 +283,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -303,12 +303,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -322,12 +322,12 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.latest)
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -342,12 +342,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -362,12 +362,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -382,12 +382,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -401,12 +401,12 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.latest)
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -421,12 +421,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatten(.latest)
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(inner)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: inner)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -437,7 +437,7 @@ class FlattenSpec: QuickSpec {
 				let producer = SignalProducer<[Int], NoError>(value: sequence)
 				producer
 					.flatten(.latest)
-					.startWithNext { value in
+					.startWithValues { value in
 						observedValues.append(value)
 					}
 				
@@ -457,12 +457,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -477,12 +477,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -496,12 +496,12 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.latest) { _ in inner }
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -516,12 +516,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -536,12 +536,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -556,12 +556,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -575,12 +575,12 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.latest) { _ in inner }
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -595,12 +595,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.observeNext { value in
+					.observeValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 		}
@@ -617,12 +617,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -637,12 +637,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -656,12 +656,12 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.latest) { _ in inner }
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -676,12 +676,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -696,12 +696,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -716,12 +716,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -735,12 +735,12 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.latest) { _ in inner }
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 			
@@ -755,12 +755,12 @@ class FlattenSpec: QuickSpec {
 				outer
 					.flatMap(.latest) { _ in inner }
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						observed = value
 					}
 				
-				outerObserver.sendNext(4)
-				innerObserver.sendNext(4)
+				outerObserver.send(value: 4)
+				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
 		}
@@ -773,17 +773,17 @@ class FlattenSpec: QuickSpec {
 				let mergedSignals = Signal.merge([signal1, signal2])
 				
 				var lastValue: Int?
-				mergedSignals.observeNext { lastValue = $0 }
+				mergedSignals.observeValues { lastValue = $0 }
 				
 				expect(lastValue).to(beNil())
 				
-				observer1.sendNext(1)
+				observer1.send(value: 1)
 				expect(lastValue) == 1
 				
-				observer2.sendNext(2)
+				observer2.send(value: 2)
 				expect(lastValue) == 2
 				
-				observer1.sendNext(3)
+				observer1.send(value: 3)
 				expect(lastValue) == 3
 			}
 			
@@ -794,17 +794,17 @@ class FlattenSpec: QuickSpec {
 				let mergedSignals = Signal.merge([signal1, signal2])
 				
 				var lastValue: Int?
-				mergedSignals.observeNext { lastValue = $0 }
+				mergedSignals.observeValues { lastValue = $0 }
 				
 				expect(lastValue).to(beNil())
 				
-				observer1.sendNext(1)
+				observer1.send(value: 1)
 				expect(lastValue) == 1
 				
 				observer1.sendCompleted()
 				expect(lastValue) == 1
 				
-				observer2.sendNext(2)
+				observer2.send(value: 2)
 				expect(lastValue) == 2
 			}
 			
@@ -819,7 +819,7 @@ class FlattenSpec: QuickSpec {
 				
 				expect(completed) == false
 				
-				observer1.sendNext(1)
+				observer1.send(value: 1)
 				expect(completed) == false
 				
 				observer1.sendCompleted()
@@ -838,17 +838,17 @@ class FlattenSpec: QuickSpec {
 				let mergedSignals = SignalProducer.merge([signal1, signal2])
 				
 				var lastValue: Int?
-				mergedSignals.startWithNext { lastValue = $0 }
+				mergedSignals.startWithValues { lastValue = $0 }
 				
 				expect(lastValue).to(beNil())
 				
-				observer1.sendNext(1)
+				observer1.send(value: 1)
 				expect(lastValue) == 1
 				
-				observer2.sendNext(2)
+				observer2.send(value: 2)
 				expect(lastValue) == 2
 				
-				observer1.sendNext(3)
+				observer1.send(value: 3)
 				expect(lastValue) == 3
 			}
 			
@@ -859,17 +859,17 @@ class FlattenSpec: QuickSpec {
 				let mergedSignals = SignalProducer.merge([signal1, signal2])
 				
 				var lastValue: Int?
-				mergedSignals.startWithNext { lastValue = $0 }
+				mergedSignals.startWithValues { lastValue = $0 }
 				
 				expect(lastValue).to(beNil())
 				
-				observer1.sendNext(1)
+				observer1.send(value: 1)
 				expect(lastValue) == 1
 				
 				observer1.sendCompleted()
 				expect(lastValue) == 1
 				
-				observer2.sendNext(2)
+				observer2.send(value: 2)
 				expect(lastValue) == 2
 			}
 			
@@ -884,7 +884,7 @@ class FlattenSpec: QuickSpec {
 				
 				expect(completed) == false
 				
-				observer1.sendNext(1)
+				observer1.send(value: 1)
 				expect(completed) == false
 				
 				observer1.sendCompleted()
@@ -902,17 +902,17 @@ class FlattenSpec: QuickSpec {
 				let mergedSignals = signal.prefix(value: 0)
 
 				var lastValue: Int?
-				mergedSignals.startWithNext { lastValue = $0 }
+				mergedSignals.startWithValues { lastValue = $0 }
 
 				expect(lastValue) == 0
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == 1
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 
-				observer.sendNext(3)
+				observer.send(value: 3)
 				expect(lastValue) == 3
 			}
 
@@ -922,17 +922,17 @@ class FlattenSpec: QuickSpec {
 				let mergedSignals = signal.prefix(SignalProducer(value: 0))
 				
 				var lastValue: Int?
-				mergedSignals.startWithNext { lastValue = $0 }
+				mergedSignals.startWithValues { lastValue = $0 }
 				
 				expect(lastValue) == 0
 				
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == 1
 				
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 				
-				observer.sendNext(3)
+				observer.send(value: 3)
 				expect(lastValue) == 3
 			}
 		}
@@ -944,15 +944,15 @@ class FlattenSpec: QuickSpec {
 				let mergedSignals = signal.concat(value: 4)
 				
 				var lastValue: Int?
-				mergedSignals.startWithNext { lastValue = $0 }
+				mergedSignals.startWithValues { lastValue = $0 }
 								
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == 1
 				
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 				
-				observer.sendNext(3)
+				observer.send(value: 3)
 				expect(lastValue) == 3
 				
 				observer.sendCompleted()

--- a/Tests/ReactiveSwiftTests/FoundationExtensionsSpec.swift
+++ b/Tests/ReactiveSwiftTests/FoundationExtensionsSpec.swift
@@ -25,7 +25,7 @@ class FoundationExtensionsSpec: QuickSpec {
 				let producer = center.rac_notifications(forName: .racFirst)
 
 				var notif: Notification? = nil
-				let disposable = producer.startWithNext { notif = $0 }
+				let disposable = producer.startWithValues { notif = $0 }
 
 				center.post(name: .racAnother, object: nil)
 				expect(notif).to(beNil())

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -32,7 +32,7 @@ class PropertySpec: QuickSpec {
 				let mutableProperty = MutableProperty(initialPropertyValue)
 				var sentValue: String?
 
-				mutableProperty.producer.startWithNext { sentValue = $0 }
+				mutableProperty.producer.startWithValues { sentValue = $0 }
 
 				expect(sentValue) == initialPropertyValue
 
@@ -47,7 +47,7 @@ class PropertySpec: QuickSpec {
 				let mutableProperty = MutableProperty(initialPropertyValue)
 				var count = 0
 
-				mutableProperty.producer.startWithNext { _ in count = count + 1 }
+				mutableProperty.producer.startWithValues { _ in count = count + 1 }
 
 				expect(count) == 1
 
@@ -62,7 +62,7 @@ class PropertySpec: QuickSpec {
 				let mutableProperty = MutableProperty(initialPropertyValue)
 				var sentValue: String?
 
-				mutableProperty.signal.observeNext { sentValue = $0 }
+				mutableProperty.signal.observeValues { sentValue = $0 }
 
 				expect(sentValue).to(beNil())
 
@@ -77,7 +77,7 @@ class PropertySpec: QuickSpec {
 				let mutableProperty = MutableProperty(initialPropertyValue)
 				var count = 0
 
-				mutableProperty.signal.observeNext { _ in count = count + 1 }
+				mutableProperty.signal.observeValues { _ in count = count + 1 }
 
 				expect(count) == 0
 
@@ -121,7 +121,7 @@ class PropertySpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case let .next(value):
+					case let .value(value):
 						latestValue = value
 					case .completed:
 						producerCompleted = true
@@ -142,11 +142,11 @@ class PropertySpec: QuickSpec {
 				expect(property.value) == subsequentPropertyValue
 			}
 
-			it("should modify the value atomically and subsquently send out a Next event with the new value") {
+			it("should modify the value atomically and subsquently send out a Value event with the new value") {
 				let property = MutableProperty(initialPropertyValue)
 				var value: String?
 
-				property.producer.startWithNext {
+				property.producer.startWithValues {
 					value = $0
 				}
 
@@ -164,11 +164,11 @@ class PropertySpec: QuickSpec {
 				expect(property.value) == subsequentPropertyValue
 			}
 
-			it("should swap the value atomically and subsquently send out a Next event with the new value") {
+			it("should swap the value atomically and subsquently send out a Value event with the new value") {
 				let property = MutableProperty(initialPropertyValue)
 				var value: String?
 
-				property.producer.startWithNext {
+				property.producer.startWithValues {
 					value = $0
 				}
 
@@ -194,11 +194,11 @@ class PropertySpec: QuickSpec {
 				var value: Int?
 
 				property <~ producer
-				property.producer.startWithNext { _ in
+				property.producer.startWithValues { _ in
 					value = property.value
 				}
 
-				observer.sendNext(10)
+				observer.send(value: 10)
 				expect(value) == 10
 			}
 
@@ -208,11 +208,11 @@ class PropertySpec: QuickSpec {
 				var value: Int?
 
 				property <~ producer
-				property.producer.startWithNext { _ in
+				property.producer.startWithValues { _ in
 					value = property.withValue { $0 + 1 }
 				}
 
-				observer.sendNext(10)
+				observer.send(value: 10)
 				expect(value) == 11
 			}
 
@@ -220,8 +220,8 @@ class PropertySpec: QuickSpec {
 				let property = MutableProperty(0)
 
 				var value: Int?
-				property.producer.startWithNext { _ in
-					property.producer.startWithNext { x in value = x }
+				property.producer.startWithValues { _ in
+					property.producer.startWithValues { x in value = x }
 				}
 
 				expect(value) == 0
@@ -235,9 +235,9 @@ class PropertySpec: QuickSpec {
 				let propertyB = MutableProperty(0)
 
 				var value: Int?
-				propertyA.producer.startWithNext { _ in
-					propertyB.producer.startWithNext { _ in
-						propertyA.producer.startWithNext { x in value = x }
+				propertyA.producer.startWithValues { _ in
+					propertyB.producer.startWithValues { _ in
+						propertyA.producer.startWithValues { x in value = x }
 					}
 				}
 
@@ -283,7 +283,7 @@ class PropertySpec: QuickSpec {
 						switch event {
 						case .interrupted:
 							signalInterrupted = true
-						case .next, .failed, .completed:
+						case .value, .failed, .completed:
 							hasUnexpectedEventsEmitted = true
 						}
 					}
@@ -300,7 +300,7 @@ class PropertySpec: QuickSpec {
 
 					constantProperty.producer.start { event in
 						switch event {
-						case let .next(value):
+						case let .value(value):
 							sentValue = value
 						case .completed:
 							signalCompleted = true
@@ -326,7 +326,7 @@ class PropertySpec: QuickSpec {
 
 					property.producer.start { event in
 						switch event {
-						case let .next(value):
+						case let .value(value):
 							sentValue = value
 						case .completed:
 							producerCompleted = true
@@ -337,7 +337,7 @@ class PropertySpec: QuickSpec {
 
 					property.signal.observe { event in
 						switch event {
-						case let .next(value):
+						case let .value(value):
 							signalSentValue = value
 						case .interrupted:
 							signalInterrupted = true
@@ -360,7 +360,7 @@ class PropertySpec: QuickSpec {
 
 						let property = MutableProperty(1)
 						let mappedProperty = property.map { $0 + 1 }
-						mappedProperty.producer.startWithNext { _ in latestValue = mappedProperty.value }
+						mappedProperty.producer.startWithValues { _ in latestValue = mappedProperty.value }
 
 						expect(latestValue) == 2
 
@@ -500,7 +500,7 @@ class PropertySpec: QuickSpec {
 
 						expect(property!.value) == 1
 
-						observer.sendNext(2)
+						observer.send(value: 2)
 						expect(property!.value) == 2
 						expect(producerCompleted) == false
 						expect(signalCompleted) == false
@@ -527,7 +527,7 @@ class PropertySpec: QuickSpec {
 
 						expect(property.value) == initialPropertyValue
 
-						observer.sendNext(subsequentPropertyValue)
+						observer.send(value: subsequentPropertyValue)
 
 						expect(property.value) == subsequentPropertyValue
 					}
@@ -548,7 +548,7 @@ class PropertySpec: QuickSpec {
 
 						expect(property!.value) == 1
 
-						observer.sendNext(2)
+						observer.send(value: 2)
 						expect(property!.value) == 2
 						expect(producerCompleted) == false
 						expect(signalCompleted) == false
@@ -593,7 +593,7 @@ class PropertySpec: QuickSpec {
 				it("should forward the latest values from both inputs") {
 					let combinedProperty = property.combineLatest(with: otherProperty)
 					var latest: (String, String)?
-					combinedProperty.signal.observeNext { latest = $0 }
+					combinedProperty.signal.observeValues { latest = $0 }
 
 					property.value = subsequentPropertyValue
 					expect(latest?.0) == subsequentPropertyValue
@@ -630,7 +630,7 @@ class PropertySpec: QuickSpec {
 					var secondResult: String!
 
 					let combined = property.combineLatest(with: otherProperty)
-					combined.producer.startWithNext { (left, right) in firstResult = left + right }
+					combined.producer.startWithValues { (left, right) in firstResult = left + right }
 
 					func getValue() -> String {
 						return combined.value.0 + combined.value.1
@@ -643,7 +643,7 @@ class PropertySpec: QuickSpec {
 					expect(getValue()) == subsequentPropertyValue + initialOtherPropertyValue
 					expect(firstResult) == subsequentPropertyValue + initialOtherPropertyValue
 
-					combined.producer.startWithNext { (left, right) in secondResult = left + right }
+					combined.producer.startWithValues { (left, right) in secondResult = left + right }
 					expect(secondResult) == subsequentPropertyValue + initialOtherPropertyValue
 
 					otherProperty.value = subsequentOtherPropertyValue
@@ -660,7 +660,7 @@ class PropertySpec: QuickSpec {
 					var firstResult: Int!
 
 					let combined = A.combineLatest(with: B)
-					combined.producer.startWithNext { (left, right) in firstResult = left + right }
+					combined.producer.startWithValues { (left, right) in firstResult = left + right }
 
 					func getValue() -> Int {
 						return combined.value.0 + combined.value.1
@@ -686,7 +686,7 @@ class PropertySpec: QuickSpec {
 					/// Zip another property now.
 					var secondResult: Int!
 					let anotherCombined = combined.combineLatest(with: C)
-					anotherCombined.producer.startWithNext { (left, right) in secondResult = (left.0 + left.1) + right }
+					anotherCombined.producer.startWithValues { (left, right) in secondResult = (left.0 + left.1) + right }
 
 					func getAnotherValue() -> Int {
 						return (anotherCombined.value.0.0 + anotherCombined.value.0.1) + anotherCombined.value.1
@@ -713,7 +713,7 @@ class PropertySpec: QuickSpec {
 					var result: [String] = []
 
 					let zippedProperty = property.zip(with: otherProperty)
-					zippedProperty.producer.startWithNext { (left, right) in result.append("\(left)\(right)") }
+					zippedProperty.producer.startWithValues { (left, right) in result.append("\(left)\(right)") }
 
 					let firstResult = [ "\(initialPropertyValue)\(initialOtherPropertyValue)" ]
 					let secondResult = firstResult + [ "\(subsequentPropertyValue)\(subsequentOtherPropertyValue)" ]
@@ -747,7 +747,7 @@ class PropertySpec: QuickSpec {
 					var secondResult: String!
 
 					let zippedProperty = property.zip(with: otherProperty)
-					zippedProperty.producer.startWithNext { (left, right) in firstResult = left + right }
+					zippedProperty.producer.startWithValues { (left, right) in firstResult = left + right }
 
 					func getValue() -> String {
 						return zippedProperty.value.0 + zippedProperty.value.1
@@ -762,7 +762,7 @@ class PropertySpec: QuickSpec {
 
 					// It should still be the tuple with initial property values,
 					// since `otherProperty` isn't changed yet.
-					zippedProperty.producer.startWithNext { (left, right) in secondResult = left + right }
+					zippedProperty.producer.startWithValues { (left, right) in secondResult = left + right }
 					expect(secondResult) == initialPropertyValue + initialOtherPropertyValue
 
 					otherProperty.value = subsequentOtherPropertyValue
@@ -779,7 +779,7 @@ class PropertySpec: QuickSpec {
 					var firstResult: Int!
 
 					let zipped = A.zip(with: B)
-					zipped.producer.startWithNext { (left, right) in firstResult = left + right }
+					zipped.producer.startWithValues { (left, right) in firstResult = left + right }
 
 					func getValue() -> Int {
 						return zipped.value.0 + zipped.value.1
@@ -805,7 +805,7 @@ class PropertySpec: QuickSpec {
 					/// Zip another property now.
 					var secondResult: Int!
 					let anotherZipped = zipped.zip(with: C)
-					anotherZipped.producer.startWithNext { (left, right) in secondResult = (left.0 + left.1) + right }
+					anotherZipped.producer.startWithValues { (left, right) in secondResult = (left.0 + left.1) + right }
 
 					func getAnotherValue() -> Int {
 						return (anotherZipped.value.0.0 + anotherZipped.value.0.1) + anotherZipped.value.1
@@ -834,7 +834,7 @@ class PropertySpec: QuickSpec {
 					var firstResult: Int!
 
 					let zipped = A.zip(with: B)
-					zipped.producer.startWithNext { (left, right) in firstResult = left + right }
+					zipped.producer.startWithValues { (left, right) in firstResult = left + right }
 
 					func getValue() -> Int {
 						return zipped.value.0 + zipped.value.1
@@ -860,7 +860,7 @@ class PropertySpec: QuickSpec {
 					/// Zip another property now.
 					var secondResult: Int!
 					let anotherZipped = zipped.zip(with: C)
-					anotherZipped.producer.startWithNext { (left, right) in secondResult = (left.0 + left.1) + right }
+					anotherZipped.producer.startWithValues { (left, right) in secondResult = (left.0 + left.1) + right }
 
 					func getAnotherValue() -> Int {
 						return (anotherZipped.value.0.0 + anotherZipped.value.0.1) + anotherZipped.value.1
@@ -880,7 +880,7 @@ class PropertySpec: QuickSpec {
 					let combined = anotherZipped.combineLatest(with: yetAnotherZipped)
 
 					var thirdResult: Int!
-					combined.producer.startWithNext { (left, right) in
+					combined.producer.startWithValues { (left, right) in
 						let leftResult = left.0.0 + left.0.1 + left.1
 						let rightResult = right.0.0.0 + right.0.0.1 + right.0.1 + right.1
 						thirdResult = leftResult + rightResult
@@ -896,7 +896,7 @@ class PropertySpec: QuickSpec {
 					var zippedProperty = Optional(property.zip(with: otherProperty))
 					zippedProperty!.producer.start { event in
 						switch event {
-						case let .next(left, right):
+						case let .value(left, right):
 							result.append("\(left)\(right)")
 						case .completed:
 							completed = true
@@ -952,7 +952,7 @@ class PropertySpec: QuickSpec {
 						var transformedProperty = Optional(property.combinePrevious(initialPropertyValue))
 						transformedProperty!.producer.start { event in
 							switch event {
-							case let .next(tuple):
+							case let .value(tuple):
 								result = tuple
 							case .completed:
 								completed = true
@@ -982,7 +982,7 @@ class PropertySpec: QuickSpec {
 						let transformedProperty = property.skipRepeats()
 
 						var counter = 0
-						transformedProperty.signal.observeNext { _ in
+						transformedProperty.signal.observeValues { _ in
 							counter += 1
 						}
 
@@ -1009,7 +1009,7 @@ class PropertySpec: QuickSpec {
 						var counter = 0
 						let transformedProperty = property.skipRepeats { _, newValue in newValue == initialPropertyValue }
 
-						transformedProperty.signal.observeNext { _ in
+						transformedProperty.signal.observeValues { _ in
 							counter += 1
 						}
 
@@ -1033,7 +1033,7 @@ class PropertySpec: QuickSpec {
 						var transformedProperty = Optional(property.skipRepeats())
 						transformedProperty!.producer.start { event in
 							switch event {
-							case .next:
+							case .value:
 								counter += 1
 							case .completed:
 								completed = true
@@ -1060,7 +1060,7 @@ class PropertySpec: QuickSpec {
 						let transformedProperty = property.uniqueValues()
 
 						var counter = 0
-						transformedProperty.signal.observeNext { _ in
+						transformedProperty.signal.observeValues { _ in
 							counter += 1
 						}
 
@@ -1083,7 +1083,7 @@ class PropertySpec: QuickSpec {
 						let transformedProperty = property.uniqueValues { _ in 0 }
 
 						var counter = 0
-						transformedProperty.signal.observeNext { _ in
+						transformedProperty.signal.observeValues { _ in
 							counter += 1
 						}
 
@@ -1100,7 +1100,7 @@ class PropertySpec: QuickSpec {
 						var transformedProperty = Optional(property.uniqueValues())
 						transformedProperty!.producer.start { event in
 							switch event {
-							case .next:
+							case .value:
 								counter += 1
 							case .completed:
 								completed = true
@@ -1141,7 +1141,7 @@ class PropertySpec: QuickSpec {
 
 							flattenedProperty!.producer.start { event in
 								switch event {
-								case let .next(value):
+								case let .value(value):
 									receivedValues.append(value)
 								case .completed:
 									completed = true
@@ -1206,7 +1206,7 @@ class PropertySpec: QuickSpec {
 
 							flattenedProperty!.producer.start { event in
 								switch event {
-								case let .next(value):
+								case let .value(value):
 									receivedValues.append(value)
 								case .completed:
 									completed = true
@@ -1269,7 +1269,7 @@ class PropertySpec: QuickSpec {
 
 							outerProperty!.flatten(.latest).producer.start { event in
 								switch event {
-								case let .next(value):
+								case let .value(value):
 									receivedValues.append(value)
 								case .completed:
 									completed = true
@@ -1326,7 +1326,7 @@ class PropertySpec: QuickSpec {
 									completed = true
 								case .failed:
 									errored = true
-								case .interrupted, .next:
+								case .interrupted, .value:
 									break
 								}
 							}
@@ -1364,7 +1364,7 @@ class PropertySpec: QuickSpec {
 
 							outerProperty!.flatMap(.latest) { $0.map { "\($0)" } }.producer.start { event in
 								switch event {
-								case let .next(value):
+								case let .value(value):
 									receivedValues.append(value)
 								case .completed:
 									completed = true
@@ -1416,7 +1416,7 @@ class PropertySpec: QuickSpec {
 					// Verify that the binding hasn't changed the property value:
 					expect(mutableProperty.value) == initialPropertyValue
 
-					observer.sendNext(subsequentPropertyValue)
+					observer.send(value: subsequentPropertyValue)
 					expect(mutableProperty.value) == subsequentPropertyValue
 				}
 
@@ -1428,7 +1428,7 @@ class PropertySpec: QuickSpec {
 					let bindingDisposable = mutableProperty <~ signal
 					bindingDisposable!.dispose()
 
-					observer.sendNext(subsequentPropertyValue)
+					observer.send(value: subsequentPropertyValue)
 					expect(mutableProperty.value) == initialPropertyValue
 				}
 				
@@ -1476,7 +1476,7 @@ class PropertySpec: QuickSpec {
 
 					disposable.dispose()
 
-					observer.sendNext(subsequentPropertyValue)
+					observer.send(value: subsequentPropertyValue)
 					expect(mutableProperty.value) == initialPropertyValue
 				}
 

--- a/Tests/ReactiveSwiftTests/SignalLifetimeSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalLifetimeSpec.swift
@@ -80,7 +80,7 @@ class SignalLifetimeSpec: QuickSpec {
 				weak var signal: Signal<AnyObject, TestError>? = {
 					let signal = Signal<AnyObject, TestError> { observer in
 						testScheduler.schedule {
-							observer.sendFailed(TestError.default)
+							observer.send(error: TestError.default)
 						}
 						return nil
 					}
@@ -164,7 +164,7 @@ class SignalLifetimeSpec: QuickSpec {
 					weakSignal = signal
 					testScheduler.schedule {
 						// Note that the input observer has a weak reference to the signal.
-						observer.sendFailed(TestError.default)
+						observer.send(error: TestError.default)
 					}
 					signal.observeFailed { _ in errored = true }
 				}
@@ -284,12 +284,12 @@ class SignalLifetimeSpec: QuickSpec {
 
 				run()
 
-				sourceObserver.sendNext(1)
+				sourceObserver.send(value: 1)
 				expect(firstCounter) == 0
 				expect(secondCounter) == 0
 				expect(thirdCounter) == 0
 
-				sourceObserver.sendNext(2)
+				sourceObserver.send(value: 2)
 				expect(firstCounter) == 0
 				expect(secondCounter) == 0
 				expect(thirdCounter) == 0
@@ -323,19 +323,19 @@ class SignalLifetimeSpec: QuickSpec {
 
 				run()
 
-				sourceObserver.sendNext(1)
+				sourceObserver.send(value: 1)
 				expect(firstCounter) == 1
 				expect(secondCounter) == 1
 				expect(thirdCounter) == 1
 
-				sourceObserver.sendNext(2)
+				sourceObserver.send(value: 2)
 				expect(firstCounter) == 2
 				expect(secondCounter) == 2
 				expect(thirdCounter) == 2
 
 				disposable?.dispose()
 
-				sourceObserver.sendNext(3)
+				sourceObserver.send(value: 3)
 				expect(firstCounter) == 2
 				expect(secondCounter) == 2
 				expect(thirdCounter) == 2
@@ -373,13 +373,13 @@ class SignalLifetimeSpec: QuickSpec {
 			it("should deallocate observe handler when signal completes") {
 				expectTokenNotDeallocated()
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expectTokenNotDeallocated()
 
 				token = nil
 				expectTokenNotDeallocated()
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expectTokenNotDeallocated()
 
 				observer.sendCompleted()
@@ -389,16 +389,16 @@ class SignalLifetimeSpec: QuickSpec {
 			it("should deallocate observe handler when signal fails") {
 				expectTokenNotDeallocated()
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expectTokenNotDeallocated()
 
 				token = nil
 				expectTokenNotDeallocated()
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expectTokenNotDeallocated()
 
-				observer.sendFailed(.default)
+				observer.send(error: .default)
 				expectTokenDeallocated()
 			}
 		}

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -20,17 +20,17 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: String?
 
-				mappedProducer.startWithNext {
+				mappedProducer.startWithValues {
 					lastValue = $0
 					return
 				}
 
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(0)
+				observer.send(value: 0)
 				expect(lastValue) == "1"
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == "2"
 			}
 		}
@@ -47,7 +47,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(error).to(beNil())
 
-				observer.sendFailed(TestError.default)
+				observer.send(error: TestError.default)
 				expect(error) == producerError
 			}
 		}
@@ -59,17 +59,17 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: Int?
 
-				mappedProducer.startWithNext { lastValue = $0 }
+				mappedProducer.startWithValues { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(0)
+				observer.send(value: 0)
 				expect(lastValue) == 0
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == 0
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 			}
 		}
@@ -81,19 +81,19 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: Int?
 
-				mappedProducer.startWithNext { lastValue = $0 }
+				mappedProducer.startWithValues { lastValue = $0 }
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(nil)
+				observer.send(value: nil)
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == 1
 
-				observer.sendNext(nil)
+				observer.send(value: nil)
 				expect(lastValue) == 1
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 			}
 		}
@@ -105,14 +105,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: String?
 
-				producer.startWithNext { lastValue = $0 }
+				producer.startWithValues { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
-				observer.sendNext("a")
+				observer.send(value: "a")
 				expect(lastValue) == "a"
 
-				observer.sendNext("bb")
+				observer.send(value: "bb")
 				expect(lastValue) == "abb"
 			}
 		}
@@ -127,7 +127,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case let .next(value):
+					case let .value(value):
 						lastValue = value
 					case .completed:
 						completed = true
@@ -138,10 +138,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue).to(beNil())
 
 				expect(completed) == false
@@ -160,7 +160,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case let .next(value):
+					case let .value(value):
 						lastValue = value
 					case .completed:
 						completed = true
@@ -185,14 +185,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skip(first: 1)
 
 				var lastValue: Int?
-				producer.startWithNext { lastValue = $0 }
+				producer.startWithValues { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 			}
 
@@ -201,14 +201,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skip(first: 0)
 
 				var lastValue: Int?
-				producer.startWithNext { lastValue = $0 }
+				producer.startWithValues { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == 1
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 			}
 		}
@@ -219,20 +219,20 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skipRepeats()
 
 				var values: [Bool] = []
-				producer.startWithNext { values.append($0) }
+				producer.startWithValues { values.append($0) }
 
 				expect(values) == []
 
-				observer.sendNext(true)
+				observer.send(value: true)
 				expect(values) == [ true ]
 
-				observer.sendNext(true)
+				observer.send(value: true)
 				expect(values) == [ true ]
 
-				observer.sendNext(false)
+				observer.send(value: false)
 				expect(values) == [ true, false ]
 
-				observer.sendNext(true)
+				observer.send(value: true)
 				expect(values) == [ true, false, true ]
 			}
 
@@ -241,20 +241,20 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skipRepeats { $0.characters.count == $1.characters.count }
 
 				var values: [String] = []
-				producer.startWithNext { values.append($0) }
+				producer.startWithValues { values.append($0) }
 
 				expect(values) == []
 
-				observer.sendNext("a")
+				observer.send(value: "a")
 				expect(values) == [ "a" ]
 
-				observer.sendNext("b")
+				observer.send(value: "b")
 				expect(values) == [ "a" ]
 
-				observer.sendNext("cc")
+				observer.send(value: "cc")
 				expect(values) == [ "a", "cc" ]
 
-				observer.sendNext("d")
+				observer.send(value: "d")
 				expect(values) == [ "a", "cc", "d" ]
 			}
 		}
@@ -272,29 +272,29 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer = incomingObserver
 				lastValue = nil
 
-				producer.startWithNext { lastValue = $0 }
+				producer.startWithValues { lastValue = $0 }
 			}
 
 			it("should skip while the predicate is true") {
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 
-				observer.sendNext(0)
+				observer.send(value: 0)
 				expect(lastValue) == 0
 			}
 
 			it("should not skip any values when the predicate starts false") {
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(3)
+				observer.send(value: 3)
 				expect(lastValue) == 3
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == 1
 			}
 		}
@@ -318,7 +318,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				producer.start { event in
 					switch event {
-					case let .next(value):
+					case let .value(value):
 						lastValue = value
 					case .failed, .completed, .interrupted:
 						break
@@ -329,28 +329,28 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should skip values until the trigger fires") {
 				expect(lastValue).to(beNil())
 				
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue).to(beNil())
 				
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue).to(beNil())
 				
-				triggerObserver.sendNext(())
-				observer.sendNext(0)
+				triggerObserver.send(value: ())
+				observer.send(value: 0)
 				expect(lastValue) == 0
 			}
 			
 			it("should skip values until the trigger completes") {
 				expect(lastValue).to(beNil())
 				
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue).to(beNil())
 				
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue).to(beNil())
 				
 				triggerObserver.sendCompleted()
-				observer.sendNext(0)
+				observer.send(value: 0)
 				expect(lastValue) == 0
 			}
 		}
@@ -364,7 +364,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var completed = false
 				producer.start { event in
 					switch event {
-					case let .next(value):
+					case let .value(value):
 						lastValue = value
 					case .completed:
 						completed = true
@@ -376,11 +376,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed) == false
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == 1
 				expect(completed) == false
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 				expect(completed) == true
 			}
@@ -395,7 +395,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 					testScheduler.schedule {
 						for number in numbers {
-							observer.sendNext(number)
+							observer.send(value: number)
 						}
 					}
 				}
@@ -421,7 +421,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 					testScheduler.schedule {
 						for number in numbers {
-							observer.sendNext(number)
+							observer.send(value: number)
 						}
 					}
 				}
@@ -433,7 +433,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				.take(first: 0)
 				.start { event in
 					switch event {
-					case let .next(number):
+					case let .value(number):
 						result.append(number)
 					case .interrupted:
 						interrupted = true
@@ -457,13 +457,13 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var result: [Int]?
 
-				producer.startWithNext { value in
+				producer.startWithValues { value in
 					expect(result).to(beNil())
 					result = value
 				}
 
 				for number in expectedResult {
-					observer.sendNext(number)
+					observer.send(value: number)
 				}
 
 				expect(result).to(beNil())
@@ -477,7 +477,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var result: [Int]?
 
-				producer.startWithNext { result = $0 }
+				producer.startWithValues { result = $0 }
 
 				expect(result).to(beNil())
 				observer.sendCompleted()
@@ -493,7 +493,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				producer.startWithFailed { error = $0 }
 
 				expect(error).to(beNil())
-				observer.sendFailed(.default)
+				observer.send(error: .default)
 				expect(error) == TestError.default
 			}
 
@@ -504,7 +504,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var observedValues: [[Int]] = []
 
-				producer.startWithNext { value in
+				producer.startWithValues { value in
 					observedValues.append(value)
 				}
 
@@ -512,7 +512,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				for i in 1...7 {
 
-					observer.sendNext(i)
+					observer.send(value: i)
 
 					if i % 3 == 0 {
 						expectation.append([Int]((i - 2)...i))
@@ -531,14 +531,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should collect values until it matches a certain value") {
 				let (original, observer) = SignalProducer<Int, NoError>.pipe()
 
-				let producer = original.collect { _, next in next != 5 }
+				let producer = original.collect { _, value in value != 5 }
 
 				var expectedValues = [
 					[5, 5],
 					[42, 5]
 				]
 
-				producer.startWithNext { value in
+				producer.startWithValues { value in
 					expect(value) == expectedValues.removeFirst()
 				}
 
@@ -548,7 +548,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expectedValues
 					.flatMap { $0 }
-					.forEach(observer.sendNext)
+					.forEach(observer.send(value:))
 
 				observer.sendCompleted()
 			}
@@ -563,7 +563,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					[5, 6, 7, 8, 9]
 				]
 
-				producer.startWithNext { value in
+				producer.startWithValues { value in
 					expect(value) == expectedValues.removeFirst()
 				}
 
@@ -573,7 +573,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expectedValues
 					.flatMap { $0 }
-					.forEach(observer.sendNext)
+					.forEach(observer.send(value:))
 				
 				observer.sendCompleted()
 			}
@@ -601,7 +601,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case let .next(value):
+					case let .value(value):
 						lastValue = value
 					case .completed:
 						completed = true
@@ -614,24 +614,24 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should take values until the trigger fires") {
 				expect(lastValue).to(beNil())
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == 1
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 
 				expect(completed) == false
-				triggerObserver.sendNext(())
+				triggerObserver.send(value: ())
 				expect(completed) == true
 			}
 
 			it("should take values until the trigger completes") {
 				expect(lastValue).to(beNil())
 				
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == 1
 				
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 				
 				expect(completed) == false
@@ -643,7 +643,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed) == false
 
-				triggerObserver.sendNext(())
+				triggerObserver.send(value: ())
 
 				expect(completed) == true
 				expect(lastValue).to(beNil())
@@ -671,7 +671,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case let .next(value):
+					case let .value(value):
 						lastValue = value
 					case .completed:
 						completed = true
@@ -685,23 +685,23 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed) == false
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(lastValue) == 1
 
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(lastValue) == 2
 
-				replacementObserver.sendNext(3)
+				replacementObserver.send(value: 3)
 
 				expect(lastValue) == 3
 				expect(completed) == false
 
-				observer.sendNext(4)
+				observer.send(value: 4)
 
 				expect(lastValue) == 3
 				expect(completed) == false
 
-				replacementObserver.sendNext(5)
+				replacementObserver.send(value: 5)
 				expect(lastValue) == 5
 
 				expect(completed) == false
@@ -726,7 +726,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case let .next(value):
+					case let .value(value):
 						latestValue = value
 					case .completed:
 						completed = true
@@ -736,12 +736,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				for value in -1...4 {
-					observer.sendNext(value)
+					observer.send(value: value)
 					expect(latestValue) == value
 					expect(completed) == false
 				}
 
-				observer.sendNext(5)
+				observer.send(value: 5)
 				expect(latestValue) == 4
 				expect(completed) == true
 			}
@@ -752,7 +752,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case let .next(value):
+					case let .value(value):
 						latestValue = value
 					case .completed:
 						completed = true
@@ -761,7 +761,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					}
 				}
 
-				observer.sendNext(5)
+				observer.send(value: 5)
 				expect(latestValue).to(beNil())
 				expect(completed) == true
 			}
@@ -776,10 +776,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer
 					.observe(on: testScheduler)
-					.startWithNext { result.append($0) }
+					.startWithValues { result.append($0) }
 				
-				observer.sendNext(1)
-				observer.sendNext(2)
+				observer.send(value: 1)
+				observer.send(value: 2)
 				expect(result).to(beEmpty())
 				
 				testScheduler.run()
@@ -792,10 +792,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let testScheduler = TestScheduler()
 				let producer: SignalProducer<Int, NoError> = SignalProducer { observer, _ in
 					testScheduler.schedule {
-						observer.sendNext(1)
+						observer.send(value: 1)
 					}
 					testScheduler.schedule(after: 5) {
-						observer.sendNext(2)
+						observer.send(value: 2)
 						observer.sendCompleted()
 					}
 				}
@@ -807,7 +807,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					.delay(10, on: testScheduler)
 					.start { event in
 						switch event {
-						case let .next(number):
+						case let .value(number):
 							result.append(number)
 						case .completed:
 							completed = true
@@ -835,7 +835,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					let observer = observer
 
 					testScheduler.schedule {
-						observer.sendFailed(TestError.default)
+						observer.send(error: TestError.default)
 					}
 				}
 				
@@ -866,20 +866,20 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should send values on the given scheduler at no less than the interval") {
 				var values: [Int] = []
-				producer.startWithNext { value in
+				producer.startWithValues { value in
 					values.append(value)
 				}
 
 				expect(values) == []
 
-				observer.sendNext(0)
+				observer.send(value: 0)
 				expect(values) == []
 
 				scheduler.advance()
 				expect(values) == [ 0 ]
 
-				observer.sendNext(1)
-				observer.sendNext(2)
+				observer.send(value: 1)
+				observer.send(value: 2)
 				expect(values) == [ 0 ]
 
 				scheduler.advance(by: 1.5)
@@ -888,26 +888,26 @@ class SignalProducerLiftingSpec: QuickSpec {
 				scheduler.advance(by: 3)
 				expect(values) == [ 0, 2 ]
 
-				observer.sendNext(3)
+				observer.send(value: 3)
 				expect(values) == [ 0, 2 ]
 
 				scheduler.advance()
 				expect(values) == [ 0, 2, 3 ]
 
-				observer.sendNext(4)
-				observer.sendNext(5)
+				observer.send(value: 4)
+				observer.send(value: 5)
 				scheduler.advance()
 				expect(values) == [ 0, 2, 3 ]
 
 				scheduler.rewind(by: 2)
 				expect(values) == [ 0, 2, 3 ]
 				
-				observer.sendNext(6)
+				observer.send(value: 6)
 				scheduler.advance()
 				expect(values) == [ 0, 2, 3, 6 ]
 				
-				observer.sendNext(7)
-				observer.sendNext(8)
+				observer.send(value: 7)
+				observer.send(value: 8)
 				scheduler.advance()
 				expect(values) == [ 0, 2, 3, 6 ]
 				
@@ -921,7 +921,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case let .next(value):
+					case let .value(value):
 						values.append(value)
 					case .completed:
 						completed = true
@@ -930,11 +930,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 					}
 				}
 
-				observer.sendNext(0)
+				observer.send(value: 0)
 				scheduler.advance()
 				expect(values) == [ 0 ]
 
-				observer.sendNext(1)
+				observer.send(value: 1)
 				observer.sendCompleted()
 				expect(completed) == false
 
@@ -959,29 +959,29 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should forward the latest value when the sampler fires") {
 				var result: [String] = []
-				sampledProducer.startWithNext { (left, right) in result.append("\(left)\(right)") }
+				sampledProducer.startWithValues { (left, right) in result.append("\(left)\(right)") }
 				
-				observer.sendNext(1)
-				observer.sendNext(2)
-				samplerObserver.sendNext("a")
+				observer.send(value: 1)
+				observer.send(value: 2)
+				samplerObserver.send(value: "a")
 				expect(result) == [ "2a" ]
 			}
 			
 			it("should do nothing if sampler fires before signal receives value") {
 				var result: [String] = []
-				sampledProducer.startWithNext { (left, right) in result.append("\(left)\(right)") }
+				sampledProducer.startWithValues { (left, right) in result.append("\(left)\(right)") }
 				
-				samplerObserver.sendNext("a")
+				samplerObserver.send(value: "a")
 				expect(result).to(beEmpty())
 			}
 			
 			it("should send lates value multiple times when sampler fires multiple times") {
 				var result: [String] = []
-				sampledProducer.startWithNext { (left, right) in result.append("\(left)\(right)") }
+				sampledProducer.startWithValues { (left, right) in result.append("\(left)\(right)") }
 				
-				observer.sendNext(1)
-				samplerObserver.sendNext("a")
-				samplerObserver.sendNext("b")
+				observer.send(value: 1)
+				samplerObserver.send(value: "a")
+				samplerObserver.send(value: "b")
 				expect(result) == [ "1a", "1b" ]
 			}
 			
@@ -1003,7 +1003,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let result = producer.sample(with: sampler)
 				
 				var valueReceived: String?
-				result.startWithNext { (left, right) in valueReceived = "\(left)\(right)" }
+				result.startWithValues { (left, right) in valueReceived = "\(left)\(right)" }
 				
 				expect(valueReceived) == "1a"
 			}
@@ -1024,29 +1024,29 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should forward the latest value when the sampler fires") {
 				var result: [Int] = []
-				sampledProducer.startWithNext { result.append($0) }
+				sampledProducer.startWithValues { result.append($0) }
 				
-				observer.sendNext(1)
-				observer.sendNext(2)
-				samplerObserver.sendNext(())
+				observer.send(value: 1)
+				observer.send(value: 2)
+				samplerObserver.send(value: ())
 				expect(result) == [ 2 ]
 			}
 			
 			it("should do nothing if sampler fires before signal receives value") {
 				var result: [Int] = []
-				sampledProducer.startWithNext { result.append($0) }
+				sampledProducer.startWithValues { result.append($0) }
 				
-				samplerObserver.sendNext(())
+				samplerObserver.send(value: ())
 				expect(result).to(beEmpty())
 			}
 			
 			it("should send lates value multiple times when sampler fires multiple times") {
 				var result: [Int] = []
-				sampledProducer.startWithNext { result.append($0) }
+				sampledProducer.startWithValues { result.append($0) }
 				
-				observer.sendNext(1)
-				samplerObserver.sendNext(())
-				samplerObserver.sendNext(())
+				observer.send(value: 1)
+				samplerObserver.send(value: ())
+				samplerObserver.send(value: ())
 				expect(result) == [ 1, 1 ]
 			}
 
@@ -1068,7 +1068,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let result = producer.sample(on: sampler)
 				
 				var valueReceived: Int?
-				result.startWithNext { valueReceived = $0 }
+				result.startWithValues { valueReceived = $0 }
 				
 				expect(valueReceived) == 1
 			}
@@ -1101,7 +1101,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 					let disposable = sampledProducer.start()
 
-					observer.sendNext(Payload { payloadFreed = true })
+					observer.send(value: Payload { payloadFreed = true })
 					observer.sendCompleted()
 
 					expect(payloadFreed) == false
@@ -1127,17 +1127,17 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should forward the latest values from both inputs") {
 				var latest: (Int, Double)?
-				combinedProducer.startWithNext { latest = $0 }
+				combinedProducer.startWithValues { latest = $0 }
 				
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(latest).to(beNil())
 				
 				// is there a better way to test tuples?
-				otherObserver.sendNext(1.5)
+				otherObserver.send(value: 1.5)
 				expect(latest?.0) == 1
 				expect(latest?.1) == 1.5
 				
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(latest?.0) == 2
 				expect(latest?.1) == 1.5
 			}
@@ -1170,26 +1170,26 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should combine pairs") {
 				var result: [String] = []
-				zipped.startWithNext { (left, right) in result.append("\(left)\(right)") }
+				zipped.startWithValues { (left, right) in result.append("\(left)\(right)") }
 
-				leftObserver.sendNext(1)
-				leftObserver.sendNext(2)
+				leftObserver.send(value: 1)
+				leftObserver.send(value: 2)
 				expect(result) == []
 
-				rightObserver.sendNext("foo")
+				rightObserver.send(value: "foo")
 				expect(result) == [ "1foo" ]
 
-				leftObserver.sendNext(3)
-				rightObserver.sendNext("bar")
+				leftObserver.send(value: 3)
+				rightObserver.send(value: "bar")
 				expect(result) == [ "1foo", "2bar" ]
 
-				rightObserver.sendNext("buzz")
+				rightObserver.send(value: "buzz")
 				expect(result) == [ "1foo", "2bar", "3buzz" ]
 
-				rightObserver.sendNext("fuzz")
+				rightObserver.send(value: "fuzz")
 				expect(result) == [ "1foo", "2bar", "3buzz" ]
 
-				leftObserver.sendNext(4)
+				leftObserver.send(value: 4)
 				expect(result) == [ "1foo", "2bar", "3buzz", "4fuzz" ]
 			}
 
@@ -1199,7 +1199,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				zipped.start { event in
 					switch event {
-					case let .next(left, right):
+					case let .value(left, right):
 						result.append("\(left)\(right)")
 					case .completed:
 						completed = true
@@ -1210,12 +1210,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(completed) == false
 
-				leftObserver.sendNext(0)
+				leftObserver.send(value: 0)
 				leftObserver.sendCompleted()
 				expect(completed) == false
 				expect(result) == []
 
-				rightObserver.sendNext("foo")
+				rightObserver.send(value: "foo")
 				expect(completed) == true
 				expect(result) == [ "0foo" ]
 			}
@@ -1227,26 +1227,26 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var latestEvent: Event<Int, TestError>?
 				producer
 					.materialize()
-					.startWithNext { latestEvent = $0 }
+					.startWithValues { latestEvent = $0 }
 				
-				observer.sendNext(2)
+				observer.send(value: 2)
 				
 				expect(latestEvent).toNot(beNil())
 				if let latestEvent = latestEvent {
 					switch latestEvent {
-					case let .next(value):
+					case let .value(value):
 						expect(value) == 2
 					case .failed, .completed, .interrupted:
 						fail()
 					}
 				}
 				
-				observer.sendFailed(TestError.default)
+				observer.send(error: TestError.default)
 				if let latestEvent = latestEvent {
 					switch latestEvent {
 					case .failed:
 						break
-					case .next, .completed, .interrupted:
+					case .value, .completed, .interrupted:
 						fail()
 					}
 				}
@@ -1264,18 +1264,18 @@ class SignalProducerLiftingSpec: QuickSpec {
 				dematerialized = producer.dematerialize()
 			}
 			
-			it("should send values for Next events") {
+			it("should send values for Value events") {
 				var result: [Int] = []
 				dematerialized
 					.assumeNoErrors()
-					.startWithNext { result.append($0) }
+					.startWithValues { result.append($0) }
 				
 				expect(result).to(beEmpty())
 				
-				observer.sendNext(.next(2))
+				observer.send(value: .value(2))
 				expect(result) == [ 2 ]
 				
-				observer.sendNext(.next(4))
+				observer.send(value: .value(4))
 				expect(result) == [ 2, 4 ]
 			}
 
@@ -1285,7 +1285,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				expect(errored) == false
 				
-				observer.sendNext(.failed(TestError.default))
+				observer.send(value: .failed(TestError.default))
 				expect(errored) == true
 			}
 
@@ -1294,7 +1294,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				dematerialized.startWithCompleted { completed = true }
 				
 				expect(completed) == false
-				observer.sendNext(IntEvent.completed)
+				observer.send(value: IntEvent.completed)
 				expect(completed) == true
 			}
 		}
@@ -1313,12 +1313,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [Int] = []
 				lastThree
 					.assumeNoErrors()
-					.startWithNext { result.append($0) }
+					.startWithValues { result.append($0) }
 				
-				observer.sendNext(1)
-				observer.sendNext(2)
-				observer.sendNext(3)
-				observer.sendNext(4)
+				observer.send(value: 1)
+				observer.send(value: 2)
+				observer.send(value: 3)
+				observer.send(value: 4)
 				expect(result).to(beEmpty())
 				
 				observer.sendCompleted()
@@ -1329,10 +1329,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [Int] = []
 				lastThree
 					.assumeNoErrors()
-					.startWithNext { result.append($0) }
+					.startWithValues { result.append($0) }
 				
-				observer.sendNext(1)
-				observer.sendNext(2)
+				observer.send(value: 1)
+				observer.send(value: 2)
 				observer.sendCompleted()
 				expect(result) == [ 1, 2 ]
 			}
@@ -1342,7 +1342,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var errored = false
 				lastThree.start { event in
 					switch event {
-					case let .next(value):
+					case let .value(value):
 						result.append(value)
 					case .failed:
 						errored = true
@@ -1351,12 +1351,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 					}
 				}
 				
-				observer.sendNext(1)
-				observer.sendNext(2)
-				observer.sendNext(3)
+				observer.send(value: 1)
+				observer.send(value: 2)
+				observer.send(value: 3)
 				expect(errored) == false
 				
-				observer.sendFailed(TestError.default)
+				observer.send(error: TestError.default)
 				expect(errored) == true
 				expect(result).to(beEmpty())
 			}
@@ -1383,7 +1383,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 						completed = true
 					case .failed:
 						errored = true
-					case .next, .interrupted:
+					case .value, .interrupted:
 						break
 					}
 				}
@@ -1409,7 +1409,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 						completed = true
 					case .failed:
 						errored = true
-					case .next, .interrupted:
+					case .value, .interrupted:
 						break
 					}
 				}
@@ -1444,12 +1444,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var current: Int?
 				producer
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						current = value
 					}
 				
 				for value in 1...5 {
-					observer.sendNext(value)
+					observer.send(value: value)
 					expect(current) == value
 				}
 			}
@@ -1465,7 +1465,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					error = err
 				}
 				
-				observer.sendNext(42)
+				observer.send(value: 42)
 				expect(error) == TestError.default
 			}
 		}
@@ -1480,14 +1480,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var even: Bool?
 				producer
 					.assumeNoErrors()
-					.startWithNext { value in
+					.startWithValues { value in
 						even = value
 					}
 				
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(even) == false
 				
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(even) == true
 			}
 			
@@ -1502,7 +1502,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					error = err
 				}
 				
-				observer.sendNext(42)
+				observer.send(value: 42)
 				expect(error) == TestError.default
 			}
 		}
@@ -1517,17 +1517,17 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				let (signal, baseObserver) = SignalProducer<Int, NoError>.pipe()
 				observer = baseObserver
-				signal.combinePrevious(initialValue).startWithNext { latestValues = $0 }
+				signal.combinePrevious(initialValue).startWithValues { latestValues = $0 }
 			}
 			
 			it("should forward the latest value with previous value") {
 				expect(latestValues).to(beNil())
 				
-				observer.sendNext(1)
+				observer.send(value: 1)
 				expect(latestValues?.0) == initialValue
 				expect(latestValues?.1) == 1
 				
-				observer.sendNext(2)
+				observer.send(value: 2)
 				expect(latestValues?.0) == 1
 				expect(latestValues?.1) == 2
 			}

--- a/Tests/ReactiveSwiftTests/SignalProducerNimbleMatchers.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerNimbleMatchers.swift
@@ -29,7 +29,7 @@ public func sendValues<T: Equatable, E: Equatable>(_ values: [T], sendError mayb
 
 			signalProducer.start { event in
 				switch event {
-				case let .next(value):
+				case let .value(value):
 					sentValues.append(value)
 				case .completed:
 					signalCompleted = true


### PR DESCRIPTION
As discussed in https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3013

I rather like this. I don’t think `next` is a particularly great name. `value` seems much better to me.

`Observer.sendValue()` becomes `Observer.send(value: )`
`Observer.sendFailed()` becomes `Observer.send(error: )`
`SignalProducer.startWithNext` becomes `SignalProducer.startWithValues`
`SignalProducer.observeNext` becomes `SignalProducer.startWithValues`