### PR TITLE
`Signal` lock elision.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. `Signal` operators now elide locks where applicable. (#129) 
+
 1. N-ary `SignalProducer` operators are now generic and accept any type that can be expressed as `SignalProducer`. (#410, kudos to @andersio)
    Types may conform to `SignalProducerConvertible` to be an eligible operand.
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -635,7 +635,7 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 	/// - parameters:
 	///   - initialValue: Starting value for the mutable property.
 	public init(_ initialValue: Value) {
-		(signal, observer) = Signal.pipe()
+		(signal, observer) = Signal.pipe(attributes: .nonatomic)
 		token = Lifetime.Token()
 		lifetime = Lifetime(token)
 


### PR DESCRIPTION
While we advocate for a safe-by-default API like how our beloved Swift does, there are places we may elide the serialization:

1. **Synchronously `Signal` operators. e.g. `map`, `filter`, `scan`, `skipNil`.**

    These can rely on the serialization at the ultimate upstream, e.g. signals created by `Signal.init` or `Signal.pipe` with default settings.

    An illustration of how the call stack would look like with `signal.map(t).map(t).map(t).map(t)...`:
    ```
    sendLock
    observers ---> [sendLock]
                   observers    ---> [sendLock]
                                     observers    ---> [sendLock]
                                                       observers    ---> ...
                                                       [unlock]
                                     [unlock] <---/
                   [unlock] <---/
    unlock    <---/
    ```

2. **Asynchronous `Signal` operators which deliver all kinds of events on the same `Scheduler`.**

    For example, `observe(on:)` forwards **all** the events to the supplied `Scheduler`. Since the scheduler serialises all the enqueued actions, there is no need for the created signal to serialise the events again.

2. **`Signal`s that are owned by synchronized entities.**

    For entities that are already synchronised, `Signal` can safely assume events not to be emitted concurrently. For example, `MutableProperty` always sends event in its critical section.

#### Implementation

The PR introduces an optional parameter `attributes` to `Signal.init` and `Signal.pipe` that allows configurability of some of the `Signal` behavior.

For the purpose of the PR, a `inheritSerialization` option was introduced. `Signal`s created with this flag would not attempt to serialise the inputs it received.