### PR TITLE
Export Result as part of ReactiveSwift's public API

### DIFF
--- a/ReactiveSwift.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
@@ -12,9 +12,7 @@
  1. Choose `View > Show Debug Area`
  */
 
-import Result
 import ReactiveSwift
-import Foundation
 
 /*:
  ## Sandbox

--- a/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
@@ -12,9 +12,7 @@
 1. Choose `View > Show Debug Area`
 */
 
-import Result
 import ReactiveSwift
-import Foundation
 
 /*:
 ## Signal

--- a/Sources/ReactiveSwift.h
+++ b/Sources/ReactiveSwift.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <Result/Result.h>
 
 //! Project version number for ReactiveSwift.
 FOUNDATION_EXPORT double ReactiveSwiftVersionNumber;

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -6,9 +6,6 @@
 //  Copyright (c) 2014 GitHub. All rights reserved.
 //
 
-import Foundation
-
-import Result
 import Nimble
 import Quick
 import ReactiveSwift

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2016 GitHub. All rights reserved.
 //
 
-import Result
 import Nimble
 import Quick
 import ReactiveSwift

--- a/Tests/ReactiveSwiftTests/FoundationExtensionsSpec.swift
+++ b/Tests/ReactiveSwiftTests/FoundationExtensionsSpec.swift
@@ -6,9 +6,6 @@
 //  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
-import Foundation
-
-import Result
 import Nimble
 import Quick
 import ReactiveSwift

--- a/Tests/ReactiveSwiftTests/LifetimeSpec.swift
+++ b/Tests/ReactiveSwiftTests/LifetimeSpec.swift
@@ -1,7 +1,6 @@
 import Quick
 import Nimble
 import ReactiveSwift
-import Result
 
 final class LifetimeSpec: QuickSpec {
 	override func spec() {

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -6,9 +6,6 @@
 //  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
-import Foundation
-
-import Result
 import Nimble
 import Quick
 @testable import ReactiveSwift

--- a/Tests/ReactiveSwiftTests/ReactiveExtensionsSpec.swift
+++ b/Tests/ReactiveSwiftTests/ReactiveExtensionsSpec.swift
@@ -1,7 +1,6 @@
 import Nimble
 import Quick
 import ReactiveSwift
-import Result
 
 private final class TestExtensionProvider: ReactiveExtensionsProvider {
 	let instanceProperty = "instance"

--- a/Tests/ReactiveSwiftTests/SignalLifetimeSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalLifetimeSpec.swift
@@ -6,9 +6,6 @@
 //  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
-import Foundation
-
-import Result
 import Nimble
 import Quick
 import ReactiveSwift

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -6,9 +6,6 @@
 //  Copyright © 2015 GitHub. All rights reserved.
 //
 
-import Foundation
-
-import Result
 import Nimble
 import Quick
 import ReactiveSwift

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -6,10 +6,6 @@
 //  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
-import Dispatch
-import Foundation
-
-import Result
 import Nimble
 import Quick
 import ReactiveSwift

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -6,9 +6,6 @@
 //  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
-import Foundation
-
-import Result
 import Nimble
 import Quick
 import ReactiveSwift

--- a/Tests/ReactiveSwiftTests/TestError.swift
+++ b/Tests/ReactiveSwiftTests/TestError.swift
@@ -7,7 +7,6 @@
 //
 
 import ReactiveSwift
-import Result
 
 internal enum TestError: Int {
 	case `default` = 0

--- a/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
+++ b/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
@@ -1,6 +1,3 @@
-import Dispatch
-
-import Result
 import Nimble
 import Quick
 @testable import ReactiveSwift


### PR DESCRIPTION
Makes working with Result-based APIs much simpler by avoiding the need to manually import Result when using ReactiveSwift.

Note: This only works on Apple platforms.
