### PR TITLE
32bit arch crash: timer producer fails when interval is >= 3 seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ matrix:
         - XCODE_SDK=iphonesimulator
         - XCODE_ACTION="build-for-testing test-without-building"
         - XCODE_DESTINATION="platform=iOS Simulator,name=iPhone 6s"
+      env:
+        - XCODE_SDK=iphonesimulator
+        - XCODE_ACTION="build-for-testing test-without-building"
+        - XCODE_DESTINATION="platform=iOS Simulator,name=iPhone 5"
     - xcode_scheme: ReactiveSwift-tvOS
       env:
         - XCODE_SDK=appletvsimulator

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -264,16 +264,16 @@ public final class QueueScheduler: DateSchedulerProtocol {
 		precondition(interval >= 0)
 		precondition(leeway >= 0)
 
-		let nsecInterval = interval * Double(NSEC_PER_SEC)
-		let nsecLeeway = leeway * Double(NSEC_PER_SEC)
+		let msecInterval = interval * 1000
+		let msecLeeway = leeway * 1000
 
 		let timer = DispatchSource.makeTimerSource(
 			flags: DispatchSource.TimerFlags(rawValue: UInt(0)),
 			queue: queue
 		)
 		timer.scheduleRepeating(wallDeadline: wallTime(with: date),
-		                        interval: .nanoseconds(Int(nsecInterval)),
-		                        leeway: .nanoseconds(Int(nsecLeeway)))
+		                        interval: .milliseconds(Int(msecInterval)),
+		                        leeway: .milliseconds(Int(msecLeeway)))
 		timer.setEventHandler(handler: action)
 		timer.resume()
 

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -794,7 +794,13 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("shouldn't overflow on a real scheduler") {
-				let scheduler = QueueScheduler()
+				let scheduler: QueueScheduler
+				if #available(OSX 10.10, *) {
+					scheduler = QueueScheduler(qos: .default, name: "\(#file):\(#line)")
+				} else {
+					scheduler = QueueScheduler(queue: DispatchQueue(label: "\(#file):\(#line)"))
+				}
+
 				let producer = timer(interval: 3, on: scheduler)
 				producer
 					.start()

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -793,6 +793,14 @@ class SignalProducerSpec: QuickSpec {
 				expect(dates) == [tick1, tick2, tick3]
 			}
 
+			it("shouldn't overflow on a real scheduler") {
+				let scheduler = QueueScheduler()
+				let producer = timer(interval: 3, on: scheduler)
+				let disposable = producer.start()
+
+				disposable.dispose()
+			}
+
 			it("should release the signal when disposed") {
 				let scheduler = TestScheduler()
 				let producer = timer(interval: 1, on: scheduler, leeway: 0)

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -796,9 +796,9 @@ class SignalProducerSpec: QuickSpec {
 			it("shouldn't overflow on a real scheduler") {
 				let scheduler = QueueScheduler()
 				let producer = timer(interval: 3, on: scheduler)
-				let disposable = producer.start()
-
-				disposable.dispose()
+				producer
+					.start()
+					.dispose()
 			}
 
 			it("should release the signal when disposed") {


### PR DESCRIPTION
Nanos conversion overflows on 32 bit devices because new dispatch API takes an Int and not Int64.
When interval and leeway get high enough and then we cast to Int, it overflows. 