### PR TITLE
Post-callout side effect injection.

### DIFF
--- a/Sources/EventLogger.swift
+++ b/Sources/EventLogger.swift
@@ -11,18 +11,18 @@ import Foundation
 /// A namespace for logging event types.
 public enum LoggingEvent {
 	public enum Signal: String {
-		case value, completed, failed, terminated, disposed, interrupted
+		case value, completed, failed, terminated, disposed, interrupted, valueSent
 
 		public static let allEvents: Set<Signal> = [
-			.value, .completed, .failed, .terminated, .disposed, .interrupted,
+			.value, .completed, .failed, .terminated, .disposed, .interrupted, .valueSent
 		]
 	}
 
 	public enum SignalProducer: String {
-		case starting, started, value, completed, failed, terminated, disposed, interrupted
+		case starting, started, value, completed, failed, terminated, disposed, interrupted, valueSent
 
 		public static let allEvents: Set<SignalProducer> = [
-			.starting, .started, .value, .completed, .failed, .terminated, .disposed, .interrupted,
+			.starting, .started, .value, .completed, .failed, .terminated, .disposed, .interrupted, .valueSent
 		]
 	}
 }
@@ -67,6 +67,7 @@ extension SignalProtocol {
 			interrupted: log(.interrupted),
 			terminated: log(.terminated),
 			disposed: log(.disposed),
+			valueSent: log(.valueSent),
 			value: log(.value)
 		)
 	}
