### PR TITLE
Lock-free disposal.

### DIFF
--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -24,7 +24,7 @@ internal protocol AtomicStateProtocol {
 	///
 	/// - returns:
 	///   `true` if the transition succeeds. `false` otherwise.
-	mutating func tryTransiting(from expected: State, to next: State) -> Bool
+	func tryTransiting(from expected: State, to next: State) -> Bool
 }
 
 /// A simple, generic lock-free finite state machine.

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -7,6 +7,123 @@
 //
 
 import Foundation
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+import MachO
+#endif
+
+/// Represents a finite state machine that can transit from one state to
+/// another.
+internal protocol AtomicStateProtocol {
+	associatedtype State: RawRepresentable
+
+	/// Try to transit from the expected current state to the specified next
+	/// state.
+	///
+	/// - parameters:
+	///   - expected: The expected state.
+	///
+	/// - returns:
+	///   `true` if the transition succeeds. `false` otherwise.
+	mutating func tryTransiting(from expected: State, to next: State) -> Bool
+}
+
+/// A simple, generic lock-free finite state machine.
+///
+/// - warning: `deinitialize` must be called to dispose of the consumed memory.
+internal struct UnsafeAtomicState<State: RawRepresentable>: AtomicStateProtocol where State.RawValue == Int32 {
+	internal typealias Transition = (expected: State, next: State)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+	private let value: UnsafeMutablePointer<Int32>
+
+	/// Create a finite state machine with the specified initial state.
+	///
+	/// - parameters:
+	///   - initial: The desired initial state.
+	internal init(_ initial: State) {
+		value = UnsafeMutablePointer<Int32>.allocate(capacity: 1)
+		value.initialize(to: initial.rawValue)
+	}
+
+	/// Deinitialize the finite state machine.
+	internal func deinitialize() {
+		value.deinitialize()
+		value.deallocate(capacity: 1)
+	}
+
+	/// Compare the current state with the specified state.
+	///
+	/// - parameters:
+	///   - expected: The expected state.
+	///
+	/// - returns:
+	///   `true` if the current state matches the expected state. `false`
+	///   otherwise.
+	@inline(__always)
+	internal func `is`(_ expected: State) -> Bool {
+		return OSAtomicCompareAndSwap32Barrier(expected.rawValue,
+		                                       expected.rawValue,
+		                                       value)
+	}
+
+	/// Try to transit from the expected current state to the specified next
+	/// state.
+	///
+	/// - parameters:
+	///   - expected: The expected state.
+	///
+	/// - returns:
+	///   `true` if the transition succeeds. `false` otherwise.
+	@inline(__always)
+	internal func tryTransiting(from expected: State, to next: State) -> Bool {
+		return OSAtomicCompareAndSwap32Barrier(expected.rawValue,
+		                                       next.rawValue,
+		                                       value)
+	}
+#else
+	private let value: Atomic<Int32>
+
+	/// Create a finite state machine with the specified initial state.
+	///
+	/// - parameters:
+	///   - initial: The desired initial state.
+	internal init(_ initial: State) {
+		value = Atomic(initial.rawValue)
+	}
+
+	/// Deinitialize the finite state machine.
+	internal func deinitialize() {}
+
+	/// Compare the current state with the specified state.
+	///
+	/// - parameters:
+	///   - expected: The expected state.
+	///
+	/// - returns:
+	///   `true` if the current state matches the expected state. `false`
+	///   otherwise.
+	internal func `is`(_ expected: State) -> Bool {
+		return value.modify { $0 == expected.rawValue }
+	}
+
+	/// Try to transit from the expected current state to the specified next
+	/// state.
+	///
+	/// - parameters:
+	///   - expected: The expected state.
+	///
+	/// - returns:
+	///   `true` if the transition succeeds. `false` otherwise.
+	internal func tryTransiting(from expected: State, to next: State) -> Bool {
+		return value.modify { value in
+			if value == expected.rawValue {
+				value = next.rawValue
+				return true
+			}
+			return false
+		}
+	}
+#endif
+}
 
 final class PosixThreadMutex: NSLocking {
 	private var mutex = pthread_mutex_t()

--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -189,7 +189,7 @@ public final class CompositeDisposable: Disposable {
 	public func dispose() {
 		if state.tryDispose() {
 			if let ds = disposables.swap(nil) {
-				for d in ds.reversed() {
+				for d in ds {
 					d.dispose()
 				}
 			}

--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -34,7 +34,7 @@ extension AtomicStateProtocol where State == DisposableState {
 	/// - returns:
 	///   `true` if the transition succeeds. `false` otherwise.
 	@inline(__always)
-	fileprivate mutating func tryDispose() -> Bool {
+	fileprivate func tryDispose() -> Bool {
 		return tryTransiting(from: .active, to: .disposed)
 	}
 }


### PR DESCRIPTION
`Disposable` is crucial part of the signal resource management, especially in transformed signals and `SignalProducer`s.

Previous attempt: https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2463

~~This PR focuses on just `Disposable`. All disposables have a `DisposableState`, which exposes accessors built on top of OSAtomic primitives. `DisposableState` is made a `struct` so that the state is embedded into the containing class without extra indirection.~~

This PR introduces a lock-free primitive `UnsafeAtomicState`, and refactored all disposable types to use it. Note that the primitive is marked with `Unsafe` as it requires manual memory management.

Note that while `CompositeDisposable` and `SerialDisposable` still use `Atomic` for storing their children, they may still benefit from the fast atomic boolean checks.

The result is pretty impressive. For 1000000 iterations of `disposable.dispose()` (just a CAS) with whole module optimization, lock-free `SimpleDisposable` completed in just 0.011 seconds (12% SD), while `Atomic<Bool>` took 0.233 sec (4% SD).

Less joules. 😸 

--

~~This includes also a 1.5-2x faster `Bag.forEach` overload under `-Owholemodule` and `-Ounchecked`.~~