### PR TITLE
Add initialisers to create an Action from an input property

### DIFF
--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -104,7 +104,7 @@ public final class Action<Input, Output, Error: Swift.Error> {
 	}
 
 	/// Initializes an action that will be conditionally enabled, and creates a
-	/// SignalProducer for each input.
+	/// `SignalProducer` for each input.
 	///
 	/// - parameters:
 	///   - enabledIf: Boolean property that shows whether the action is
@@ -261,15 +261,15 @@ extension Action: ActionProtocol {
 }
 
 extension ActionProtocol where Input == Void {
-	/// Initializes an action that uses an optional property for its input,
-	/// and is disabled whenever the input is nil. When executed, a SignalProducer
+	/// Initializes an action that uses an `Optional` property for its input,
+	/// and is disabled whenever the input is `nil`. When executed, a `SignalProducer`
 	/// is created with the current value of the input.
 	///
 	/// - parameters:
-	///   - input: An Optional property whose current value is used as input
+	///   - input: An `Optional` property whose current value is used as input
 	///            whenever the action is executed. The action is disabled
-	///            whenever the value is nil.
-	///   - execute: A closure to return a new SignalProducer based on the
+	///            whenever the value is `nil`.
+	///   - execute: A closure to return a new `SignalProducer` based on the
 	///              current value of `input`.
 	public init<P: PropertyProtocol, T>(input: P, _ execute: @escaping (T) -> SignalProducer<Output, Error>) where P.Value == T? {
 		self.init(state: input, enabledIf: { $0 != nil }) { input, _ in
@@ -278,12 +278,12 @@ extension ActionProtocol where Input == Void {
 	}
 
 	/// Initializes an action that uses a property for its input. When executed,
-	/// a SignalProducer is created with the current value of the input.
+	/// a `SignalProducer` is created with the current value of the input.
 	///
 	/// - parameters:
 	///   - input: A property whose current value is used as input
 	///            whenever the action is executed.
-	///   - execute: A closure to return a new SignalProducer based on the
+	///   - execute: A closure to return a new `SignalProducer` based on the
 	///              current value of `input`.
 	public init<P: PropertyProtocol, T>(input: P, _ execute: @escaping (T) -> SignalProducer<Output, Error>) where P.Value == T {
 		self.init(input: input.map(Optional.some), execute)

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -88,7 +88,7 @@ public final class Action<Input, Output, Error: Swift.Error> {
 		errors = events.map { $0.error }.skipNil()
 		completed = events.filter { $0.isCompleted }.map { _ in }
 
-		let initial = ActionState(isExecuting: false, value: property.value, isEnabled: { isEnabled($0 as! State.Value) })
+		let initial = ActionState(value: property.value, isEnabled: { isEnabled($0 as! State.Value) })
 		state = MutableProperty(initial)
 
 		property.signal
@@ -179,12 +179,11 @@ public final class Action<Input, Output, Error: Swift.Error> {
 }
 
 private struct ActionState {
-	var isExecuting: Bool
+	var isExecuting: Bool = false
 	var value: Any
 	private let userEnabled: (Any) -> Bool
 
-	init(isExecuting: Bool, value: Any, isEnabled: @escaping (Any) -> Bool) {
-		self.isExecuting = isExecuting
+	init(value: Any, isEnabled: @escaping (Any) -> Bool) {
 		self.value = value
 		self.userEnabled = isEnabled
 	}

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -180,18 +180,26 @@ public final class Action<Input, Output, Error: Swift.Error> {
 
 private struct ActionState {
 	var isExecuting: Bool = false
-	var value: Any
-	private let userEnabled: (Any) -> Bool
+
+	var value: Any {
+		didSet {
+			userEnabled = userEnabledClosure(value)
+		}
+	}
+
+	private var userEnabled: Bool
+	private let userEnabledClosure: (Any) -> Bool
 
 	init(value: Any, isEnabled: @escaping (Any) -> Bool) {
 		self.value = value
-		self.userEnabled = isEnabled
+		self.userEnabled = isEnabled(value)
+		self.userEnabledClosure = isEnabled
 	}
 
 	/// Whether the action should be enabled for the given combination of user
 	/// enabledness and executing status.
 	fileprivate var isEnabled: Bool {
-		return userEnabled(value) && !isExecuting
+		return userEnabled && !isExecuting
 	}
 }
 

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -222,5 +222,35 @@ class ActionSpec: QuickSpec {
 				}
 			}
 		}
+
+		describe("using a property as input") {
+			let echo: (Int) -> SignalProducer<Int, NoError> = SignalProducer.init(value:)
+
+			it("executes the action with the property's current value") {
+				let input = MutableProperty(0)
+				let action = Action(input: input, echo)
+
+				var values: [Int] = []
+				action.values.observeValues { values.append($0) }
+
+				input.value = 1
+				action.apply().start()
+				input.value = 2
+				action.apply().start()
+				input.value = 3
+				action.apply().start()
+
+				expect(values) == [1, 2, 3]
+			}
+
+			it("is disabled if the property is nil") {
+				let input = MutableProperty<Int?>(1)
+				let action = Action(input: input, echo)
+
+				expect(action.isEnabled.value) == true
+				input.value = nil
+				expect(action.isEnabled.value) == false
+			}
+		}
 	}
 }


### PR DESCRIPTION
**Update:** Closes #88.

---

`PropertyAction` encapsulates the pattern where an `Action` should be enabled only if its input is non-nil.

The prime example of this pattern is form validation: validate some input text, and store the validated results in a property. If the form is valid, the property will be non-nil, and it should be safe to grab the current value and submit the form.

I've personally written a bunch of `Action`-based code that basically just implemented this logic in an ad-hoc fashion, so I think it would be super useful to have a convenient shorthand for it.

---

Ideally this could just be a convenience initialiser on `Action`:

```
extension Action where Input == Void {
  // ...
}
```

But unfortunately this triggers Swift's "same-type requirement makes generic parameter non-generic" error.