@@ -102,12 +103,13 @@ extension SignalProducerProtocol {
 		return self.on(
 			starting: log(.starting),
 			started: log(.started),
-			value: log(.value),
 			failed: log(.failed),
 			completed: log(.completed),
 			interrupted: log(.interrupted),
 			terminated: log(.terminated),
-			disposed: log(.disposed)
+			disposed: log(.disposed),
+			valueSent: log(.valueSent),
+			value: log(.value)
 		)
 	}
 }

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1242,32 +1242,37 @@ extension SignalProducerProtocol {
 	/// Injects side effects to be performed upon the specified producer events.
 	///
 	/// - note: In a composed producer, `starting` is invoked in the reverse
-	///         direction of the flow of events.
+	///         direction of the flow of events. Moreover, unless otherwise
+	///         specified, all side effects are invoked before the call-out to the
+	///         observers.
 	///
 	/// - parameters:
 	///   - starting: A closure that is invoked before the producer is started.
 	///   - started: A closure that is invoked after the producer is started.
 	///   - event: A closure that accepts an event and is invoked on every
 	///            received event.
-	///   - value: A closure that accepts a value from `value` event.
 	///   - failed: A closure that accepts error object and is invoked for
 	///             `failed` event.
 	///   - completed: A closure that is invoked for `completed` event.
 	///   - interrupted: A closure that is invoked for `interrupted` event.
 	///   - terminated: A closure that is invoked for any terminating event.
 	///   - disposed: A closure added as disposable when signal completes.
+	///   - valueSent: A closure tthat is invoked after a `next` event has been
+	///                  sent to all observers.
+	///   - value: A closure that accepts a value from `value` event.
 	///
 	/// - returns: A producer with attached side-effects for given event cases.
 	public func on(
 		starting: (() -> Void)? = nil,
 		started: (() -> Void)? = nil,
 		event: ((Event<Value, Error>) -> Void)? = nil,
-		value: ((Value) -> Void)? = nil,
 		failed: ((Error) -> Void)? = nil,
 		completed: (() -> Void)? = nil,
 		interrupted: (() -> Void)? = nil,
 		terminated: (() -> Void)? = nil,
-		disposed: (() -> Void)? = nil
+		disposed: (() -> Void)? = nil,
+		valueSent: ((Value) -> Void)? = nil,
+		value: ((Value) -> Void)? = nil
 	) -> SignalProducer<Value, Error> {
 		return SignalProducer { observer, compositeDisposable in
 			starting?()
@@ -1283,6 +1288,7 @@ extension SignalProducerProtocol {
 						interrupted: interrupted,
 						terminated: terminated,
 						disposed: disposed,
+						valueSent: valueSent,
 						value: value
 					)
 					.observe(observer)

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -841,21 +841,18 @@ class SignalProducerSpec: QuickSpec {
 				var value = 0
 				var completed = 0
 				var terminated = 0
+				var valueSent = 0
+				var disposed = 0
 
 				let producer = baseProducer
-					.on(starting: {
-						starting += 1
-					}, started: {
-						started += 1
-					}, event: { e in
-						event += 1
-					}, value: { n in
-						value += 1
-					}, completed: {
-						completed += 1
-					}, terminated: {
-						terminated += 1
-					})
+					.on(starting: { starting += 1 },
+					    started: { started += 1 },
+					    event: { _ in event += 1 },
+					    completed: { completed += 1 },
+					    terminated: { terminated += 1 },
+					    disposed: { disposed += 1 },
+					    valueSent: { _ in valueSent += 1 },
+					    value: { _ in value += 1 })
 
 				producer.start()
 				expect(starting) == 1
@@ -868,11 +865,13 @@ class SignalProducerSpec: QuickSpec {
 				observer.send(value: 1)
 				expect(event) == 2
 				expect(value) == 2
+				expect(valueSent) == 2
 
 				observer.sendCompleted()
 				expect(event) == 4
 				expect(completed) == 2
 				expect(terminated) == 2
+				expect(disposed) == 2
 			}
 
 			it("should attach event handlers for disposal") {
@@ -916,6 +915,27 @@ class SignalProducerSpec: QuickSpec {
 					.start()
 
 				expect(numbers) == [3, 2, 1]
+			}
+
+			it("should invoke the `valueSent` action after the next event is posted") {
+				let (baseProducer, baseObserver) = SignalProducer<Int, NoError>.pipe()
+				var pre = [Int]()
+				var post = [Int]()
+
+				var number = 0
+
+				_ = baseProducer
+					.on(valueSent: { _ in post.append(number) },
+					    value: { _ in pre.append(number) })
+					.startWithValues { number = $0 }
+
+				baseObserver.send(value: 1)
+				expect(pre) == [0]
+				expect(post) == [1]
+
+				baseObserver.send(value: 10)
+				expect(pre) == [0, 1]
+				expect(post) == [1, 10]
 			}
 		}
 
@@ -2247,6 +2267,7 @@ class SignalProducerSpec: QuickSpec {
 						{ event in expect(event) == "[] starting" },
 						{ event in expect(event) == "[] started" },
 						{ event in expect(event) == "[] value 1" },
+						{ event in expect(event) == "[] valueSent 1" },
 						{ event in expect(event) == "[] completed" },
 						{ event in expect(event) == "[] terminated" },
 						{ event in expect(event) == "[] disposed" }

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -2220,6 +2220,7 @@ class SignalSpec: QuickSpec {
 				it("should output the correct event without identifier") {
 					let expectations: [(String) -> Void] = [
 						{ event in expect(event) == "[] value 1" },
+						{ event in expect(event) == "[] valueSent 1" },
 						{ event in expect(event) == "[] completed" },
 						{ event in expect(event) == "[] terminated" },
 						{ event in expect(event) == "[] disposed" },
@@ -2239,6 +2240,7 @@ class SignalSpec: QuickSpec {
 				it("should output the correct event with identifier") {
 					let expectations: [(String) -> Void] = [
 						{ event in expect(event) == "[test.rac] value 1" },
+						{ event in expect(event) == "[test.rac] valueSent 1" },
 						{ event in expect(event) == "[test.rac] failed error1" },
 						{ event in expect(event) == "[test.rac] terminated" },
 						{ event in expect(event) == "[test.rac] disposed" },


### PR DESCRIPTION
All events have options of pre- and post-callout injection, except for `value`. This PR adds a `valueSent` injection point to `Signal.on` and `SignalProducer.on`. It also reordered the arguments in `SignalProducer.on` to match `Signal.on`.

**Rationale**
It wasn't possible to inject a side effect **_after_** every value is consumed by a `BindingTarget`.
```
textField.stringValue <~ viewModel.name
    .on(value: { _ in print("This happens before the consumption") })

// You can wrap a binding target in a binding target though.
didSet(textField.stringValue) {
    // My "didSet" side effect.
} <~ viewModel.name
```