### PR TITLE
[SwiftPM] Remove test dependencies from `Package.swift`

### DIFF
--- a/.Package.test.swift
+++ b/.Package.test.swift
@@ -4,6 +4,8 @@ let package = Package(
     name: "ReactiveSwift",
     dependencies: [
         .Package(url: "https://github.com/antitypical/Result.git", majorVersion: 3, minor: 0),
+        .Package(url: "https://github.com/Quick/Nimble", majorVersion: 5, minor: 0),
+        .Package(url: "https://github.com/Quick/Quick", majorVersion: 0, minor: 10),
     ],
     exclude: [
         "Sources/Deprecations+Removals.swift",

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ matrix:
       before_install:
         - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
       script:
+        - mv .Package.test.swift Package.swift
         # https://github.com/Quick/Nimble/pull/342 is needed.
         - swift package update
         - cd Packages/Nimble-*


### PR DESCRIPTION
We still run `swift test` on CI using separated `.Package.test.swift`.

This is the same as https://github.com/Carthage/Commandant/pull/83.