### PR TITLE
Failing test cases for race conditions in signal interruption (#123).

### DIFF
--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Dispatch
 
 import Result
 import Nimble

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -235,7 +235,8 @@ class SignalSpec: QuickSpec {
 				signal.observe { event in
 					if !hasSlept {
 						sema.signal()
-						sleep(5)
+						// 100000 us = 0.1 s
+						usleep(100000)
 						hasSlept = true
 					}
 					events.append(event)
@@ -271,7 +272,7 @@ class SignalSpec: QuickSpec {
 					queue = DispatchQueue.global(priority: .high)
 				}
 
-				let iterations = 100000
+				let iterations = 1000
 				let group = DispatchGroup()
 
 				queue.async(group: group) {
@@ -300,7 +301,7 @@ class SignalSpec: QuickSpec {
 				group.wait()
 
 				expect(executionCounter.value) == iterations * 2
-				expect(counter.value).toEventually(equal(iterations), timeout: 10)
+				expect(counter.value).toEventually(equal(iterations), timeout: 5)
 			}
 		}
 


### PR DESCRIPTION
Included in #123.

Note that the test case _"should interrupt concurrently"_ may not fail on Travis CI due to the limited concurrency. Running the test case locally should yield the expected result.