### PR TITLE
Optimize `Bag`.

### DIFF
--- a/Sources/Bag.swift
+++ b/Sources/Bag.swift
@@ -18,7 +18,7 @@ public final class RemovalToken {
 
 /// An unordered, non-unique collection of values of type `Element`.
 public struct Bag<Element> {
-	fileprivate var elements: [BagElement<Element>] = []
+	fileprivate var elements: ContiguousArray<BagElement<Element>> = []
 	private var currentIdentifier: UInt = 0
 
 	public init() {
@@ -95,6 +95,10 @@ extension Bag: Collection {
 	public func index(after i: Index) -> Index {
 		return i + 1
 	}
+
+	public func makeIterator() -> BagIterator<Element> {
+		return BagIterator(elements)
+	}
 }
 
 private struct BagElement<Value> {
@@ -106,5 +110,28 @@ private struct BagElement<Value> {
 extension BagElement: CustomStringConvertible {
 	var description: String {
 		return "BagElement(\(value))"
+	}
+}
+
+public struct BagIterator<Element>: IteratorProtocol {
+	private let base: ContiguousArray<BagElement<Element>>
+	private var nextIndex: Int
+	private let endIndex: Int
+
+	fileprivate init(_ base: ContiguousArray<BagElement<Element>>) {
+		self.base = base
+		nextIndex = base.startIndex
+		endIndex = base.endIndex
+	}
+
+	public mutating func next() -> Element? {
+		let currentIndex = nextIndex
+		nextIndex = currentIndex + 1
+
+		if currentIndex < endIndex {
+			return base[currentIndex].value
+		}
+
+		return nil
 	}
 }

--- a/Sources/Bag.swift
+++ b/Sources/Bag.swift
@@ -96,9 +96,9 @@ public struct BagIterator<Element>: IteratorProtocol {
 
 	public mutating func next() -> Element? {
 		let currentIndex = nextIndex
-		nextIndex = currentIndex + 1
 
 		if currentIndex < endIndex {
+			nextIndex = currentIndex + 1
 			return base[currentIndex].value
 		}
 


### PR DESCRIPTION
[Test Case 1 & 2](https://gist.github.com/andersio/5cc8fd27a8adccf70d53036505069db3#file-perftests-swift)
Same environment as in #124

#### Baseline: `master`
One Observer:    0.018 sec (10%)
Eight Observers: 0.053 sec (5%)

#### A custom iterator to mitigate the time spent in protocol witness table for calling the default implementations.
One Observer:    0.012 sec (10%)
Eight Observers: 0.030 sec (6%)

#### Replace `Array` with `ContiguousArray` to avoid `swift_bridgeObjectRetain` calls in Array subscript getter, despite `BagElement` being a Swift struct.
One Observer:    0.010 sec (12%)
Eight Observers: 0.020 sec (3%)

#### Replace the monotonic ID in `Bag` with `ObjectIdentifier`.
Apparently no effect on iteration performance.