### PR TITLE
Only build pushes to master and PRs on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ before_install: true
 install: true
 git:
   submodules: false
+branches:
+  only:
+    - master
 before_script:
   - git submodule update --init --recursive
 script:


### PR DESCRIPTION
Every push to a PR currently triggers two builds on CI, which is pretty wasteful (not to mention slow). Hoping this cuts down on the duplication. *fingers crossed*