### PR TITLE
Minor refactoring in `Signal`.

### DIFF
--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -8,10 +8,10 @@
 
 import Foundation
 
-final class PosixThreadMutex: NSLocking {
+internal final class PosixThreadMutex: NSLocking {
 	private var mutex = pthread_mutex_t()
 
-	init() {
+	internal init() {
 		let result = pthread_mutex_init(&mutex, nil)
 		precondition(result == 0, "Failed to initialize mutex with error \(result).")
 	}
@@ -21,12 +21,16 @@ final class PosixThreadMutex: NSLocking {
 		precondition(result == 0, "Failed to destroy mutex with error \(result).")
 	}
 
-	func lock() {
+	internal func `try`() -> Bool {
+		return pthread_mutex_trylock(&mutex) == 0
+	}
+
+	internal func lock() {
 		let result = pthread_mutex_lock(&mutex)
 		precondition(result == 0, "Failed to lock \(self) with error \(result).")
 	}
 
-	func unlock() {
+	internal func unlock() {
 		let result = pthread_mutex_unlock(&mutex)
 		precondition(result == 0, "Failed to unlock \(self) with error \(result).")
 	}

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -160,7 +160,9 @@ public final class Signal<Value, Error: Swift.Error> {
 	public func observe(_ observer: Observer) -> Disposable? {
 		var token: RemovalToken?
 		observers.modify { observers in
-			reference = self
+			if observers != nil {
+				reference = self
+			}
 			token = observers?.insert(observer)
 		}
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -41,8 +41,7 @@ public final class Signal<Value, Error: Swift.Error> {
 		state = Atomic(SignalState())
 
 		/// Used to ensure that events are serialized during delivery to observers.
-		let sendLock = NSLock()
-		sendLock.name = "org.reactivecocoa.ReactiveSwift.Signal"
+		let sendLock = PosixThreadMutex()
 
 		/// When set to `true`, the Signal should interrupt as soon as possible.
 		let interrupted = Atomic(false)
@@ -624,7 +623,7 @@ private final class CombineLatestState<Value> {
 }
 
 extension SignalProtocol {
-	private func observeWithStates<U>(_ signalState: CombineLatestState<Value>, _ otherState: CombineLatestState<U>, _ lock: NSLock, _ observer: Signal<(), Error>.Observer) -> Disposable? {
+	private func observeWithStates<U>(_ signalState: CombineLatestState<Value>, _ otherState: CombineLatestState<U>, _ lock: PosixThreadMutex, _ observer: Signal<(), Error>.Observer) -> Disposable? {
 		return self.observe { event in
 			switch event {
 			case let .value(value):
@@ -672,8 +671,7 @@ extension SignalProtocol {
 	///            and given signal.
 	public func combineLatest<U>(with other: Signal<U, Error>) -> Signal<(Value, U), Error> {
 		return Signal { observer in
-			let lock = NSLock()
-			lock.name = "org.reactivecocoa.ReactiveSwift.combineLatestWith"
+			let lock = PosixThreadMutex()
 
 			let signalState = CombineLatestState<Value>()
 			let otherState = CombineLatestState<U>()


### PR DESCRIPTION
1. Drop `NSLock`s to be in line with `Atomic`. (it is slower than pthread mutexes on Darwin due to dynamic dispatching)
2. Break the `SignalState` to reduce unnecessary retains and releases caused by the signal self reference.