### PR TITLE
Added `--no-use-binaries` flag 

### DIFF
--- a/ReactiveSwift.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
@@ -4,7 +4,7 @@
  1. Retrieve the project dependencies using one of the following terminal commands from the ReactiveSwift project root directory:
  - `script/bootstrap`
  **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
- - `carthage checkout`
+ - `carthage checkout --no-use-binaries`
  1. Open `ReactiveSwift.xcworkspace`
  1. Build `Result-Mac` scheme
  1. Build `ReactiveSwift-macOS` scheme


### PR DESCRIPTION
Added `--no-use-binaries` flag to playground setup through Carthage documentation as without it Carthage installs Result binary instead of checking out the sources. In such case Result build scheme is not defined and cannot be built. 