### PR TITLE
Allow targeting work on a specific queue

### DIFF
--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -157,8 +157,8 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	///         the `QueueScheduler` will be serial with respect to each other.
 	///
 	/// - warning: Obsoleted in OS X 10.11
-	@available(OSX, deprecated:10.10, obsoleted:10.11, message:"Use init(qos:, name:) instead")
-	@available(iOS, deprecated:8.0, obsoleted:9.0, message:"Use init(qos:, name:) instead.")
+	@available(OSX, deprecated:10.10, obsoleted:10.11, message:"Use init(qos:name:targeting:) instead")
+	@available(iOS, deprecated:8.0, obsoleted:9.0, message:"Use init(qos:name:targeting:) instead.")
 	public convenience init(queue: DispatchQueue, name: String = "org.reactivecocoa.ReactiveSwift.QueueScheduler") {
 		self.init(internalQueue: DispatchQueue(label: name, attributes: [], target: queue))
 	}
@@ -169,15 +169,14 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	/// - parameters:
 	///   - qos: Dispatch queue's QoS value.
 	///   - name: Name for the queue in the form of reverse domain.
+	///   - targeting: (Optional) The queue on which this scheduler's work is
+	///     targeted
 	@available(OSX 10.10, *)
-	public convenience init(
-		qos: DispatchQoS = .default,
-		name: String = "org.reactivecocoa.ReactiveSwift.QueueScheduler"
-	) {
-		self.init(internalQueue: DispatchQueue(
-			label: name,
-			qos: qos
-		))
+	public convenience init(qos: DispatchQoS = .default, name: String = "org.reactivecocoa.ReactiveSwift.QueueScheduler", targeting targetQueue: DispatchQueue? = nil) {
+		self.init(internalQueue: DispatchQueue(label: name, qos: qos))
+		if let targetQueue = targetQueue {
+			queue.setTarget(queue: targetQueue)
+		}
 	}
 
 	/// Schedules action for dispatch on internal queue

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -160,10 +160,10 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	@available(OSX, deprecated:10.10, obsoleted:10.11, message:"Use init(qos:name:targeting:) instead")
 	@available(iOS, deprecated:8.0, obsoleted:9.0, message:"Use init(qos:name:targeting:) instead.")
 	public convenience init(queue: DispatchQueue, name: String = "org.reactivecocoa.ReactiveSwift.QueueScheduler") {
-		self.init(internalQueue: DispatchQueue(label: name, attributes: [], target: queue))
+		self.init(internalQueue: DispatchQueue(label: name, target: queue))
 	}
 
-	/// Initializes a scheduler that will target a new serial queue with the
+	/// Initializes a scheduler that creates a new serial queue with the
 	/// given quality of service class.
 	///
 	/// - parameters:
@@ -172,11 +172,16 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	///   - targeting: (Optional) The queue on which this scheduler's work is
 	///     targeted
 	@available(OSX 10.10, *)
-	public convenience init(qos: DispatchQoS = .default, name: String = "org.reactivecocoa.ReactiveSwift.QueueScheduler", targeting targetQueue: DispatchQueue? = nil) {
-		self.init(internalQueue: DispatchQueue(label: name, qos: qos))
-		if let targetQueue = targetQueue {
-			queue.setTarget(queue: targetQueue)
-		}
+	public convenience init(
+		qos: DispatchQoS = .default,
+		name: String = "org.reactivecocoa.ReactiveSwift.QueueScheduler",
+		targeting targetQueue: DispatchQueue? = nil
+	) {
+		self.init(internalQueue: DispatchQueue(
+			label: name,
+			qos: qos,
+			target: targetQueue
+		))
 	}
 
 	/// Schedules action for dispatch on internal queue


### PR DESCRIPTION
When modernizing the QueueScheduler API, I inadvertently left out the rare-but-useful case where work could be targeted to a specific destination queue.

This was driven by some late-breaking discussion in https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2295.

This change is rather minimal in that it pushes the target queue into an optional parameter with a default nil value, so callers should not be forced to change.

I also intended for the API to be clear about the fact that we are targeting an existing queue, so callers (hopefully) won't end up "falling back" into the old pattern of targeting a global queue of their preferred priority.