### PR TITLE
Add the @discardableResult attribute to a Disposable.add overload

### DIFF
--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -185,6 +185,7 @@ public final class CompositeDisposable: Disposable {
 	///
 	/// - returns: An instance of `DisposableHandle` that can be used to
 	///            opaquely remove the disposable later (if desired).
+	@discardableResult
 	public func add(_ action: @escaping () -> Void) -> DisposableHandle {
 		return add(ActionDisposable(action: action))
 	}


### PR DESCRIPTION
As implied by the documentation comment (and correctly so, IMO), it seems like the return value of this `Disposable.add` function overload should be discardable.