### PR TITLE
BindingSourceProtocol

### DIFF
--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -5,7 +5,7 @@ import enum Result.NoError
 ///
 /// Only classes can conform to this protocol, because having a signal
 /// for changes over time implies the origin must have a unique identity.
-public protocol PropertyProtocol: class {
+public protocol PropertyProtocol: class, BindingSourceProtocol {
 	associatedtype Value
 
 	/// The current value of the property.
@@ -22,6 +22,13 @@ public protocol PropertyProtocol: class {
 	/// completes when the property has deinitialized, or has no further
 	/// change.
 	var signal: Signal<Value, NoError> { get }
+}
+
+extension PropertyProtocol {
+	@discardableResult
+	public func observe(_ observer: Observer<Value, NoError>) -> Disposable? {
+		return producer.observe(observer)
+	}
 }
 
 /// Represents an observable property that can be mutated directly.

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -210,7 +210,7 @@ public final class Signal<Value, Error: Swift.Error> {
 	///   - observer: An observer to forward the events to.
 	///
 	/// - returns: A `Disposable` which can be used to disconnect the observer,
-	///            or `nil` if the signal has already completed.
+	///            or `nil` if the signal has already terminated.
 	@discardableResult
 	public func observe(_ observer: Observer) -> Disposable? {
 		var token: RemovalToken?

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -209,8 +209,8 @@ public final class Signal<Value, Error: Swift.Error> {
 	/// - parameters:
 	///   - observer: An observer to forward the events to.
 	///
-	/// - returns: An optional `Disposable` which can be used to disconnect the
-	///            observer.
+	/// - returns: A `Disposable` which can be used to disconnect the observer,
+	///            or `nil` if the signal has already completed.
 	@discardableResult
 	public func observe(_ observer: Observer) -> Disposable? {
 		var token: RemovalToken?

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -16,7 +16,7 @@ public protocol BindingSourceProtocol {
 	associatedtype Value
 	associatedtype Error: Swift.Error
 	
-	/// Observe the binding source by sending any evenst to the given observer.
+	/// Observe the binding source by sending any events to the given observer.
 	@discardableResult
 	func observe(_ observer: Observer<Value, Error>) -> Disposable?
 }
@@ -49,11 +49,11 @@ public protocol BindingTargetProtocol: class {
 	func consume(_ value: Value)
 }
 
-/// Binds a signal to a target, updating the target's value to the latest
-/// value sent by the signal.
+/// Binds a source to a target, updating the target's value to the latest
+/// value sent by the source.
 ///
 /// - note: The binding will automatically terminate when the target is
-///         deinitialized, or when the signal sends a `completed` event.
+///         deinitialized, or when the source sends a `completed` event.
 ///
 /// ````
 /// let property = MutableProperty(0)
@@ -73,10 +73,10 @@ public protocol BindingTargetProtocol: class {
 ///
 /// - parameters:
 ///   - target: A target to be bond to.
-///   - signal: A signal to bind.
+///   - source: A source to bind.
 ///
 /// - returns: A disposable that can be used to terminate binding before the
-///            deinitialization of the target or the signal's `completed`
+///            deinitialization of the target or the source's `completed`
 ///            event.
 @discardableResult
 public func <~
@@ -92,10 +92,10 @@ public func <~
 }
 
 /// Binds a source to a target, updating the target's value to the latest
-/// value sent by the signal.
+/// value sent by the source.
 ///
 /// - note: The binding will automatically terminate when the target is
-///         deinitialized, or when the signal sends a `completed` event.
+///         deinitialized, or when the source sends a `completed` event.
 ///
 /// ````
 /// let property = MutableProperty(0)
@@ -115,10 +115,10 @@ public func <~
 ///
 /// - parameters:
 ///   - target: A target to be bond to.
-///   - signal: A signal to bind.
+///   - source: A source to bind.
 ///
 /// - returns: A disposable that can be used to terminate binding before the
-///            deinitialization of the target or the signal's `completed`
+///            deinitialization of the target or the source's `completed`
 ///            event.
 @discardableResult
 public func <~

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -16,6 +16,7 @@ public protocol BindingSourceProtocol {
 	associatedtype Value
 	associatedtype Error: Swift.Error
 	
+	/// Observe the binding source by sending any evenst to the given observer.
 	@discardableResult
 	func observe(_ observer: Observer<Value, Error>) -> Disposable?
 }

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -42,7 +42,7 @@ public protocol BindingTargetProtocol: class {
 	associatedtype Value
 
 	/// The lifetime of `self`. The binding operators use this to determine when
-	/// the binding should be teared down.
+	/// the binding should be torn down.
 	var lifetime: Lifetime { get }
 
 	/// Consume a value from the binding.

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -167,5 +167,3 @@ public final class BindingTarget<Value>: BindingTargetProtocol {
 		setter(value)
 	}
 }
-
-private let specificKey = DispatchSpecificKey<ObjectIdentifier>()

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -1554,7 +1554,7 @@ class PropertySpec: QuickSpec {
 					let mutableProperty = MutableProperty(initialPropertyValue)
 					let disposable = mutableProperty <~ signalProducer
 
-					disposable.dispose()
+					disposable?.dispose()
 
 					observer.send(value: subsequentPropertyValue)
 					expect(mutableProperty.value) == initialPropertyValue
@@ -1603,7 +1603,7 @@ class PropertySpec: QuickSpec {
 					let destinationProperty = MutableProperty("")
 
 					let bindingDisposable = destinationProperty <~ sourceProperty.producer
-					bindingDisposable.dispose()
+					bindingDisposable?.dispose()
 
 					sourceProperty.value = subsequentPropertyValue
 

--- a/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
+++ b/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
@@ -23,6 +23,20 @@ class UnidirectionalBindingSpec: QuickSpec {
 			it("should pass through the lifetime") {
 				expect(target.lifetime).to(beIdenticalTo(lifetime))
 			}
+			
+			it("should stay bound after deallocation") {
+				weak var weakTarget = target
+				
+				let property = MutableProperty(1)
+				target <~ property
+				expect(value) == 1
+				
+				target = nil
+				
+				property.value = 2
+				expect(value) == 2
+				expect(weakTarget).to(beNil())
+			}
 
 			it("should trigger the supplied setter") {
 				expect(value).to(beNil())


### PR DESCRIPTION
The idea here is to eliminate redundancy in things like https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3289.

By adding a `BindingSourceProtocol` type, both ends of `<~` become generic. That makes it easier to add conformance on either end.

This could also be called `Observable`—if we want to make it some more generic.

I'm curious what people think of this approach.