### PR TITLE
Mitigate race conditions in the interruption handling.

### DIFF
--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -269,7 +269,13 @@ private struct InterruptingState {
 	///         `!isIdle`.
 	var isInterrupted: Bool {
 		mutating get {
-			return state.swap(.finalized) == .interrupted
+			return state.modify { state in
+				if state == .interrupted {
+					state = .finalized
+					return true
+				}
+				return false
+			}
 		}
 	}
 


### PR DESCRIPTION
It seems there is a race condition in the signal interruption handling that would result in the interruption being indefinitely delayed until the next event arrives. Though the possibility is very likely razor thin, since the contention window is between the unlock of `interrupted` and that of `sendLock`.

In the Design Guidelines: [Interruption cancels outstanding work and usually propagates immediately](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Documentation/DesignGuidelines.md#interruption-cancels-outstanding-work-and-usually-propagates-immediately)
```
// Race condition if we perform the interruption check within the
// protected section, specifically:
//
// 1. The `interrupted` event sets the atomic flag to true, but after
//    the send lock owner has checked the atomic flag.
//
// 2. The `interrupted` event proceeds to try to lock the `sendLock`,
//    but failed since the lock has not yet been released.
//
// 3. The `sendLock` is released. But since the `interrupted` event
//    does no attempt to retry, the interruption would be indefinitely
//    delayed until the next event arrives.
```

The original design might also let events slip through after the `interrupted` event, which violates the Signal contract.

In the Design Guidelines: [After a terminating event, no other events will be received.](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Documentation/DesignGuidelines.md#the-event-contract)

```swift
// Closure, Signal.init, Signal.swift

// (1) Multiple senders could have grabbed a copy of the state before `interrupted`
//     turns `true` and eventually have the state cleared.
if let state = (event.isTerminating ? signal.state.swap(nil) : signal.state.value) {
	sendLock.lock()

	// (2) Since there is no extra check in place, the observers here could have
	//     already received `interrupted` sent by a previous sender.
	for observer in state.observers {
		observer.action(event)
	}

	let shouldInterrupt = !event.isTerminating && interrupted.value
	if shouldInterrupt {
		interrupt()
	}
```

The PR attempts to address these with a new threading design that builds around a ternary, lock-free `InterruptingState`. The three key guarantees of the design are:

1. After the interruption is started, if there is any pending sender, the first event that queries the `InterruptingState.isInterrupted` is obligated to send an `interrupted` event. The rest of the senders would observe `false` for the said property, and hence be dropped.

2. No observer can be attached after the interruption has started.

3. If the interruption has started, the signal must be interrupted after zero to two* pending events are emitted.

_* not entirely correlated to the number of pending senders, but the runtime memory order._

---

Evaluation of Lock-free vs `Atomic`: Please check #107.