### PR TITLE
Revert `Observer` back to be a `struct`.

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -152,12 +152,12 @@ extension CompositeDisposable {
 
 extension Observer {
 	@available(*, unavailable, renamed: "init(value:failed:completed:interrupted:)")
-	public convenience init(
+	public init(
 		next: ((Value) -> Void)? = nil,
 		failed: ((Error) -> Void)? = nil,
 		completed: (() -> Void)? = nil,
 		interrupted: (() -> Void)? = nil
-		) { fatalError() }
+	) { fatalError() }
 }
 
 extension ObserverProtocol {

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -26,7 +26,7 @@ public protocol ObserverProtocol {
 
 /// An Observer is a simple wrapper around a function which can receive Events
 /// (typically from a Signal).
-public final class Observer<Value, Error: Swift.Error> {
+public struct Observer<Value, Error: Swift.Error> {
 	public typealias Action = (Event<Value, Error>) -> Void
 
 	/// An action that will be performed upon arrival of the event.
@@ -51,7 +51,7 @@ public final class Observer<Value, Error: Swift.Error> {
 	///                observed.
 	///   - interruped: Optional closure executed when an `interrupted` event is
 	///                 observed.
-	public convenience init(
+	public init(
 		value: ((Value) -> Void)? = nil,
 		failed: ((Error) -> Void)? = nil,
 		completed: (() -> Void)? = nil,

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1736,10 +1736,13 @@ extension SignalProducerProtocol {
 			// have terminated.
 			disposable += { _ = lifetimeToken }
 
+			// A token to identify this instance of produced signal.
+			let token = ReplayToken()
+
 			while true {
 				var result: Result<RemovalToken?, ReplayError<Value>>!
 				state.modify {
-					result = $0.observe(observer)
+					result = $0.observe(observer, token: token)
 				}
 
 				switch result! {
@@ -1773,6 +1776,8 @@ private struct ReplayError<Value>: Error {
 	/// The values that should be replayed by the observer.
 	let values: [Value]
 }
+
+private class ReplayToken {}
 
 private struct ReplayState<Value, Error: Swift.Error> {
 	let capacity: Int
@@ -1813,11 +1818,8 @@ private struct ReplayState<Value, Error: Swift.Error> {
 	///   If the observer is successfully attached, a `Result.success` with the
 	///   corresponding removal token would be returned. Otherwise, a
 	///   `Result.failure` with a `ReplayError` would be returned.
-	mutating func observe(_ observer: Signal<Value, Error>.Observer) -> Result<RemovalToken?, ReplayError<Value>> {
-		// Since the only use case is `replayLazily`, which always creates a unique
-		// `Observer` for every produced signal, we can use the ObjectIdentifier of
-		// the `Observer` to track them directly.
-		let id = ObjectIdentifier(observer)
+	mutating func observe(_ observer: Signal<Value, Error>.Observer, token: ReplayToken) -> Result<RemovalToken?, ReplayError<Value>> {
+		let id = ObjectIdentifier(token)
 
 		switch replayBuffers[id] {
 		case .none where !values.isEmpty:


### PR DESCRIPTION
This seems to be an artefact from https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3120. 

`Observer` being `class` was solely to serve the internal implementation of `replayLazily`.