### PR TITLE
`flatten` and `flatMap` overloads for `PropertyProtocol`.

### DIFF
--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -320,6 +320,28 @@ extension SignalProducerProtocol where Value: Sequence, Error == NoError {
 	}
 }
 
+extension SignalProtocol where Value: PropertyProtocol {
+	/// Flattens the inner properties sent upon `signal` (into a single signal of
+	/// values), according to the semantics of the given strategy.
+	///
+	/// - note: If `signal` fails, the returned signal will forward that failure
+	///         immediately.
+	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Value, Error> {
+		return self.flatMap(strategy) { $0.producer }
+	}
+}
+
+extension SignalProducerProtocol where Value: PropertyProtocol {
+	/// Flattens the inner properties sent upon `signal` (into a single signal of
+	/// values), according to the semantics of the given strategy.
+	///
+	/// - note: If `signal` fails, the returned signal will forward that failure
+	///         immediately.
+	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Value, Error> {
+		return self.flatMap(strategy) { $0.producer }
+	}
+}
+
 extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Error {
 	/// Returns a signal which sends all the values from producer signal emitted
 	/// from `signal`, waiting until each inner producer completes before
@@ -754,6 +776,16 @@ extension SignalProtocol {
 	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, NoError>) -> Signal<U, Error> {
 		return map(transform).flatten(strategy)
 	}
+
+	/// Maps each event from `signal` to a new property, then flattens the
+	/// resulting properties (into a signal of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// If `signal` emits an error, the returned signal will forward that
+	/// error immediately.
+	public func flatMap<P: PropertyProtocol>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> P) -> Signal<P.Value, Error> {
+		return map(transform).flatten(strategy)
+	}
 }
 
 extension SignalProtocol where Error == NoError {
@@ -783,7 +815,7 @@ extension SignalProtocol where Error == NoError {
 	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, E>) -> Signal<U, E> {
 		return map(transform).flatten(strategy)
 	}
-	
+
 	/// Maps each event from `signal` to a new signal, then flattens the
 	/// resulting signals (into a signal of values), according to the
 	/// semantics of the given strategy.
@@ -830,6 +862,16 @@ extension SignalProducerProtocol {
 	/// If `self` emits an error, the returned producer will forward that
 	/// error immediately.
 	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, NoError>) -> SignalProducer<U, Error> {
+		return map(transform).flatten(strategy)
+	}
+
+	/// Maps each event from `self` to a new property, then flattens the
+	/// resulting properties (into a producer of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// If `self` emits an error, the returned producer will forward that
+	/// error immediately.
+	public func flatMap<P: PropertyProtocol>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> P) -> SignalProducer<P.Value, Error> {
 		return map(transform).flatten(strategy)
 	}
 }

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -269,6 +269,16 @@ class FlattenSpec: QuickSpec {
 				innerObserver.send(value: sequence)
 				expect(observedValues) == sequence
 			}
+
+			it("works with Property and any arbitrary error") {
+				_ = Signal<Property<Int>, TestError>.empty
+					.flatten(.latest)
+			}
+
+			it("works with Property and NoError") {
+				_ = Signal<Property<Int>, NoError>.empty
+					.flatten(.latest)
+			}
 		}
 		
 		describe("SignalProducer.flatten()") {
@@ -443,6 +453,16 @@ class FlattenSpec: QuickSpec {
 				
 				expect(observedValues) == sequence
 			}
+
+			it("works with Property and any arbitrary error") {
+				_ = SignalProducer<Property<Int>, TestError>.empty
+					.flatten(.latest)
+			}
+
+			it("works with Property and NoError") {
+				_ = SignalProducer<Property<Int>, NoError>.empty
+					.flatten(.latest)
+			}
 		}
 		
 		describe("Signal.flatMap()") {
@@ -603,6 +623,16 @@ class FlattenSpec: QuickSpec {
 				innerObserver.send(value: 4)
 				expect(observed) == 4
 			}
+
+			it("works with Property and any arbitrary error") {
+				_ = Signal<Int, TestError>.empty
+					.flatMap(.latest) { _ in Property(value: 0) }
+			}
+
+			it("works with Property and NoError") {
+				_ = Signal<Int, NoError>.empty
+					.flatMap(.latest) { _ in Property(value: 0) }
+			}
 		}
 		
 		describe("SignalProducer.flatMap()") {
@@ -762,6 +792,16 @@ class FlattenSpec: QuickSpec {
 				outerObserver.send(value: 4)
 				innerObserver.send(value: 4)
 				expect(observed) == 4
+			}
+
+			it("works with Property and any arbitrary error") {
+				_ = SignalProducer<Int, TestError>.empty
+					.flatMap(.latest) { _ in Property(value: 0) }
+			}
+
+			it("works with Property and NoError") {
+				_ = SignalProducer<Int, NoError>.empty
+					.flatMap(.latest) { _ in Property(value: 0) }
 			}
 		}
 		


### PR DESCRIPTION
The new overloads flatten `Signal[Producer]<P, Error> where P: PropertyProtocol` into `Signal[Producer]<P.Value, Error>`.