### PR TITLE
Drop the label of `SignalProducer` initializers that take a sequence.

### DIFF
--- a/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -262,7 +262,7 @@ scopedExample("`mapError`") {
 Preserves only the values of the producer that pass the given predicate.
 */
 scopedExample("`filter`") {
-	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
+	SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
 		.filter { $0 > 3 }
 		.startWithValues { value in
 			print(value)
@@ -275,7 +275,7 @@ Returns a producer that will yield the first `count` values from the
 input producer.
 */
 scopedExample("`take(first:)`") {
-	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
+	SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
 		.take(first: 2)
 		.startWithValues { value in
 			print(value)
@@ -288,7 +288,7 @@ Forwards all events onto the given scheduler, instead of whichever
 scheduler they originally arrived upon.
 */
 scopedExample("`observe(on:)`") {
-	let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
+	let baseProducer = SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
 	let completion = { print("is main thread? \(Thread.current.isMainThread)") }
 
 	baseProducer
@@ -391,8 +391,8 @@ least one value each. If either producer is interrupted, the returned producer
 will also be interrupted.
 */
 scopedExample("`combineLatest(with:)`") {
-	let producer1 = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
-	let producer2 = SignalProducer<Int, NoError>(values: [ 1, 2 ])
+	let producer1 = SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
+	let producer2 = SignalProducer<Int, NoError>([ 1, 2 ])
 
 	producer1
 		.combineLatest(with: producer2)
@@ -407,7 +407,7 @@ Returns a producer that will skip the first `count` values, then forward
 everything afterward.
 */
 scopedExample("`skip(first:)`") {
-	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
+	SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
 		.skip(first: 2)
 		.startWithValues { value in
 			print(value)
@@ -427,7 +427,7 @@ the Event itself and then complete. When an Interrupted event is received,
 the resulting producer will send the Event itself and then interrupt.
 */
 scopedExample("`materialize`") {
-	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
+	SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
 		.materialize()
 		.startWithValues { value in
 			print(value)
@@ -447,8 +447,8 @@ multiple times) by `sampler`, then complete once both input producers have
 completed, or interrupt if either input producer is interrupted.
 */
 scopedExample("`sample(on:)`") {
-	let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
-	let sampledOnProducer = SignalProducer<Int, NoError>(values: [ 1, 2 ])
+	let baseProducer = SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
+	let sampledOnProducer = SignalProducer<Int, NoError>([ 1, 2 ])
 		.map { _ in () }
 
 	baseProducer
@@ -466,7 +466,7 @@ is the current value. `initial` is supplied as the first member when `self`
 sends its first value.
 */
 scopedExample("`combinePrevious`") {
-	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
+	SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
 		.combinePrevious(42)
 		.startWithValues { value in
 			print("\(value)")
@@ -482,7 +482,7 @@ producer returned from `scan`. That result is then passed to `combine` as the
 first argument when the next value is emitted, and so on.
 */
 scopedExample("`scan`") {
-	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
+	SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
 		.scan(0, +)
 		.startWithValues { value in
 			print(value)
@@ -494,7 +494,7 @@ scopedExample("`scan`") {
 Like `scan`, but sends only the final value and then immediately completes.
 */
 scopedExample("`reduce`") {
-	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
+	SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
 		.reduce(0, +)
 		.startWithValues { value in
 			print(value)
@@ -507,7 +507,7 @@ Forwards only those values from `self` which do not pass `isRepeat` with
 respect to the previous value. The first value is always forwarded.
 */
 scopedExample("`skipRepeats`") {
-	SignalProducer<Int, NoError>(values: [ 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 1, 1, 1, 2, 2, 2, 4 ])
+	SignalProducer<Int, NoError>([ 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 1, 1, 1, 2, 2, 2, 4 ])
 		.skipRepeats(==)
 		.startWithValues { value in
 			print(value)
@@ -521,7 +521,7 @@ at which point the returned signal behaves exactly like `self`.
 */
 scopedExample("`skip(while:)`") {
 	// Note that trailing closure is used for `skip(while:)`.
-	SignalProducer<Int, NoError>(values: [ 3, 3, 3, 3, 1, 2, 3, 4 ])
+	SignalProducer<Int, NoError>([ 3, 3, 3, 3, 1, 2, 3, 4 ])
 		.skip { $0 > 2 }
 		.startWithValues { value in
 			print(value)
@@ -566,7 +566,7 @@ Waits until `self` completes and then forwards the final `count` values
 on the returned producer.
 */
 scopedExample("`take(last:)`") {
-	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
+	SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
 		.take(last: 2)
 		.startWithValues { value in
 			print(value)
@@ -579,7 +579,7 @@ Unwraps non-`nil` values and forwards them on the returned signal, `nil`
 values are dropped.
 */
 scopedExample("`skipNil`") {
-	SignalProducer<Int?, NoError>(values: [ nil, 1, 2, nil, 3, 4, nil ])
+	SignalProducer<Int?, NoError>([ nil, 1, 2, nil, 3, 4, nil ])
 		.skipNil()
 		.startWithValues { value in
 			print(value)
@@ -593,8 +593,8 @@ Zips elements of two producers into pairs. The elements of any Nth pair
 are the Nth elements of the two input producers.
 */
 scopedExample("`zip(with:)`") {
-	let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
-	let zippedProducer = SignalProducer<Int, NoError>(values: [ 42, 43 ])
+	let baseProducer = SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
+	let zippedProducer = SignalProducer<Int, NoError>([ 42, 43 ])
 
 	baseProducer
 		.zip(with: zippedProducer)
@@ -651,7 +651,7 @@ which case `replacement` will not be started, and none of its events will be
 be forwarded. All values sent from `producer` are ignored.
 */
 scopedExample("`then`") {
-	let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
+	let baseProducer = SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
 	let thenProducer = SignalProducer<Int, NoError>(value: 42)
 
 	baseProducer
@@ -686,7 +686,7 @@ a layer of caching in front of another `SignalProducer`.
 This operator has the same semantics as `SignalProducer.buffer`.
 */
 scopedExample("`replayLazily(upTo:)`") {
-	let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4, 42 ])
+	let baseProducer = SignalProducer<Int, NoError>([ 1, 2, 3, 4, 42 ])
 		.replayLazily(upTo: 2)
 
 	baseProducer.startWithValues { value in
@@ -712,7 +712,7 @@ If `self` or any of the created producers fail, the returned producer
 will forward that failure immediately.
 */
 scopedExample("`flatMap(.latest)`") {
-	SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
+	SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
 		.flatMap(.latest) { SignalProducer(value: $0 + 3) }
 		.startWithValues { value in
 			print(value)
@@ -743,8 +743,8 @@ sampled (possibly multiple times) by `sampler`, then complete once both
 input producers have completed, or interrupt if either input producer is interrupted.
 */
 scopedExample("`sample(with:)`") {
-	let producer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
-	let sampler = SignalProducer<String, NoError>(values: [ "a", "b" ])
+	let producer = SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
+	let sampler = SignalProducer<String, NoError>([ "a", "b" ])
 
 	let result = producer.sample(with: sampler)
 
@@ -759,7 +759,7 @@ Logs all events that the receiver sends.
 By default, it will print to the standard output.
 */
 scopedExample("`log events`") {
-	let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4, 42 ])
+	let baseProducer = SignalProducer<Int, NoError>([ 1, 2, 3, 4, 42 ])
 	
  	baseProducer
  		.logEvents(identifier: "Playground is fun!")

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -297,6 +297,12 @@ extension SignalProducerProtocol where Error == NoError {
 extension SignalProducer {
 	@available(*, unavailable, message:"Use properties instead. `buffer(_:)` is removed in RAC 5.0.")
 	public static func buffer(_ capacity: Int) -> (SignalProducer, Signal<Value, Error>.Observer) { fatalError() }
+
+	@available(*, unavailable, renamed:"init(_:)")
+	public init<S: SignalProtocol>(signal: S) where S.Value == Value, S.Error == Error { fatalError() }
+
+	@available(*, unavailable, renamed:"init(_:)")
+	public init<S: Sequence>(values: S) where S.Iterator.Element == Value { fatalError() }
 }
 
 extension PropertyProtocol {

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -249,7 +249,7 @@ extension SignalProtocol where Value: Sequence, Error == NoError {
 	/// Flattens the `sequence` value sent by `signal` according to
 	/// the semantics of the given strategy.
 	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Iterator.Element, Error> {
-		return self.flatMap(strategy) { .init(values: $0) }
+		return self.flatMap(strategy) { .init($0) }
 	}
 }
 
@@ -316,7 +316,7 @@ extension SignalProducerProtocol where Value: Sequence, Error == NoError {
 	/// Flattens the `sequence` value sent by `producer` according to
 	/// the semantics of the given strategy.
 	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Iterator.Element, Error> {
-		return self.flatMap(strategy) { .init(values: $0) }
+		return self.flatMap(strategy) { .init($0) }
 	}
 }
 
@@ -440,7 +440,7 @@ extension SignalProducerProtocol where Value: SignalProducerProtocol, Error == V
 extension SignalProducerProtocol {
 	/// `concat`s `next` onto `self`.
 	public func concat(_ next: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
-		return SignalProducer<SignalProducer<Value, Error>, Error>(values: [ self.producer, next ]).flatten(.concat)
+		return SignalProducer<SignalProducer<Value, Error>, Error>([ self.producer, next ]).flatten(.concat)
 	}
 	
 	/// `concat`s `value` onto `self`.
@@ -578,7 +578,7 @@ extension SignalProtocol {
 	public static func merge<Seq: Sequence, S: SignalProtocol>(_ signals: Seq) -> Signal<Value, Error>
 		where S.Value == Value, S.Error == Error, Seq.Iterator.Element == S
 	{
-		return SignalProducer<S, Error>(values: signals)
+		return SignalProducer<S, Error>(signals)
 			.flatten(.merge)
 			.startAndRetrieveSignal()
 	}
@@ -599,7 +599,7 @@ extension SignalProducerProtocol {
 	public static func merge<Seq: Sequence, S: SignalProducerProtocol>(_ producers: Seq) -> SignalProducer<Value, Error>
 		where S.Value == Value, S.Error == Error, Seq.Iterator.Element == S
 	{
-		return SignalProducer(values: producers).flatten(.merge)
+		return SignalProducer(producers).flatten(.merge)
 	}
 	
 	/// Merges the given producers into a single `SignalProducer` that will emit

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -456,10 +456,10 @@ public final class Property<Value>: PropertyProtocol {
 	///
 	/// - parameters:
 	///   - initial: Starting value for the property.
-	///   - producer: A producer that will start immediately and send values to
-	///               the property.
-	public convenience init(initial: Value, then producer: SignalProducer<Value, NoError>) {
-		self.init(unsafeProducer: producer.prefix(value: initial))
+	///   - values: A producer that will start immediately and send values to
+	///             the property.
+	public convenience init(initial: Value, then values: SignalProducer<Value, NoError>) {
+		self.init(unsafeProducer: values.prefix(value: initial))
 	}
 
 	/// Initialize a composed property that first takes on `initial`, then each
@@ -467,9 +467,9 @@ public final class Property<Value>: PropertyProtocol {
 	///
 	/// - parameters:
 	///   - initialValue: Starting value for the property.
-	///   - signal: A signal that will send values to the property.
-	public convenience init(initial: Value, then signal: Signal<Value, NoError>) {
-		self.init(unsafeProducer: SignalProducer(signal).prefix(value: initial))
+	///   - values: A signal that will send values to the property.
+	public convenience init(initial: Value, then values: Signal<Value, NoError>) {
+		self.init(unsafeProducer: SignalProducer(values).prefix(value: initial))
 	}
 
 	/// Initialize a composed property by applying the unary `SignalProducer`

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -469,7 +469,7 @@ public final class Property<Value>: PropertyProtocol {
 	///   - initialValue: Starting value for the property.
 	///   - signal: A signal that will send values to the property.
 	public convenience init(initial: Value, then signal: Signal<Value, NoError>) {
-		self.init(unsafeProducer: SignalProducer(signal: signal).prefix(value: initial))
+		self.init(unsafeProducer: SignalProducer(signal).prefix(value: initial))
 	}
 
 	/// Initialize a composed property by applying the unary `SignalProducer`

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -29,7 +29,7 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	///
 	/// - parameters:
 	///   - signal: A signal to observe after starting the producer.
-	public init<S: SignalProtocol>(signal: S) where S.Value == Value, S.Error == Error {
+	public init<S: SignalProtocol>(_ signal: S) where S.Value == Value, S.Error == Error {
 		self.init { observer, disposable in
 			disposable += signal.observe(observer)
 		}
@@ -100,9 +100,9 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	/// - parameters:
 	///   - values: A sequence of values that a `Signal` will send as separate
 	///             `value` events and then complete.
-	public init<S: Sequence>(values: S) where S.Iterator.Element == Value {
+	public init<S: Sequence>(_ sequence: S) where S.Iterator.Element == Value {
 		self.init { observer, disposable in
-			for value in values {
+			for value in sequence {
 				observer.send(value: value)
 
 				if disposable.isDisposed {
@@ -122,7 +122,7 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	///   - second: Second value for the `Signal` to send.
 	///   - tail: Rest of the values to be sent by the `Signal`.
 	public init(values first: Value, _ second: Value, _ tail: Value...) {
-		self.init(values: [ first, second ] + tail)
+		self.init([ first, second ] + tail)
 	}
 
 	/// A producer for a Signal that will immediately complete without sending
@@ -448,7 +448,7 @@ extension SignalProducerProtocol {
 	///            `SignalProducer`.
 	public func lift<U, F, V, G>(_ transform: @escaping (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (Signal<U, F>) -> SignalProducer<V, G> {
 		return { otherSignal in
-			return self.liftRight(transform)(SignalProducer(signal: otherSignal))
+			return self.liftRight(transform)(SignalProducer(otherSignal))
 		}
 	}
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -100,9 +100,9 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	/// - parameters:
 	///   - values: A sequence of values that a `Signal` will send as separate
 	///             `value` events and then complete.
-	public init<S: Sequence>(_ sequence: S) where S.Iterator.Element == Value {
+	public init<S: Sequence>(_ values: S) where S.Iterator.Element == Value {
 		self.init { observer, disposable in
-			for value in sequence {
+			for value in values {
 				observer.send(value: value)
 
 				if disposable.isDisposed {

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -578,7 +578,7 @@ class PropertySpec: QuickSpec {
 
 						let (signal, observer) = Signal<Int, NoError>.pipe()
 						var property: Property<Int>? = Property(initial: 1,
-																											 then: SignalProducer(signal: signal))
+						                                        then: SignalProducer(signal))
 						let propertySignal = property!.signal
 
 						propertySignal.observeCompleted { signalCompleted = true }
@@ -1539,7 +1539,7 @@ class PropertySpec: QuickSpec {
 			describe("from a SignalProducer") {
 				it("should start a signal and update the property with its values") {
 					let signalValues = [initialPropertyValue, subsequentPropertyValue]
-					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
+					let signalProducer = SignalProducer<String, NoError>(signalValues)
 
 					let mutableProperty = MutableProperty(initialPropertyValue)
 
@@ -1562,7 +1562,7 @@ class PropertySpec: QuickSpec {
 
 				it("should tear down the binding when the property deallocates") {
 					let (signal, _) = Signal<String, NoError>.pipe()
-					let signalProducer = SignalProducer(signal: signal)
+					let signalProducer = SignalProducer(signal)
 
 					var mutableProperty: MutableProperty<String>? = MutableProperty(initialPropertyValue)
 

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -999,7 +999,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			}
 			
 			it("should emit an initial value if the sampler is a synchronous SignalProducer") {
-				let producer = SignalProducer<Int, NoError>(values: [1])
+				let producer = SignalProducer<Int, NoError>([1])
 				let sampler = SignalProducer<String, NoError>(value: "a")
 				
 				let result = producer.sample(with: sampler)
@@ -1064,7 +1064,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			}
 
 			it("should emit an initial value if the sampler is a synchronous SignalProducer") {
-				let producer = SignalProducer<Int, NoError>(values: [1])
+				let producer = SignalProducer<Int, NoError>([1])
 				let sampler = SignalProducer<(), NoError>(value: ())
 				
 				let result = producer.sample(on: sampler)

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -141,7 +141,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should emit values then complete") {
-				let producer = SignalProducer<Int, TestError>(signal: signal)
+				let producer = SignalProducer<Int, TestError>(signal)
 
 				var values: [Int] = []
 				var error: TestError?
@@ -174,7 +174,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should emit error") {
-				let producer = SignalProducer<Int, TestError>(signal: signal)
+				let producer = SignalProducer<Int, TestError>(signal)
 
 				var error: TestError?
 				let sentError = TestError.default
@@ -234,7 +234,7 @@ class SignalProducerSpec: QuickSpec {
 		describe("init(values:)") {
 			it("should immediately send the sequence of values") {
 				let sequenceValues = [1, 2, 3]
-				let signalProducer = SignalProducer<Int, NSError>(values: sequenceValues)
+				let signalProducer = SignalProducer<Int, NSError>(sequenceValues)
 
 				expect(signalProducer).to(sendValues(sequenceValues, sendError: nil, complete: true))
 			}
@@ -478,7 +478,7 @@ class SignalProducerSpec: QuickSpec {
 
 		describe("start") {
 			it("should immediately begin sending events") {
-				let producer = SignalProducer<Int, NoError>(values: [1, 2])
+				let producer = SignalProducer<Int, NoError>([1, 2])
 
 				var values: [Int] = []
 				var completed = false
@@ -571,7 +571,7 @@ class SignalProducerSpec: QuickSpec {
 		describe("lift") {
 			describe("over unary operators") {
 				it("should invoke transformation once per started signal") {
-					let baseProducer = SignalProducer<Int, NoError>(values: [1, 2])
+					let baseProducer = SignalProducer<Int, NoError>([1, 2])
 
 					var counter = 0
 					let transform = { (signal: Signal<Int, NoError>) -> Signal<Int, NoError> in
@@ -590,7 +590,7 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				it("should not miss any events") {
-					let baseProducer = SignalProducer<Int, NoError>(values: [1, 2, 3, 4])
+					let baseProducer = SignalProducer<Int, NoError>([1, 2, 3, 4])
 
 					let producer = baseProducer.lift { signal in
 						return signal.map { $0 * $0 }
@@ -603,8 +603,8 @@ class SignalProducerSpec: QuickSpec {
 
 			describe("over binary operators") {
 				it("should invoke transformation once per started signal") {
-					let baseProducer = SignalProducer<Int, NoError>(values: [1, 2])
-					let otherProducer = SignalProducer<Int, NoError>(values: [3, 4])
+					let baseProducer = SignalProducer<Int, NoError>([1, 2])
+					let otherProducer = SignalProducer<Int, NoError>([3, 4])
 
 					var counter = 0
 					let transform = { (signal: Signal<Int, NoError>) -> (Signal<Int, NoError>) -> Signal<(Int, Int), NoError> in
@@ -625,8 +625,8 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				it("should not miss any events") {
-					let baseProducer = SignalProducer<Int, NoError>(values: [1, 2, 3])
-					let otherProducer = SignalProducer<Int, NoError>(values: [4, 5, 6])
+					let baseProducer = SignalProducer<Int, NoError>([1, 2, 3])
+					let otherProducer = SignalProducer<Int, NoError>([4, 5, 6])
 
 					let transform = { (signal: Signal<Int, NoError>) -> (Signal<Int, NoError>) -> Signal<Int, NoError> in
 						return { otherSignal in
@@ -643,7 +643,7 @@ class SignalProducerSpec: QuickSpec {
 
 			describe("over binary operators with signal") {
 				it("should invoke transformation once per started signal") {
-					let baseProducer = SignalProducer<Int, NoError>(values: [1, 2])
+					let baseProducer = SignalProducer<Int, NoError>([1, 2])
 					let (otherSignal, otherSignalObserver) = Signal<Int, NoError>.pipe()
 
 					var counter = 0
@@ -667,7 +667,7 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				it("should not miss any events") {
-					let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3 ])
+					let baseProducer = SignalProducer<Int, NoError>([ 1, 2, 3 ])
 					let (otherSignal, otherSignalObserver) = Signal<Int, NoError>.pipe()
 
 					let transform = { (signal: Signal<Int, NoError>) -> (Signal<Int, NoError>) -> Signal<Int, NoError> in
@@ -750,8 +750,8 @@ class SignalProducerSpec: QuickSpec {
 
 		describe("zip") {
 			it("should zip the events to one array") {
-				let producerA = SignalProducer<Int, NoError>(values: [ 1, 2 ])
-				let producerB = SignalProducer<Int, NoError>(values: [ 3, 4 ])
+				let producerA = SignalProducer<Int, NoError>([ 1, 2 ])
+				let producerB = SignalProducer<Int, NoError>([ 3, 4 ])
 
 				let producer = SignalProducer.zip([producerA, producerB])
 				let result = producer.collect().single()
@@ -864,7 +864,7 @@ class SignalProducerSpec: QuickSpec {
 				let (baseSignal, baseObserver) = Signal<Int, NoError>.pipe()
 				observer = baseObserver
 
-				producer = SignalProducer(signal: baseSignal)
+				producer = SignalProducer(baseSignal)
 					.throttle(while: shouldThrottle, on: scheduler)
 
 				expect(producer).notTo(beNil())
@@ -1608,7 +1608,7 @@ class SignalProducerSpec: QuickSpec {
 
 		describe("times") {
 			it("should start a signal N times upon completion") {
-				let original = SignalProducer<Int, NoError>(values: [ 1, 2, 3 ])
+				let original = SignalProducer<Int, NoError>([ 1, 2, 3 ])
 				let producer = original.repeat(3)
 
 				let result = producer.collect().single()
@@ -1824,7 +1824,7 @@ class SignalProducerSpec: QuickSpec {
 					forwardingScheduler = QueueScheduler(queue: DispatchQueue(label: "\(#file):\(#line)"))
 				}
 
-				let producer = SignalProducer(signal: _signal.delay(0.1, on: forwardingScheduler))
+				let producer = SignalProducer(_signal.delay(0.1, on: forwardingScheduler))
 
 				let observingScheduler: QueueScheduler
 
@@ -1852,7 +1852,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should return the first value if more than one value is sent") {
-				let result = SignalProducer<Int, NoError>(values: [ 1, 2 ]).first()
+				let result = SignalProducer<Int, NoError>([ 1, 2 ]).first()
 				expect(result?.value) == 1
 			}
 
@@ -1873,7 +1873,7 @@ class SignalProducerSpec: QuickSpec {
 					forwardingScheduler = QueueScheduler(queue: DispatchQueue(label: "\(#file):\(#line)"))
 				}
 
-				let producer = SignalProducer(signal: _signal.delay(0.1, on: forwardingScheduler))
+				let producer = SignalProducer(_signal.delay(0.1, on: forwardingScheduler))
 
 				let observingScheduler: QueueScheduler
 
@@ -1905,7 +1905,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should return a nil result if more than one value is sent before completion") {
-				let result = SignalProducer<Int, NoError>(values: [ 1, 2 ]).single()
+				let result = SignalProducer<Int, NoError>([ 1, 2 ]).single()
 				expect(result).to(beNil())
 			}
 
@@ -1925,7 +1925,7 @@ class SignalProducerSpec: QuickSpec {
 				} else {
 					scheduler = QueueScheduler(queue: DispatchQueue(label: "\(#file):\(#line)"))
 				}
-				let producer = SignalProducer(signal: _signal.delay(0.1, on: scheduler))
+				let producer = SignalProducer(_signal.delay(0.1, on: scheduler))
 
 				var result: Result<Int, NoError>?
 
@@ -1959,7 +1959,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should return the last value if more than one value is sent") {
-				let result = SignalProducer<Int, NoError>(values: [ 1, 2 ]).last()
+				let result = SignalProducer<Int, NoError>([ 1, 2 ]).last()
 				expect(result?.value) == 2
 			}
 
@@ -1978,7 +1978,7 @@ class SignalProducerSpec: QuickSpec {
 				} else {
 					scheduler = QueueScheduler(queue: DispatchQueue(label: "\(#file):\(#line)"))
 				}
-				let producer = SignalProducer(signal: _signal.delay(0.1, on: scheduler))
+				let producer = SignalProducer(_signal.delay(0.1, on: scheduler))
 
 				var result: Result<(), NoError>?
 
@@ -2358,7 +2358,7 @@ class SignalProducerSpec: QuickSpec {
 					let producer2: SignalProducer<Int, NoError> = SignalProducer.empty
 
 					// This expression verifies at compile time that the type is as expected.
-					let _: SignalProducer<Int, NoError> = SignalProducer(values: [producer1, producer2])
+					let _: SignalProducer<Int, NoError> = SignalProducer([producer1, producer2])
 						.flatten(.merge)
 				}
 			}
@@ -2407,7 +2407,7 @@ class SignalProducerSpec: QuickSpec {
 extension SignalProducer {
 	internal static func pipe() -> (SignalProducer, ProducedSignal.Observer) {
 		let (signal, observer) = ProducedSignal.pipe()
-		let producer = SignalProducer(signal: signal)
+		let producer = SignalProducer(signal)
 		return (producer, observer)
 	}
 


### PR DESCRIPTION
Since this is not a lossy conversion, and there is no conflicting signature, the `signal` label does not give any extra clarity at call site.