### PR TITLE
Allow reactive extensions to provide static members

### DIFF
--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		02D2602A1C1D6DAF003ACC61 /* SignalLifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */; };
 		02D2602B1C1D6DB8003ACC61 /* SignalLifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */; };
+		4A0AB6721DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0AB6711DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift */; };
+		4A0AB6731DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0AB6711DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift */; };
+		4A0AB6741DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0AB6711DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift */; };
 		4A0E10FF1D2A92720065D310 /* Lifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E10FE1D2A92720065D310 /* Lifetime.swift */; };
 		4A0E11001D2A92720065D310 /* Lifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E10FE1D2A92720065D310 /* Lifetime.swift */; };
 		4A0E11011D2A92720065D310 /* Lifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E10FE1D2A92720065D310 /* Lifetime.swift */; };
@@ -219,6 +222,7 @@
 
 /* Begin PBXFileReference section */
 		02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalLifetimeSpec.swift; sourceTree = "<group>"; };
+		4A0AB6711DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveExtensionsSpec.swift; sourceTree = "<group>"; };
 		4A0E10FE1D2A92720065D310 /* Lifetime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lifetime.swift; sourceTree = "<group>"; };
 		4A0E11031D2A95200065D310 /* LifetimeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifetimeSpec.swift; sourceTree = "<group>"; };
 		57A4D2411BA13D7A00F7D4B1 /* ReactiveSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -482,7 +486,7 @@
 				D8170FC01B100EBC004192AD /* FoundationExtensionsSpec.swift */,
 				4A0E11031D2A95200065D310 /* LifetimeSpec.swift */,
 				D0A2260D1A72F16D00D33B74 /* PropertySpec.swift */,
-				9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */,
+				4A0AB6711DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift */,
 				D0C312F219EF2A7700984962 /* SchedulerSpec.swift */,
 				02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */,
 				D8024DB11B2E1BB0005E6B9A /* SignalProducerLiftingSpec.swift */,
@@ -490,6 +494,7 @@
 				D0A226071A72E0E900D33B74 /* SignalSpec.swift */,
 				B696FB801A7640C00075236D /* TestError.swift */,
 				C79B64731CD38B2B003F2376 /* TestLogger.swift */,
+				9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */,
 				D04725FA19E49ED7006002AA /* Supporting Files */,
 			);
 			name = ReactiveSwiftTests;
@@ -903,6 +908,7 @@
 				9A1D067F1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */,
 				4A0E11061D2A95200065D310 /* LifetimeSpec.swift in Sources */,
 				7DFBED6D1CDB8F7D00EE435B /* SignalProducerNimbleMatchers.swift in Sources */,
+				4A0AB6741DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -979,6 +985,7 @@
 				9A1D067D1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */,
 				D0A2260B1A72E6C500D33B74 /* SignalProducerSpec.swift in Sources */,
 				D8024DB21B2E1BB0005E6B9A /* SignalProducerLiftingSpec.swift in Sources */,
+				4A0AB6721DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1029,6 +1036,7 @@
 				9A1D067E1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */,
 				4A0E11051D2A95200065D310 /* LifetimeSpec.swift in Sources */,
 				02D2602A1C1D6DAF003ACC61 /* SignalLifetimeSpec.swift in Sources */,
+				4A0AB6731DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Reactive.swift
+++ b/Sources/Reactive.swift
@@ -11,6 +11,11 @@ extension ReactiveExtensionsProvider {
 	public var reactive: Reactive<Self> {
 		return Reactive(self)
 	}
+
+	/// A proxy which hosts static reactive extensions for the type of `self`.
+	public static var reactive: Reactive<Self>.Type {
+		return Reactive<Self>.self
+	}
 }
 
 // A `Reactive` proxy hosts reactive extensions to `Base`.

--- a/Tests/ReactiveSwiftTests/ReactiveExtensionsSpec.swift
+++ b/Tests/ReactiveSwiftTests/ReactiveExtensionsSpec.swift
@@ -1,0 +1,33 @@
+import Nimble
+import Quick
+import ReactiveSwift
+import Result
+
+private final class TestExtensionProvider: ReactiveExtensionsProvider {
+	let instanceProperty = "instance"
+	static let staticProperty = "static"
+}
+
+extension Reactive where Base: TestExtensionProvider {
+	var instanceProperty: SignalProducer<String, NoError> {
+		return SignalProducer(value: base.instanceProperty)
+	}
+
+	static var staticProperty: SignalProducer<String, NoError> {
+		return SignalProducer(value: Base.staticProperty)
+	}
+}
+
+final class ReactiveExtensionsSpec: QuickSpec {
+	override func spec() {
+		describe("ReactiveExtensions") {
+			it("allows reactive extensions of instances") {
+				expect(TestExtensionProvider().reactive.instanceProperty.first()?.value) == "instance"
+			}
+
+			it("allows reactive extensions of types") {
+				expect(TestExtensionProvider.reactive.staticProperty.first()?.value) == "static"
+			}
+		}
+	}
+}


### PR DESCRIPTION
It's useful to be able to attach reactive extensions to types, not just instances. This adds support for static members in Reactive extensions, adding a static `reactive` property to types conforming to `ReactiveExtensionsProvider`.