### PR TITLE
Created internal SignalProducer.startAndRetrieveSignal to simplify some implementations

### DIFF
--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -556,14 +556,9 @@ extension SignalProtocol {
 	public static func merge<Seq: Sequence, S: SignalProtocol>(_ signals: Seq) -> Signal<Value, Error>
 		where S.Value == Value, S.Error == Error, Seq.Iterator.Element == S
 	{
-		let producer = SignalProducer<S, Error>(values: signals)
-		var result: Signal<Value, Error>!
-
-		producer.startWithSignal { signal, _ in
-			result = signal.flatten(.merge)
-		}
-
-		return result
+		return SignalProducer<S, Error>(values: signals)
+			.flatten(.merge)
+			.startAndRetrieveSignal()
 	}
 	
 	/// Merges the given signals into a single `Signal` that will emit all

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -513,11 +513,7 @@ public final class Property<Value>: PropertyProtocol {
 		self.sources = sources
 		_value = { atomic.value! }
 		_producer = { producer }
-		_signal = {
-			var extractedSignal: Signal<Value, NoError>!
-			producer.startWithSignal { signal, _ in extractedSignal = signal }
-			return extractedSignal
-		}
+		_signal = { producer.startAndRetrieveSignal() }
 	}
 
 	deinit {

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -330,6 +330,22 @@ extension SignalProducerProtocol {
 	public func startWithInterrupted(_ interrupted: @escaping () -> Void) -> Disposable {
 		return start(Observer(interrupted: interrupted))
 	}
+	
+	/// Creates a `Signal` from the producer.
+	///
+	/// This is equivalent to `SignalProducer.startWithSignal`, but it has 
+	/// the downside that any values emitted synchronously upon starting will 
+	/// be missed by the observer, because it won't be able to subscribe in time.
+	/// That's why we don't want this method to be exposed as `public`, 
+	/// but it's useful internally.
+	internal func startAndRetrieveSignal() -> Signal<Value, Error> {
+		var result: Signal<Value, Error>!
+		self.startWithSignal { signal, _ in
+			result = signal
+		}
+		
+		return result
+	}
 }
 
 extension SignalProducerProtocol where Error == NoError {


### PR DESCRIPTION
I've noticed this pattern being used in many places (also used in https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3210), so this finally simplifies it.
Note the docstring explaining why we don't want to actually expose this, it's very important as it most certainly would be misused.