### PR TITLE
Remove references to 'script/bootstrap' from playground documentation

### DIFF
--- a/ReactiveSwift.playground/Pages/Property.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Property.xcplaygroundpage/Contents.swift
@@ -2,7 +2,7 @@
  > # IMPORTANT: To use `ReactiveSwift.playground`, please:
  
  1. Retrieve the project dependencies using one of the following terminal commands from the ReactiveSwift project root directory:
-    - `script/bootstrap`
+    - `git submodule update --init`
  **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
     - `carthage checkout`
  1. Open `ReactiveSwift.xcworkspace`

--- a/ReactiveSwift.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
@@ -2,9 +2,9 @@
  > # IMPORTANT: To use `ReactiveSwift.playground`, please:
  
  1. Retrieve the project dependencies using one of the following terminal commands from the ReactiveSwift project root directory:
- - `script/bootstrap`
+    - `git submodule update --init`
  **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
- - `carthage checkout --no-use-binaries`
+    - `carthage checkout --no-use-binaries`
  1. Open `ReactiveSwift.xcworkspace`
  1. Build `Result-Mac` scheme
  1. Build `ReactiveSwift-macOS` scheme

--- a/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
@@ -2,8 +2,8 @@
 > # IMPORTANT: To use `ReactiveSwift.playground`, please:
 
 1. Retrieve the project dependencies using one of the following terminal commands from the ReactiveSwift project root directory:
-    - `script/bootstrap`
-**OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
+    - `git submodule update --init`
+ **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
     - `carthage checkout`
 1. Open `ReactiveSwift.xcworkspace`
 1. Build `Result-Mac` scheme

--- a/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -2,7 +2,7 @@
 > # IMPORTANT: To use `ReactiveSwift.playground`, please:
 
 1. Retrieve the project dependencies using one of the following terminal commands from the ReactiveSwift project root directory:
-    - `script/bootstrap`
+    - `git submodule update --init`
  **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
     - `carthage checkout`
 1. Open `ReactiveSwift.xcworkspace`


### PR DESCRIPTION
Noticed this when reviewing #75.

This was removed in commit 923f07b1cd19bbf632f9fc9a9f078958168efe88.  It's referenced in the playground setup documentation and is useful, so restoring it.