### PR TITLE
Failing Test Case: Delayed `Lifetime` deinit deadlocking `sendLock`. (#137)

### DIFF
--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -265,6 +265,39 @@ class PropertySpec: QuickSpec {
 				property = nil
 				expect(isEnded) == true
 			}
+
+			it("should not deadlock") {
+				let queue: DispatchQueue
+
+				if #available(macOS 10.10, *) {
+					queue = DispatchQueue.global(qos: .userInitiated)
+				} else {
+					queue = DispatchQueue.global(priority: .high)
+				}
+
+				let group = DispatchGroup()
+
+				DispatchQueue.concurrentPerform(iterations: 500) { _ in
+					let source = MutableProperty(1)
+					var target = Optional(MutableProperty(1))
+
+					let semaphore = DispatchSemaphore(value: 0)
+
+					target! <~ source
+
+					queue.async(group: group) {
+						semaphore.wait()
+						target = nil
+					}
+
+					queue.async(group: group) {
+						semaphore.signal()
+						source.value = 2
+					}
+				}
+
+				group.wait()
+			}
 		}
 
 		describe("Property") {


### PR DESCRIPTION
Related issue: #135 

#### Cause
1. A strong release atomically drops the refCount to 0. But deinitialization does not start right away.
2. A weak retain - the binding's observer closure in this case - manages to increment the refCount before the strong release flags the object as deallocating.
3. The deinitialization is thus delayed until exiting the scope of the observer closure, i.e. within the `sendLock`.

#### What's affected?
Everything in the following pattern:
```swift
signal
    .take(during: object.lifetime)
    .observeValues { [weak object] _ in }
```

#### Note
The test case would not fail in a uniprocessor environment.

#### Possible Solution
Allowing `completed` to be recursively sent like `interrupted` seems the only way, since:
1. We have no `autoreleasepool` for Swift objects.
2. The order cannot be controlled.