### PR TITLE
Use Schedulers in `BindingTarget`.

### DIFF
--- a/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
+++ b/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
@@ -41,13 +41,29 @@ class UnidirectionalBindingSpec: QuickSpec {
 			}
 
 			it("should not deadlock on the same queue") {
-				target = BindingTarget(on: .main,
+				target = BindingTarget(on: UIScheduler(),
 				                       lifetime: lifetime,
 				                       setter: { value = $0 })
 
 				let property = MutableProperty(1)
 				target <~ property
 				expect(value) == 1
+			}
+
+			it("should not deadlock on the main thread even if the context was switched to a different queue") {
+				let queue = DispatchQueue(label: #file)
+
+				target = BindingTarget(on: UIScheduler(),
+				                       lifetime: lifetime,
+				                       setter: { value = $0 })
+
+				let property = MutableProperty(1)
+
+				queue.sync {
+					_ = target <~ property
+				}
+
+				expect(value).toEventually(equal(1))
 			}
 
 			it("should not deadlock even if the value is originated from the same queue indirectly") {
@@ -61,7 +77,7 @@ class UnidirectionalBindingSpec: QuickSpec {
 					mainQueueCounter.modify { $0 += DispatchQueue.getSpecific(key: key) != nil ? 1 : 0 }
 				}
 
-				target = BindingTarget(on: .main,
+				target = BindingTarget(on: UIScheduler(),
 				                       lifetime: lifetime,
 				                       setter: setter)
 


### PR DESCRIPTION
When making progress for the Rex PR, I hit a ~~weird~~ case which:

1. `Thread.isMainThread` is true;
2. `DispatchQueue.main.getSpecific(key: specificKey)` gives me the right queue id (for the main queue);
3. BUT `DispatchQueue.getSpecific(key: specificKey)` gives `nil`.

~~It seems it might be because of this:~~

> ~~https://developer.apple.com/reference/dispatch/1453125-dispatch_get_specific~~
>
> ~~This function is intended to be called from a block executing in a dispatch queue. You use it to obtain context data associated with the queue. Calling this method from code not running in a dispatch queue returns NULL because there is no queue to provide context.~~

The issue is in fact caused by the implicit nesting of `DispatchQueue.sync`. Somewhere in the middle of the call stack was a `sync` to another queue, causing the current context being bound to the private queue despite still being on the main thread. This PR adds the ability to elide the `sync` call for this particular case.