### PR TITLE
Add throttle(while:on:)

### DIFF
--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1565,6 +1565,10 @@ extension SignalProtocol {
 	///         that value will be discarded and the returned signal will
 	///         terminate immediately.
 	///
+	/// - note: If `shouldThrottle` completes before the receiver, and its last
+	///         value is `true`, the returned signal will remain in the throttled
+	///         state, emitting no further values until it terminates.
+	///
 	/// - parameters:
 	///   - shouldThrottle: A boolean property that controls whether values
 	///                     should be throttled.

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1575,7 +1575,7 @@ extension SignalProtocol {
 		where P.Value == Bool
 	{
 		return Signal { observer in
-			let initial: ThrottleWhileState<Value> = shouldThrottle.value ? .throttled(nil) : .resumed
+			let initial: ThrottleWhileState<Value> = .resumed
 			let state = Atomic(initial)
 			let schedulerDisposable = SerialDisposable()
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1581,7 +1581,6 @@ extension SignalProtocol {
 
 			let disposable = CompositeDisposable()
 			disposable += schedulerDisposable
-			disposable += { _ = shouldThrottle }
 
 			disposable += shouldThrottle.producer
 				.skipRepeats()

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1556,10 +1556,9 @@ extension SignalProtocol {
 	/// `shouldThrottle` is true, forwarding values on the given scheduler.
 	///
 	/// - note: While `shouldThrottle` remains false, values are forwarded on the
-	///         given scheduler.
-	///
-	/// - note: If multiple values are received while `shouldThrottle` is true,
-	///         the latest value is the one that will be passed on.
+	///         given scheduler. If multiple values are received while
+	///         `shouldThrottle` is true, the latest value is the one that will
+	///         be passed on.
 	///
 	/// - note: If the input signal terminates while a value is being throttled,
 	///         that value will be discarded and the returned signal will

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1044,10 +1044,9 @@ extension SignalProducerProtocol {
 	/// `shouldThrottle` is true, forwarding values on the given scheduler.
 	///
 	/// - note: While `shouldThrottle` remains false, values are forwarded on the
-	///         given scheduler.
-	///
-	/// - note: If multiple values are received while `shouldThrottle` is true,
-	///         the latest value is the one that will be passed on.
+	///         given scheduler. If multiple values are received while
+	///         `shouldThrottle` is true, the latest value is the one that will
+	///         be passed on.
 	///
 	/// - note: If the input signal terminates while a value is being throttled,
 	///         that value will be discarded and the returned signal will

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1053,6 +1053,10 @@ extension SignalProducerProtocol {
 	///         that value will be discarded and the returned signal will
 	///         terminate immediately.
 	///
+	/// - note: If `shouldThrottle` completes before the receiver, and its last
+	///         value is `true`, the returned signal will remain in the throttled
+	///         state, emitting no further values until it terminates.
+	///
 	/// - parameters:
 	///   - shouldThrottle: A boolean property that controls whether values
 	///                     should be throttled.

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1062,6 +1062,10 @@ extension SignalProducerProtocol {
 	public func throttle<P: PropertyProtocol>(while shouldThrottle: P, on scheduler: SchedulerProtocol) -> SignalProducer<Value, Error>
 		where P.Value == Bool
 	{
+		// Using `Property.init(_:)` avoids capturing a strong reference
+		// to `shouldThrottle`, so that we don't extend its lifetime.
+		let shouldThrottle = Property(shouldThrottle)
+
 		return lift { $0.throttle(while: shouldThrottle, on: scheduler) }
 	}
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1040,6 +1040,31 @@ extension SignalProducerProtocol {
 		return lift { $0.throttle(interval, on: scheduler) }
 	}
 
+	/// Conditionally throttles values sent on the receiver whenever
+	/// `shouldThrottle` is true, forwarding values on the given scheduler.
+	///
+	/// - note: While `shouldThrottle` remains false, values are forwarded on the
+	///         given scheduler.
+	///
+	/// - note: If multiple values are received while `shouldThrottle` is true,
+	///         the latest value is the one that will be passed on.
+	///
+	/// - note: If the input signal terminates while a value is being throttled,
+	///         that value will be discarded and the returned signal will
+	///         terminate immediately.
+	///
+	/// - parameters:
+	///   - shouldThrottle: A boolean property that controls whether values
+	///                     should be throttled.
+	///   - scheduler: A scheduler to deliver events on.
+	///
+	/// - returns: A producer that sends values only while `shouldThrottle` is false.
+	public func throttle<P: PropertyProtocol>(while shouldThrottle: P, on scheduler: SchedulerProtocol) -> SignalProducer<Value, Error>
+		where P.Value == Bool
+	{
+		return lift { $0.throttle(while: shouldThrottle, on: scheduler) }
+	}
+
 	/// Debounce values sent by the receiver, such that at least `interval`
 	/// seconds pass after the receiver has last sent a value, then
 	/// forward the latest value on the given scheduler.

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -851,6 +851,36 @@ class SignalProducerSpec: QuickSpec {
 			}
 		}
 
+		describe("throttle while") {
+			var scheduler: ImmediateScheduler!
+			var shouldThrottle: MutableProperty<Bool>!
+			var observer: Signal<Int, NoError>.Observer!
+			var producer: SignalProducer<Int, NoError>!
+
+			beforeEach {
+				scheduler = ImmediateScheduler()
+				shouldThrottle = MutableProperty(false)
+
+				let (baseSignal, baseObserver) = Signal<Int, NoError>.pipe()
+				observer = baseObserver
+
+				producer = SignalProducer(signal: baseSignal)
+					.throttle(while: shouldThrottle, on: scheduler)
+
+				expect(producer).notTo(beNil())
+			}
+
+			it("doesn't extend the lifetime of the throttle property") {
+				var completed = false
+				shouldThrottle.lifetime.ended.observeCompleted { completed = true }
+
+				observer.send(value: 1)
+				shouldThrottle = nil
+
+				expect(completed) == true
+			}
+		}
+
 		describe("on") {
 			it("should attach event handlers to each started signal") {
 				let (baseProducer, observer) = SignalProducer<Int, TestError>.pipe()

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -1445,6 +1445,60 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
+		describe("throttle while") {
+			var scheduler: ImmediateScheduler!
+			var shouldThrottle: MutableProperty<Bool>!
+			var observer: Signal<Int, NoError>.Observer!
+			var signal: Signal<Int, NoError>!
+
+			beforeEach {
+				scheduler = ImmediateScheduler()
+				shouldThrottle = MutableProperty(false)
+
+				let (baseSignal, baseObserver) = Signal<Int, NoError>.pipe()
+				observer = baseObserver
+
+				signal = baseSignal.throttle(while: shouldThrottle, on: scheduler)
+				expect(signal).notTo(beNil())
+			}
+
+			it("passes through unthrottled values") {
+				var values: [Int] = []
+				signal.observeValues { values.append($0) }
+
+				observer.send(value: 1)
+				observer.send(value: 2)
+				observer.send(value: 3)
+
+				expect(values) == [1, 2, 3]
+			}
+
+			it("emits the latest throttled value when resumed") {
+				var values: [Int] = []
+				signal.observeValues { values.append($0) }
+
+				shouldThrottle.value = true
+				observer.send(value: 1)
+				observer.send(value: 2)
+				shouldThrottle.value = false
+
+				expect(values) == [2]
+			}
+
+			it("continues sending values after being resumed") {
+				var values: [Int] = []
+				signal.observeValues { values.append($0) }
+
+				shouldThrottle.value = true
+				observer.send(value: 1)
+				shouldThrottle.value = false
+				observer.send(value: 2)
+				observer.send(value: 3)
+
+				expect(values) == [1, 2, 3]
+			}
+		}
+
 		describe("debounce") {
 			var scheduler: TestScheduler!
 			var observer: Signal<Int, NoError>.Observer!

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -1498,6 +1498,34 @@ class SignalSpec: QuickSpec {
 				expect(values) == [1, 2, 3]
 			}
 
+			it("stays throttled if the property completes while throttled") {
+				var values: [Int] = []
+				signal.observeValues { values.append($0) }
+
+				shouldThrottle.value = false
+				observer.send(value: 1)
+				shouldThrottle.value = true
+				observer.send(value: 2)
+				shouldThrottle = nil
+				observer.send(value: 3)
+
+				expect(values) == [1]
+			}
+
+			it("stays resumed if the property completes while resumed") {
+				var values: [Int] = []
+				signal.observeValues { values.append($0) }
+
+				shouldThrottle.value = true
+				observer.send(value: 1)
+				shouldThrottle.value = false
+				observer.send(value: 2)
+				shouldThrottle = nil
+				observer.send(value: 3)
+
+				expect(values) == [1, 2, 3]
+			}
+
 			it("doesn't extend the lifetime of the throttle property") {
 				var completed = false
 				shouldThrottle.lifetime.ended.observeCompleted { completed = true }

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -1497,6 +1497,16 @@ class SignalSpec: QuickSpec {
 
 				expect(values) == [1, 2, 3]
 			}
+
+			it("doesn't extend the lifetime of the throttle property") {
+				var completed = false
+				shouldThrottle.lifetime.ended.observeCompleted { completed = true }
+
+				observer.send(value: 1)
+				shouldThrottle = nil
+
+				expect(completed) == true
+			}
 		}
 
 		describe("debounce") {


### PR DESCRIPTION
There are times where you'd like to throttle values whenever some condition is met, rather than based on a time interval.

This is inspired by ReactiveViewModel's `-throttleSignalWhileInactive:`.

Basic usage might involve a simple `MutableProperty` to toggle throttled values:

``` swift
let isActive = MutableProperty(false)

label.reactive.text <~ somethingChanged
  .throttle(while: isActive.map(!), on: QueueScheduler())
  .flatMap(.latest, transform: doSomethingExpensive)
  .observeOn(UIScheduler())

// later

isActive.value = true
```

At some point it would be great to be able to throttle events while the view has disappeared:

``` swift
somethingChanged
  .throttle(while: reactive.viewHasDisappeared, on: UIScheduler())
  .startWithValues {
    // expensive layout stuff
  }
```

I'd love some feedback on this, especially potential thread safety issues! For example, I'm a little concerned that `shouldThrottle` could technically have changed between reading `shouldThrottle.value` and starting `shouldThrottle.producer.uniqueValues { $0 }`.
