### PR TITLE
Remove Property source capturing.

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -305,10 +305,10 @@ extension PropertyProtocol {
 }
 
 extension Property {
-	@available(*, unavailable, renamed:"AnyProperty(initial:then:)")
+	@available(*, unavailable, renamed:"Property(initial:then:)")
 	public convenience init(initialValue: Value, producer: SignalProducer<Value, NoError>) { fatalError() }
 
-	@available(*, unavailable, renamed:"AnyProperty(initial:then:)")
+	@available(*, unavailable, renamed:"Property(initial:then:)")
 	public convenience init(initialValue: Value, signal: Signal<Value, NoError>) { fatalError() }
 }
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -367,14 +367,17 @@ extension PropertyProtocol {
 /// property would complete immediately when it is initialized.
 ///
 /// # Existential property
-/// Created by `Property(_:)`, it wraps any arbitrary `PropertyProtocol` types.
-/// It would retain the wrapped property.
+/// Created by `Property(capturing:)`, it wraps any arbitrary `PropertyProtocol`
+/// types, and passes through the behavior. Note that it would retain the
+/// wrapped property.
+///
+/// Existential property would be deprecated when generalized existential
+/// eventually lands in Swift.
 ///
 /// # Composed property
 /// A composed property presents a composed view of its sources, which can be
 /// one or more properties, a producer, or a signal. It can be created using
-/// property composition operators, `Property(initial:then:)` or
-/// `Property(reflecting:)`.
+/// property composition operators, `Property(_:)` or `Property(initial:then:)`.
 ///
 /// It respects and have no effect on the lifetime of its root sources. In other
 /// words, the producer and signal of a composed property could complete before
@@ -424,7 +427,7 @@ public final class Property<Value>: PropertyProtocol {
 	///
 	/// - parameters:
 	///   - property: A property to be wrapped.
-	public init<P: PropertyProtocol>(_ property: P) where P.Value == Value {
+	public init<P: PropertyProtocol>(capturing property: P) where P.Value == Value {
 		disposable = nil
 		_value = { property.value }
 		_producer = { property.producer }
@@ -437,7 +440,7 @@ public final class Property<Value>: PropertyProtocol {
 	///
 	/// - parameters:
 	///   - property: A property to be wrapped.
-	public convenience init<P: PropertyProtocol>(reflecting property: P) where P.Value == Value {
+	public convenience init<P: PropertyProtocol>(_ property: P) where P.Value == Value {
 		self.init(unsafeProducer: property.producer)
 	}
 

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -373,23 +373,16 @@ class PropertySpec: QuickSpec {
 						expect(latestValue) == 4
 					}
 
-					it("should retain its source property") {
+					it("should not retain its source property") {
 						var property = Optional(MutableProperty(1))
 						weak var weakProperty = property
 
-						var firstMappedProperty = Optional(property!.map { $0 + 1 })
-						var secondMappedProperty = Optional(firstMappedProperty!.map { $0 + 2 })
+						let mapped = Optional(property!.map { $0 + 2 })
 
 						// Suppress the "written to but never read" warning on `secondMappedProperty`.
-						_ = secondMappedProperty
+						_ = mapped
 
 						property = nil
-						expect(weakProperty).toNot(beNil())
-
-						firstMappedProperty = nil
-						expect(weakProperty).toNot(beNil())
-
-						secondMappedProperty = nil
 						expect(weakProperty).to(beNil())
 					}
 
@@ -426,15 +419,15 @@ class PropertySpec: QuickSpec {
 						expect(producerCompleted) == 0
 
 						property = nil
-						expect(signalCompleted) == 0
-						expect(producerCompleted) == 0
+						expect(signalCompleted) == 3
+						expect(producerCompleted) == 3
 
 						thirdMappedProperty = nil
 						expect(signalCompleted) == 3
 						expect(producerCompleted) == 3
 					}
 
-					it("should not capture intermediate properties but only the ultimate sources") {
+					it("should capture no properties") {
 						func increment(input: Int) -> Int {
 							return input + 1
 						}
@@ -465,7 +458,7 @@ class PropertySpec: QuickSpec {
 						scope()
 
 						expect(finalProperty.value) == 5
-						expect(weakSourceProperty).toNot(beNil())
+						expect(weakSourceProperty).to(beNil())
 						expect(weakPropertyA).to(beNil())
 						expect(weakPropertyB).to(beNil())
 						expect(weakPropertyC).to(beNil())
@@ -1139,9 +1132,9 @@ class PropertySpec: QuickSpec {
 							var errored = false
 							var completed = false
 
-							var flattenedProperty = Optional(outerProperty!.flatten(.concat))
+							let flattenedProperty = outerProperty!.flatten(.concat)
 
-							flattenedProperty!.producer.start { event in
+							flattenedProperty.producer.start { event in
 								switch event {
 								case let .value(value):
 									receivedValues.append(value)
@@ -1184,9 +1177,6 @@ class PropertySpec: QuickSpec {
 							expect(completed) == false
 
 							thirdProperty = nil
-							expect(completed) == false
-
-							flattenedProperty = nil
 							expect(completed) == true
 							expect(errored) == false
 						}
@@ -1204,9 +1194,9 @@ class PropertySpec: QuickSpec {
 							var errored = false
 							var completed = false
 
-							var flattenedProperty = Optional(outerProperty!.flatten(.merge))
+							let flattenedProperty = outerProperty!.flatten(.merge)
 
-							flattenedProperty!.producer.start { event in
+							flattenedProperty.producer.start { event in
 								switch event {
 								case let .value(value):
 									receivedValues.append(value)
@@ -1249,9 +1239,6 @@ class PropertySpec: QuickSpec {
 							expect(completed) == false
 
 							thirdProperty = nil
-							expect(completed) == false
-
-							flattenedProperty = nil
 							expect(completed) == true
 							expect(errored) == false
 						}


### PR DESCRIPTION
The PR proposes to have composed properties *not* retaining its sources. [This test case](https://github.com/ReactiveCocoa/ReactiveSwift/pull/117/files#diff-8719ae7a50d7fc426e03c8da6c209061R411) helps illustrate the new behaviour.

Recall that retaining `Property` would defer the termination of the event stream. Source capturing retains the sources, causing the sources' lifetime being a union with the lifetime of all their derivatives.

However, if we consider properties are just streams of values with a stronger guarantee than `Signal`s (having one latest value), operators - that are fundamentally an observation - should not have a side effect on the observed event stream. In this sense, source capturing should be dropped.

~~It also adds a new initializer `Property(reflecting:)`, which does the same thing as `Property(_:)` but without retaining the supplied property.~~

The default initializer `Property(_:)` is changed not to capture the supplied property, while the capturing "existential" variant is renamed to `Property(capturing:)`. The renaming makes a better migration path when we deprecate the initializer as [generalised existential](https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#generalized-existentials) lands in Swift.

P.S. Existential properties serves to work around the current language limits, so they should be left untouched.

#### Background

As brought up in https://github.com/ReactiveCocoa/ReactiveSwift/pull/58#discussion_r89527936, I have made a review on why we had composed properties capturing its source.

It was originated in https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2788:

> Chain constructs like `let p1 = p0.map { $0.location }.map { $0.latitude }` are not safe with the proposed implementation, unless you explicitly capture `p0` for the whole `p1`'s lifecycle. 

It was true at that time, since the [property composition operators](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/2922) wasn't a thing yet, and the composition is done through `AnyProperty` which at that time was based on `MutableProperty`. So had we not made the property captured, **chaining** of `map` would not behave as expected.

But now with the [property composition formally introduced](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/2922), we propagate the values using [replayed producer](https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3078), which works properly when chained, rendering the need of capturing moot.