### PR TITLE
Add withLatest(from:) (Rx.withLatestFrom)

### DIFF
--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1030,7 +1030,7 @@ extension SignalProtocol {
 	///         nothing happens.
 	///
 	/// - parameters:
-	///   - samplee: A signal that its latest value is sampled by `self`.
+	///   - samplee: A signal whose latest value is sampled by `self`.
 	///
 	/// - returns: A signal that will send values from `self` and `samplee`,
 	///            sampled (possibly multiple times) by `self`, then terminate
@@ -1073,7 +1073,7 @@ extension SignalProtocol {
 	///         nothing happens.
 	///
 	/// - parameters:
-	///   - samplee: A producer that its latest value is sampled by `self`.
+	///   - samplee: A producer whose latest value is sampled by `self`.
 	///
 	/// - returns: A signal that will send values from `self` and `samplee`,
 	///            sampled (possibly multiple times) by `self`, then terminate

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1036,7 +1036,7 @@ extension SignalProtocol {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func withLatest<U>(_ samplee: Signal<U, NoError>) -> Signal<(Value, U), Error> {
+	public func withLatest<U>(from samplee: Signal<U, NoError>) -> Signal<(Value, U), Error> {
 		return Signal { observer in
 			let state = Atomic<U?>(nil)
 			let disposable = CompositeDisposable()
@@ -1079,12 +1079,12 @@ extension SignalProtocol {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func withLatest<U>(_ samplee: SignalProducer<U, NoError>) -> Signal<(Value, U), Error> {
+	public func withLatest<U>(from samplee: SignalProducer<U, NoError>) -> Signal<(Value, U), Error> {
 		return Signal { observer in
 			let d = CompositeDisposable()
 			samplee.startWithSignal { signal, disposable in
 				d += disposable
-				d += self.withLatest(signal).observe(observer)
+				d += self.withLatest(from: signal).observe(observer)
 			}
 			return d
 		}

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1023,7 +1023,8 @@ extension SignalProtocol {
 
 	/// Forward the latest value from `samplee` with the value from `self` as a
 	/// tuple, only when `self` sends a `value` event.
-	/// This is like a flipped version of `sample(with:)` and Rx's `withLatestFrom`.
+	/// This is like a flipped version of `sample(with:)`, but `samplee`'s
+	/// terminal events are completely ignored.
 	///
 	/// - note: If `self` fires before a value has been observed on `samplee`,
 	///         nothing happens.
@@ -1035,7 +1036,7 @@ extension SignalProtocol {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func sample<U>(from samplee: Signal<U, NoError>) -> Signal<(Value, U), Error> {
+	public func withLatest<U>(_ samplee: Signal<U, NoError>) -> Signal<(Value, U), Error> {
 		return Signal { observer in
 			let state = Atomic<U?>(nil)
 			let disposable = CompositeDisposable()
@@ -1065,7 +1066,8 @@ extension SignalProtocol {
 
 	/// Forward the latest value from `samplee` with the value from `self` as a
 	/// tuple, only when `self` sends a `value` event.
-	/// This is like a flipped version of `sample(with:)` and Rx's `withLatestFrom`.
+	/// This is like a flipped version of `sample(with:)`, but `samplee`'s
+	/// terminal events are completely ignored.
 	///
 	/// - note: If `self` fires before a value has been observed on `samplee`,
 	///         nothing happens.
@@ -1077,12 +1079,12 @@ extension SignalProtocol {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func sample<U>(from samplee: SignalProducer<U, NoError>) -> Signal<(Value, U), Error> {
+	public func withLatest<U>(_ samplee: SignalProducer<U, NoError>) -> Signal<(Value, U), Error> {
 		return Signal { observer in
 			let d = CompositeDisposable()
 			samplee.startWithSignal { signal, disposable in
 				d += disposable
-				d += self.sample(from: signal).observe(observer)
+				d += self.withLatest(signal).observe(observer)
 			}
 			return d
 		}

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -814,7 +814,8 @@ extension SignalProducerProtocol {
 
 	/// Forward the latest value from `samplee` with the value from `self` as a
 	/// tuple, only when `self` sends a `value` event.
-	/// This is like a flipped version of `sample(with:)` and Rx's `withLatestFrom`.
+	/// This is like a flipped version of `sample(with:)`, but `samplee`'s
+	/// terminal events are completely ignored.
 	///
 	/// - note: If `self` fires before a value has been observed on `samplee`,
 	///         nothing happens.
@@ -826,13 +827,14 @@ extension SignalProducerProtocol {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func sample<U>(from samplee: SignalProducer<U, NoError>) -> SignalProducer<(Value, U), Error> {
-		return liftRight(Signal.sample(from:))(samplee)
+	public func withLatest<U>(_ samplee: SignalProducer<U, NoError>) -> SignalProducer<(Value, U), Error> {
+		return liftRight(Signal.withLatest)(samplee)
 	}
 
 	/// Forward the latest value from `samplee` with the value from `self` as a
 	/// tuple, only when `self` sends a `value` event.
-	/// This is like a flipped version of `sample(with:)` and Rx's `withLatestFrom`.
+	/// This is like a flipped version of `sample(with:)`, but `samplee`'s
+	/// terminal events are completely ignored.
 	///
 	/// - note: If `self` fires before a value has been observed on `samplee`,
 	///         nothing happens.
@@ -844,8 +846,8 @@ extension SignalProducerProtocol {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func sample<U>(from samplee: Signal<U, NoError>) -> SignalProducer<(Value, U), Error> {
-		return lift(Signal.sample(from:))(samplee)
+	public func withLatest<U>(_ samplee: Signal<U, NoError>) -> SignalProducer<(Value, U), Error> {
+		return lift(Signal.withLatest)(samplee)
 	}
 
 	/// Forwards events from `self` until `lifetime` ends, at which point the

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -827,7 +827,7 @@ extension SignalProducerProtocol {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func withLatest<U>(_ samplee: SignalProducer<U, NoError>) -> SignalProducer<(Value, U), Error> {
+	public func withLatest<U>(from samplee: SignalProducer<U, NoError>) -> SignalProducer<(Value, U), Error> {
 		return liftRight(Signal.withLatest)(samplee)
 	}
 
@@ -846,7 +846,7 @@ extension SignalProducerProtocol {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func withLatest<U>(_ samplee: Signal<U, NoError>) -> SignalProducer<(Value, U), Error> {
+	public func withLatest<U>(from samplee: Signal<U, NoError>) -> SignalProducer<(Value, U), Error> {
 		return lift(Signal.withLatest)(samplee)
 	}
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -812,6 +812,42 @@ extension SignalProducerProtocol {
 		return lift(Signal.sample(on:))(sampler)
 	}
 
+	/// Forward the latest value from `samplee` with the value from `self` as a
+	/// tuple, only when `self` sends a `value` event.
+	/// This is like a flipped version of `sample(with:)` and Rx's `withLatestFrom`.
+	///
+	/// - note: If `self` fires before a value has been observed on `samplee`,
+	///         nothing happens.
+	///
+	/// - parameters:
+	///   - samplee: A producer that its latest value is sampled by `self`.
+	///
+	/// - returns: A signal that will send values from `self` and `samplee`,
+	///            sampled (possibly multiple times) by `self`, then terminate
+	///            once `self` has terminated. **`samplee`'s terminated events
+	///            are ignored**.
+	public func sample<U>(from samplee: SignalProducer<U, NoError>) -> SignalProducer<(Value, U), Error> {
+		return liftRight(Signal.sample(from:))(samplee)
+	}
+
+	/// Forward the latest value from `samplee` with the value from `self` as a
+	/// tuple, only when `self` sends a `value` event.
+	/// This is like a flipped version of `sample(with:)` and Rx's `withLatestFrom`.
+	///
+	/// - note: If `self` fires before a value has been observed on `samplee`,
+	///         nothing happens.
+	///
+	/// - parameters:
+	///   - samplee: A signal that its latest value is sampled by `self`.
+	///
+	/// - returns: A signal that will send values from `self` and `samplee`,
+	///            sampled (possibly multiple times) by `self`, then terminate
+	///            once `self` has terminated. **`samplee`'s terminated events
+	///            are ignored**.
+	public func sample<U>(from samplee: Signal<U, NoError>) -> SignalProducer<(Value, U), Error> {
+		return lift(Signal.sample(from:))(samplee)
+	}
+
 	/// Forwards events from `self` until `lifetime` ends, at which point the
 	/// returned producer will complete.
 	///

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -821,7 +821,7 @@ extension SignalProducerProtocol {
 	///         nothing happens.
 	///
 	/// - parameters:
-	///   - samplee: A producer that its latest value is sampled by `self`.
+	///   - samplee: A producer whose latest value is sampled by `self`.
 	///
 	/// - returns: A signal that will send values from `self` and `samplee`,
 	///            sampled (possibly multiple times) by `self`, then terminate
@@ -840,7 +840,7 @@ extension SignalProducerProtocol {
 	///         nothing happens.
 	///
 	/// - parameters:
-	///   - samplee: A signal that its latest value is sampled by `self`.
+	///   - samplee: A signal whose latest value is sampled by `self`.
 	///
 	/// - returns: A signal that will send values from `self` and `samplee`,
 	///            sampled (possibly multiple times) by `self`, then terminate

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -1114,7 +1114,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			}
 		}
 
-		describe("withLatest(signal)") {
+		describe("withLatest(from: signal)") {
 			var withLatestProducer: SignalProducer<(Int, String), NoError>!
 			var observer: Signal<Int, NoError>.Observer!
 			var sampleeObserver: Signal<String, NoError>.Observer!
@@ -1122,7 +1122,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			beforeEach {
 				let (producer, incomingObserver) = SignalProducer<Int, NoError>.pipe()
 				let (samplee, incomingSampleeObserver) = Signal<String, NoError>.pipe()
-				withLatestProducer = producer.withLatest(samplee)
+				withLatestProducer = producer.withLatest(from: samplee)
 				observer = incomingObserver
 				sampleeObserver = incomingSampleeObserver
 			}
@@ -1180,7 +1180,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			}
 		}
 
-		describe("withLatest(producer)") {
+		describe("withLatest(from: producer)") {
 			var withLatestProducer: SignalProducer<(Int, String), NoError>!
 			var observer: Signal<Int, NoError>.Observer!
 			var sampleeObserver: Signal<String, NoError>.Observer!
@@ -1188,7 +1188,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			beforeEach {
 				let (producer, incomingObserver) = SignalProducer<Int, NoError>.pipe()
 				let (samplee, incomingSampleeObserver) = SignalProducer<String, NoError>.pipe()
-				withLatestProducer = producer.withLatest(samplee)
+				withLatestProducer = producer.withLatest(from: samplee)
 				observer = incomingObserver
 				sampleeObserver = incomingSampleeObserver
 			}

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -1628,7 +1628,7 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
-		describe("withLatest(signal)") {
+		describe("withLatest(from: signal)") {
 			var withLatestSignal: Signal<(Int, String), NoError>!
 			var observer: Signal<Int, NoError>.Observer!
 			var sampleeObserver: Signal<String, NoError>.Observer!
@@ -1636,7 +1636,7 @@ class SignalSpec: QuickSpec {
 			beforeEach {
 				let (signal, incomingObserver) = Signal<Int, NoError>.pipe()
 				let (samplee, incomingSampleeObserver) = Signal<String, NoError>.pipe()
-				withLatestSignal = signal.withLatest(samplee)
+				withLatestSignal = signal.withLatest(from: samplee)
 				observer = incomingObserver
 				sampleeObserver = incomingSampleeObserver
 			}
@@ -1697,7 +1697,7 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
-		describe("withLatest(producer)") {
+		describe("withLatest(from: producer)") {
 			var withLatestSignal: Signal<(Int, String), NoError>!
 			var observer: Signal<Int, NoError>.Observer!
 			var sampleeObserver: Signal<String, NoError>.Observer!
@@ -1705,7 +1705,7 @@ class SignalSpec: QuickSpec {
 			beforeEach {
 				let (signal, incomingObserver) = Signal<Int, NoError>.pipe()
 				let (samplee, incomingSampleeObserver) = SignalProducer<String, NoError>.pipe()
-				withLatestSignal = signal.withLatest(samplee)
+				withLatestSignal = signal.withLatest(from: samplee)
 				observer = incomingObserver
 				sampleeObserver = incomingSampleeObserver
 			}

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -1628,6 +1628,141 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
+		describe("withLatest(signal)") {
+			var withLatestSignal: Signal<(Int, String), NoError>!
+			var observer: Signal<Int, NoError>.Observer!
+			var sampleeObserver: Signal<String, NoError>.Observer!
+
+			beforeEach {
+				let (signal, incomingObserver) = Signal<Int, NoError>.pipe()
+				let (samplee, incomingSampleeObserver) = Signal<String, NoError>.pipe()
+				withLatestSignal = signal.withLatest(samplee)
+				observer = incomingObserver
+				sampleeObserver = incomingSampleeObserver
+			}
+
+			it("should forward the latest value when the receiver fires") {
+				var result: [String] = []
+				withLatestSignal.observeValues { (left, right) in result.append("\(left)\(right)") }
+
+				sampleeObserver.send(value: "a")
+				sampleeObserver.send(value: "b")
+				observer.send(value: 1)
+				expect(result) == [ "1b" ]
+			}
+
+			it("should do nothing if receiver fires before samplee sends value") {
+				var result: [String] = []
+				withLatestSignal.observeValues { (left, right) in result.append("\(left)\(right)") }
+
+				observer.send(value: 1)
+				expect(result).to(beEmpty())
+			}
+
+			it("should send latest value with samplee value multiple times when receiver fires multiple times") {
+				var result: [String] = []
+				withLatestSignal.observeValues { (left, right) in result.append("\(left)\(right)") }
+
+				sampleeObserver.send(value: "a")
+				observer.send(value: 1)
+				observer.send(value: 2)
+				expect(result) == [ "1a", "2a" ]
+			}
+
+			it("should complete when receiver has completed") {
+				var completed = false
+				withLatestSignal.observeCompleted { completed = true }
+
+				sampleeObserver.sendCompleted()
+				expect(completed) == false
+
+				observer.sendCompleted()
+				expect(completed) == true
+			}
+
+			it("should not affect when samplee has completed") {
+				var event: Event<(Int, String), NoError>? = nil
+				withLatestSignal.observe { event = $0 }
+
+				sampleeObserver.sendCompleted()
+				expect(event).to(beNil())
+			}
+
+			it("should not affect when samplee has interrupted") {
+				var event: Event<(Int, String), NoError>? = nil
+				withLatestSignal.observe { event = $0 }
+
+				sampleeObserver.sendInterrupted()
+				expect(event).to(beNil())
+			}
+		}
+
+		describe("withLatest(producer)") {
+			var withLatestSignal: Signal<(Int, String), NoError>!
+			var observer: Signal<Int, NoError>.Observer!
+			var sampleeObserver: Signal<String, NoError>.Observer!
+
+			beforeEach {
+				let (signal, incomingObserver) = Signal<Int, NoError>.pipe()
+				let (samplee, incomingSampleeObserver) = SignalProducer<String, NoError>.pipe()
+				withLatestSignal = signal.withLatest(samplee)
+				observer = incomingObserver
+				sampleeObserver = incomingSampleeObserver
+			}
+
+			it("should forward the latest value when the receiver fires") {
+				var result: [String] = []
+				withLatestSignal.observeValues { (left, right) in result.append("\(left)\(right)") }
+
+				sampleeObserver.send(value: "a")
+				sampleeObserver.send(value: "b")
+				observer.send(value: 1)
+				expect(result) == [ "1b" ]
+			}
+
+			it("should do nothing if receiver fires before samplee sends value") {
+				var result: [String] = []
+				withLatestSignal.observeValues { (left, right) in result.append("\(left)\(right)") }
+
+				observer.send(value: 1)
+				expect(result).to(beEmpty())
+			}
+
+			it("should send latest value with samplee value multiple times when receiver fires multiple times") {
+				var result: [String] = []
+				withLatestSignal.observeValues { (left, right) in result.append("\(left)\(right)") }
+
+				sampleeObserver.send(value: "a")
+				observer.send(value: 1)
+				observer.send(value: 2)
+				expect(result) == [ "1a", "2a" ]
+			}
+
+			it("should complete when receiver has completed") {
+				var completed = false
+				withLatestSignal.observeCompleted { completed = true }
+
+				observer.sendCompleted()
+				expect(completed) == true
+			}
+
+			it("should not affect when samplee has completed") {
+				var event: Event<(Int, String), NoError>? = nil
+				withLatestSignal.observe { event = $0 }
+
+				sampleeObserver.sendCompleted()
+				expect(event).to(beNil())
+			}
+
+			it("should not affect when samplee has interrupted") {
+				var event: Event<(Int, String), NoError>? = nil
+				withLatestSignal.observe { event = $0 }
+
+				sampleeObserver.sendInterrupted()
+				expect(event).to(beNil())
+			}
+		}
+
 		describe("combineLatestWith") {
 			var combinedSignal: Signal<(Int, Double), NoError>!
 			var observer: Signal<Int, NoError>.Observer!


### PR DESCRIPTION
This PR is RAC port of `Rx.withLatestFrom` (namely, `sample(from:)`) with `samplee`'s error type constrained to `NoError` only.

Diagram: http://rxmarbles.com/#withLatestFrom

This was originally discussed in https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2082 (not accepted), but I found this operator very useful because it is easy to fetch current state (`MutableProperty`) via `sourceSignal`:

```swift
let state: MutableProperty<String> = ...

sourceSignal
    .sample(from: state.producer)
    .observeValues { sourceValue, currentState in ... }
```

Above code is much easier to read compared to:

```swift
sourceSignal
    .map { [unowned state] sourceValue in (sourceValue, state.value) }
    .observeValues { sourceValue, currentState in ... }
```

or:

```swift
state.producer
    .sample(with: sourceSignal)
    .observeValues { currentState, sourceValue in ... }
// receiver is flipped, and hard to understand which signal is the source of this whole chaining
```

Please note that `sample(from:)` is NOT actually a flipped version of `sample(with:)` since it discards `samplee`'s any terminal events.
For `.completed` handling, this behavior is same as `Rx.withLatestFrom` (and is often easy to use).

---

The code is originally from: https://github.com/inamiy/ReactiveAutomaton/blob/28027a656b923008f34089c739e51cdbe13b65cb/Sources/ReactiveCocoa%2BSampleFrom.swift
