### PR TITLE
`notifications` as Signal.

### DIFF
--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -12,34 +12,23 @@ import enum Result.NoError
 extension NotificationCenter: ReactiveExtensionsProvider {}
 
 extension Reactive where Base: NotificationCenter {
-	/// Returns a SignalProducer to observe posting of the specified
-	/// notification.
+	/// Returns a Signal to observe posting of the specified notification.
 	///
 	/// - parameters:
 	///   - name: name of the notification to observe
 	///   - object: an instance which sends the notifications
 	///
-	/// - returns: A SignalProducer of notifications posted that match the given
-	///            criteria.
+	/// - returns: A Signal of notifications posted that match the given criteria.
 	///
-	/// - note: If the `object` is deallocated before starting the producer, it
-	///         will terminate immediately with an `interrupted` event.
-	///         Otherwise, the producer will not terminate naturally, so it must
-	///         be explicitly disposed to avoid leaks.
-	public func notifications(forName name: Notification.Name?, object: AnyObject? = nil) -> SignalProducer<Notification, NoError> {
-		// We're weakly capturing an optional reference here, which makes destructuring awkward.
-		let objectWasNil = (object == nil)
-		return SignalProducer { [base = self.base, weak object] observer, disposable in
-			guard object != nil || objectWasNil else {
-				observer.sendInterrupted()
-				return
-			}
-
+	/// - note: The signal does not terminate naturally. Observers must be
+	///         explicitly disposed to avoid leaks.
+	public func notifications(forName name: Notification.Name?, object: AnyObject? = nil) -> Signal<Notification, NoError> {
+		return Signal { [base = self.base] observer in
 			let notificationObserver = base.addObserver(forName: name, object: object, queue: nil) { notification in
 				observer.send(value: notification)
 			}
 
-			disposable += {
+			return ActionDisposable {
 				base.removeObserver(notificationObserver)
 			}
 		}


### PR DESCRIPTION
`Signal` starts right away, so the weak capturing of `observer` was removed.