### PR TITLE
Add Event.isCompleted and Action.completed

### DIFF
--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -40,6 +40,12 @@ public final class Action<Input, Output, Error: Swift.Error> {
 	/// A signal which is triggered by `ActionError.disabled`.
 	public let disabledErrors: Signal<(), NoError>
 
+	/// A signal of all completed events generated from applications of the action.
+	///
+	/// In other words, this will send completed events from every signal generated
+	/// by each SignalProducer returned from apply().
+	public let completed: Signal<(), NoError>
+
 	/// Whether the action is currently executing.
 	public let isExecuting: Property<Bool>
 
@@ -86,6 +92,7 @@ public final class Action<Input, Output, Error: Swift.Error> {
 
 		values = events.map { $0.value }.skipNil()
 		errors = events.map { $0.error }.skipNil()
+		completed = events.filter { $0.isCompleted }.map { _ in }
 
 		isEnabled = Property(_isEnabled)
 		isExecuting = Property(_isExecuting)

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -28,6 +28,17 @@ public enum Event<Value, Error: Swift.Error> {
 	///              completion of the signal.
 	case interrupted
 
+	/// Whether this event is a completed event.
+	public var isCompleted: Bool {
+		switch self {
+		case .completed:
+			return true
+
+		case .value, .failed, .interrupted:
+			return false
+		}
+	}
+
 	/// Whether this event indicates signal termination (i.e., that no further
 	/// events will be received).
 	public var isTerminating: Bool {


### PR DESCRIPTION
Adds a simple way to check if an event is a completed event, and to observe whenever an Action successfully completes.

One place I've used this is in error handling:

- Observe Action.errors and map over it to generate an error message for the UI.
- Observe Action.completed to clear the error message (it's useful to keep it around to provide the user context).