### PR TITLE
SignalProducer.on: restore `value` as the last parameter

### DIFF
--- a/Sources/EventLogger.swift
+++ b/Sources/EventLogger.swift
@@ -102,12 +102,12 @@ extension SignalProducerProtocol {
 		return self.on(
 			starting: log(.starting),
 			started: log(.started),
-			value: log(.value),
 			failed: log(.failed),
 			completed: log(.completed),
 			interrupted: log(.interrupted),
 			terminated: log(.terminated),
-			disposed: log(.disposed)
+			disposed: log(.disposed),
+			value: log(.value)
 		)
 	}
 }

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -815,13 +815,13 @@ extension SignalProtocol {
 	/// - parameters:
 	///   - event: A closure that accepts an event and is invoked on every
 	///            received event.
-	///   - value: A closure that accepts a value from `value` event.
 	///   - failed: A closure that accepts error object and is invoked for
 	///             failed event.
 	///   - completed: A closure that is invoked for `completed` event.
 	///   - interrupted: A closure that is invoked for `interrupted` event.
 	///   - terminated: A closure that is invoked for any terminating event.
 	///   - disposed: A closure added as disposable when signal completes.
+	///   - value: A closure that accepts a value from `value` event.
 	///
 	/// - returns: A signal with attached side-effects for given event cases.
 	public func on(

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1265,25 +1265,25 @@ extension SignalProducerProtocol {
 	///   - started: A closure that is invoked after the producer is started.
 	///   - event: A closure that accepts an event and is invoked on every
 	///            received event.
-	///   - value: A closure that accepts a value from `value` event.
 	///   - failed: A closure that accepts error object and is invoked for
 	///             `failed` event.
 	///   - completed: A closure that is invoked for `completed` event.
 	///   - interrupted: A closure that is invoked for `interrupted` event.
 	///   - terminated: A closure that is invoked for any terminating event.
 	///   - disposed: A closure added as disposable when signal completes.
+	///   - value: A closure that accepts a value from `value` event.
 	///
 	/// - returns: A producer with attached side-effects for given event cases.
 	public func on(
 		starting: (() -> Void)? = nil,
 		started: (() -> Void)? = nil,
 		event: ((Event<Value, Error>) -> Void)? = nil,
-		value: ((Value) -> Void)? = nil,
 		failed: ((Error) -> Void)? = nil,
 		completed: (() -> Void)? = nil,
 		interrupted: (() -> Void)? = nil,
 		terminated: (() -> Void)? = nil,
-		disposed: (() -> Void)? = nil
+		disposed: (() -> Void)? = nil,
+		value: ((Value) -> Void)? = nil
 	) -> SignalProducer<Value, Error> {
 		return SignalProducer { observer, compositeDisposable in
 			starting?()

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -849,12 +849,12 @@ class SignalProducerSpec: QuickSpec {
 						started += 1
 					}, event: { e in
 						event += 1
-					}, value: { n in
-						value += 1
 					}, completed: {
 						completed += 1
 					}, terminated: {
 						terminated += 1
+					}, value: { n in
+						value += 1
 					})
 
 				producer.start()


### PR DESCRIPTION
Conceptually, `value` should be defined before `failed` since that goes in line with the natural order of events, however [this reordering](https://github.com/ReactiveCocoa/ReactiveCocoa/commit/85e2359d931c978b751940e066bcd95f0b215dd6) can introduce some confusion/inconvenience while using trailing closures specially during the migration from ReactiveCocoa 4.x where `value`, formerly known as `next`, was the last parameter and now represents `disposed`.

This can silently introduce some problems after migration if a project is using `.on` with a trailing closure to inject side-effects on values without being interested in the value itself.

```swift
producer.on { _ in 
    // Inject side-effect, e.g. invalidate context
}
```

## ⚠️ Note ⚠️
If we do not go forward with this we need to fix an inconsistency between `SignalProducer` and `Signal` where the former was not updated accordingly.