### PR TITLE
Fixed a bug in `on` which caused the signal to be disposed of too early.

### DIFF
--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1291,7 +1291,7 @@ extension SignalProducerProtocol {
 
 			self.startWithSignal { signal, disposable in
 				compositeDisposable += disposable
-				compositeDisposable += signal
+				signal
 					.on(
 						event: event,
 						failed: failed,

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -1419,6 +1419,8 @@ class SignalProducerSpec: QuickSpec {
 				var execute: ((FlattenStrategy) -> Void)!
 
 				var innerDisposable = SimpleDisposable()
+				var isInnerInterrupted = false
+				var isInnerDisposed = false
 				var interrupted = false
 
 				beforeEach {
@@ -1426,7 +1428,10 @@ class SignalProducerSpec: QuickSpec {
 						let (outerProducer, outerObserver) = SignalProducer<SignalProducer<Int, NoError>, NoError>.pipe()
 
 						innerDisposable = SimpleDisposable()
+						isInnerInterrupted = false
+						isInnerDisposed = false
 						let innerProducer = SignalProducer<Int, NoError> { $1.add(innerDisposable) }
+							.on(interrupted: { isInnerInterrupted = true }, disposed: { isInnerDisposed = true })
 						
 						interrupted = false
 						let outerDisposable = outerProducer.flatten(strategy).startWithInterrupted {
@@ -1446,10 +1451,15 @@ class SignalProducerSpec: QuickSpec {
 
 						expect(innerDisposable.isDisposed) == false
 						expect(interrupted) == false
+						expect(isInnerInterrupted) == false
+						expect(isInnerDisposed) == false
+
 						disposeOuter()
 
 						expect(innerDisposable.isDisposed) == true
 						expect(interrupted) == true
+						expect(isInnerInterrupted) == true
+						expect(isInnerDisposed) == true
 					}
 
 					it("should cancel inner work when disposed after the outer producer completes") {
@@ -1459,10 +1469,15 @@ class SignalProducerSpec: QuickSpec {
 
 						expect(innerDisposable.isDisposed) == false
 						expect(interrupted) == false
+						expect(isInnerInterrupted) == false
+						expect(isInnerDisposed) == false
+
 						disposeOuter()
 
 						expect(innerDisposable.isDisposed) == true
 						expect(interrupted) == true
+						expect(isInnerInterrupted) == true
+						expect(isInnerDisposed) == true
 					}
 				}
 
@@ -1472,10 +1487,15 @@ class SignalProducerSpec: QuickSpec {
 
 						expect(innerDisposable.isDisposed) == false
 						expect(interrupted) == false
+						expect(isInnerInterrupted) == false
+						expect(isInnerDisposed) == false
+
 						disposeOuter()
 
 						expect(innerDisposable.isDisposed) == true
 						expect(interrupted) == true
+						expect(isInnerInterrupted) == true
+						expect(isInnerDisposed) == true
 					}
 
 					it("should cancel inner work when disposed after the outer producer completes") {
@@ -1485,10 +1505,15 @@ class SignalProducerSpec: QuickSpec {
 
 						expect(innerDisposable.isDisposed) == false
 						expect(interrupted) == false
+						expect(isInnerInterrupted) == false
+						expect(isInnerDisposed) == false
+
 						disposeOuter()
 
 						expect(innerDisposable.isDisposed) == true
 						expect(interrupted) == true
+						expect(isInnerInterrupted) == true
+						expect(isInnerDisposed) == true
 					}
 				}
 
@@ -1498,10 +1523,16 @@ class SignalProducerSpec: QuickSpec {
 
 						expect(innerDisposable.isDisposed) == false
 						expect(interrupted) == false
+						expect(isInnerInterrupted) == false
+						expect(isInnerDisposed) == false
+
 						disposeOuter()
 
 						expect(innerDisposable.isDisposed) == true
 						expect(interrupted) == true
+						expect(isInnerInterrupted) == true
+						expect(isInnerDisposed) == true
+
 					}
 
 					it("should cancel inner work when disposed after the outer producer completes") {
@@ -1511,10 +1542,15 @@ class SignalProducerSpec: QuickSpec {
 
 						expect(innerDisposable.isDisposed) == false
 						expect(interrupted) == false
+						expect(isInnerInterrupted) == false
+						expect(isInnerDisposed) == false
+
 						disposeOuter()
 
 						expect(innerDisposable.isDisposed) == true
 						expect(interrupted) == true
+						expect(isInnerInterrupted) == true
+						expect(isInnerDisposed) == true
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #77.

#### The root cause

```
 		return SignalProducer { observer, compositeDisposable in
  			// ...
  			self.startWithSignal { signal, disposable in
  				compositeDisposable += disposable
 				compositeDisposable += signal.on(...).observe(observer)
```
The outer input observer was detached by the outer interruption, and this causes the started signal to dispose of itself (no observer + unreachable) under the new lifetime semantics. 

Moreover, since `CompositeDisposable` disposes its inner disposables in the reversed insertion order, the inner producer is interrupted after the said detachment and self-disposal happened.

So in the end, both together caused the injected side effect via `on` capturing no interrupted event. 

#### The fix

Generally speaking, the disposable of the outer observer to the produced inner signal should not be added to the outer producer's disposable. The termination is already propagated via `interrupted`. 

#### Note 
We might need to review the rest of the operators.