### PR TITLE
`Atomic`: The Unexpected Journey.

### DIFF
--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -125,6 +125,12 @@ internal struct UnsafeAtomicState<State: RawRepresentable>: AtomicStateProtocol 
 #endif
 }
 
+/// A pthread mutex wrapper. Manual memory management by calling
+/// `deinitialize` is required.
+///
+/// The wrapper is a struct so that it can be inlined when it is contained as
+/// part of a reference type, and dodges an extra level of calling indirection
+/// that would otherwise happen if the wrapper itself is an reference type.
 internal struct PosixThreadMutex {
 	private let mutex: UnsafeMutablePointer<pthread_mutex_t>
 

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -379,7 +379,7 @@ extension AtomicProtocol {
 	/// - returns: The old value.
 	@discardableResult
 	@inline(__always)
-	func swap(_ newValue: Value) -> Value {
+	public func swap(_ newValue: Value) -> Value {
 		return modify { (value: inout Value) in
 			let oldValue = value
 			value = newValue

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -214,9 +214,14 @@ public final class Atomic<Value>: AtomicProtocol {
 	@inline(__always)
 	public func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result {
 		lock.lock()
-		let value = try action(&_value)
-		lock.unlock()
-		return value
+		do {
+			let value = try action(&_value)
+			lock.unlock()
+			return value
+		} catch let error {
+			lock.unlock()
+			throw error
+		}
 	}
 	
 	/// Atomically perform an arbitrary action using the current value of the
@@ -230,9 +235,14 @@ public final class Atomic<Value>: AtomicProtocol {
 	@inline(__always)
 	public func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result {
 		lock.lock()
-		let value = try action(_value)
-		lock.unlock()
-		return value
+		do {
+			let value = try action(_value)
+			lock.unlock()
+			return value
+		} catch let error {
+			lock.unlock()
+			throw error
+		}
 	}
 
 	/// Atomically replace the contents of the variable.
@@ -296,10 +306,15 @@ internal final class RecursiveAtomic<Value>: AtomicProtocol {
 	@inline(__always)
 	func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result {
 		lock.lock()
-		let returnValue = try action(&_value)
-		didSetObserver?(_value)
-		lock.unlock()
-		return returnValue
+		do {
+			let returnValue = try action(&_value)
+			didSetObserver?(_value)
+			lock.unlock()
+			return returnValue
+		} catch let error {
+			lock.unlock()
+			throw error
+		}
 	}
 	
 	/// Atomically perform an arbitrary action using the current value of the
@@ -313,9 +328,14 @@ internal final class RecursiveAtomic<Value>: AtomicProtocol {
 	@inline(__always)
 	func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result {
 		lock.lock()
-		let returnValue = try action(_value)
-		lock.unlock()
-		return returnValue
+		do {
+			let returnValue = try action(_value)
+			lock.unlock()
+			return returnValue
+		} catch let error {
+			lock.unlock()
+			throw error
+		}
 	}
 }
 

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -250,7 +250,6 @@ public final class Atomic<Value>: AtomicProtocol {
 	}
 }
 
-
 /// An atomic variable which uses a recursive lock.
 internal final class RecursiveAtomic<Value>: AtomicProtocol {
 	private let lock: NSRecursiveLock
@@ -329,6 +328,22 @@ internal final class RecursiveAtomic<Value>: AtomicProtocol {
 			throw error
 		}
 	}
+
+	/// Atomically replace the contents of the variable.
+	///
+	/// - parameters:
+	///   - newValue: A new value for the variable.
+	///
+	/// - returns: The old value.
+	@discardableResult
+	@inline(__always)
+	func swap(_ newValue: Value) -> Value {
+		return modify { value in
+			let oldValue = value
+			value = newValue
+			return oldValue
+		}
+	}
 }
 
 /// A protocol used to constraint convenience `Atomic` methods and properties.
@@ -365,7 +380,7 @@ extension AtomicProtocol {
 	@discardableResult
 	@inline(__always)
 	func swap(_ newValue: Value) -> Value {
-		return modify { value in
+		return modify { (value: inout Value) in
 			let oldValue = value
 			value = newValue
 			return oldValue

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -125,7 +125,7 @@ internal struct UnsafeAtomicState<State: RawRepresentable>: AtomicStateProtocol 
 #endif
 }
 
-internal struct _PosixThreadMutex {
+internal struct PosixThreadMutex {
 	private let mutex: UnsafeMutablePointer<pthread_mutex_t>
 
 	init() {
@@ -159,27 +159,9 @@ internal struct _PosixThreadMutex {
 	}
 }
 
-internal final class PosixThreadMutex: NSLocking {
-	private let mutex = _PosixThreadMutex()
-
-	deinit {
-		mutex.deinitialize()
-	}
-
-	@inline(__always)
-	func lock() {
-		mutex.lock()
-	}
-
-	@inline(__always)
-	func unlock() {
-		mutex.unlock()
-	}
-}
-
 /// An atomic variable.
 public final class Atomic<Value>: AtomicProtocol {
-	private let lock: _PosixThreadMutex
+	private let lock: PosixThreadMutex
 	private var _value: Value
 
 	/// Atomically get or set the value of the variable.
@@ -201,7 +183,7 @@ public final class Atomic<Value>: AtomicProtocol {
 	///   - value: Initial value for `self`.
 	public init(_ value: Value) {
 		_value = value
-		lock = _PosixThreadMutex()
+		lock = PosixThreadMutex()
 	}
 
 	deinit {

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -131,7 +131,7 @@ internal struct UnsafeAtomicState<State: RawRepresentable>: AtomicStateProtocol 
 /// The wrapper is a struct so that it can be inlined when it is contained as
 /// part of a reference type, and dodges an extra level of calling indirection
 /// that would otherwise happen if the wrapper itself is an reference type.
-internal struct PosixThreadMutex {
+internal struct PthreadMutex {
 	private let mutex: UnsafeMutablePointer<pthread_mutex_t>
 
 	init() {
@@ -167,7 +167,7 @@ internal struct PosixThreadMutex {
 
 /// An atomic variable.
 public final class Atomic<Value>: AtomicProtocol {
-	private let lock: PosixThreadMutex
+	private let lock: PthreadMutex
 	private var _value: Value
 
 	/// Atomically get or set the value of the variable.
@@ -189,7 +189,7 @@ public final class Atomic<Value>: AtomicProtocol {
 	///   - value: Initial value for `self`.
 	public init(_ value: Value) {
 		_value = value
-		lock = PosixThreadMutex()
+		lock = PthreadMutex()
 	}
 
 	deinit {

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -622,6 +622,9 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 
 	/// Atomically modifies the variable.
 	///
+	/// - note: Throwing in `action` does not revert any changes made, and a
+	///         `next` event would be sent regardless.
+	///
 	/// - parameters:
 	///   - action: A closure that accepts old property value and returns a new
 	///             property value.

--- a/Tests/ReactiveSwiftTests/AtomicSpec.swift
+++ b/Tests/ReactiveSwiftTests/AtomicSpec.swift
@@ -35,6 +35,16 @@ class AtomicSpec: QuickSpec {
 			expect(atomic.value) == 2
 		}
 
+		it("should modify the value atomically despite throwing an error") {
+			expect {
+				try atomic.modify {
+					$0 += 1
+					throw TestError.default
+				}
+			}.to(throwError(TestError.default))
+			expect(atomic.value) == 2
+		}
+
 		it("should perform an action with the value") {
 			let result: Bool = atomic.withValue { $0 == 1 }
 			expect(result) == true

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -166,6 +166,18 @@ class PropertySpec: QuickSpec {
 				expect(property.value) == subsequentPropertyValue
 			}
 
+			it("should modify the value atomically despite throwing an error") {
+				let property = MutableProperty(initialPropertyValue)
+
+				expect {
+					try property.modify {
+						$0 = subsequentPropertyValue
+						throw TestError.default
+					}
+				}.to(throwError(TestError.default))
+				expect(property.value) == subsequentPropertyValue
+			}
+
 			it("should swap the value atomically and subsquently send out a Value event with the new value") {
 				let property = MutableProperty(initialPropertyValue)
 				var value: String?


### PR DESCRIPTION
#### The benchmark
[Source](https://gist.github.com/andersio/9b3f64754e4f35437673fe78a693209f)
It simulates the critical path of `Signal`, which is grabbing the signal state + querying the `interrupted`.

Compiler Settings: Both the framework and the test are compiled with `-Owholemodule`. Checked builds.
Test Environment: i5 4258U, macOS 10.12.1, Xcode 8.1, Swift 3.0.1

#### Final Speedup
4.641x 😦

The optimised `Atomic` now takes only 0.029 sec (5%) in the synthetic test of the [lock-free disposal PR](https://github.com/ReactiveCocoa/ReactiveSwift/pull/107), significantly faster than it was before.

#### Baseline Performance
`master`
0.673 sec (2%)

#### The Journey
Mark `AtomicProtocol.value` and `AtomicProtocol.swap` as `@inline(__always)`.
0.434 sec (2%)

Mark `Atomic.modify` and `Atomic.swap` as `@inline(__always)`.
0.296 sec (2%)

Mark `PosixThreadMutex.lock` and `PosixThreadMutex.unlock` as `@inline(__always)`.
0.223 sec (2%)

Drop `defer` statements in `Atomic.modify` and `Atomic.swap`.
0.212 sec (3%)

Drop `precondition` in favour of `if-fatalError`.
0.188 sec (2%)

Embed `PosixThreadMutex` into `Atomic`.
0.179 sec (4%)

Implement `value` and `swap` in `Atomic`.
0.149 sec (4%)

Use the non-copying `modify` instead of `withValue` in `value.get`.
0.145 sec (2%)

#### Misc 
Inline `modify` into `swap` manually.
0.145 sec (2%)

Closure based `_PosixThreadMutex.lock`.
0.179 sec (3%)

`-Onone`
0.479 sec (3%)