### PR TITLE
Allow all termination events to be recursively sent.

### DIFF
--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -52,7 +52,6 @@ public final class Signal<Value, Error: Swift.Error> {
 		let sendLock = NSLock()
 		sendLock.name = "org.reactivecocoa.ReactiveSwift.Signal"
 
-		@inline(__always)
 		func terminate(with state: SignalTerminationState<Value, Error>) {
 			state.send()
 			terminated = true
@@ -257,7 +256,6 @@ private final class SignalTerminationState<Value, Error: Swift.Error> {
 	}
 
 	/// Send the termination event to the observers.
-	@inline(__always)
 	func send() {
 		for observer in state.observers {
 			observer.action(event)

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -73,26 +73,30 @@ public final class Signal<Value, Error: Swift.Error> {
 			//
 			//   Read directly.
 			//
-			// - Deliver `value` events in the `alive` state.
+			// - Deliver `value` events with the alive state.
 			//
 			//   `sendLock` must be acquired.
 			//
-			// - Replace the snapshot of a signal that is alive.
+			// - Replace the alive state with another.
 			//   (e.g. observers bag manipulation)
 			//
 			//   `updateLock` must be acquired.
 			//
-			// - Transition from `alive` to `terminating`.
+			// - Transition from `alive` to `terminating` as a result of receiving
+			//   a termination event.
 			//
-			//   `updateLock` must be acquired.
+			//   `updateLock` must be acquired, and should fail gracefully if the
+			//   signal has terminated.
 			//
-			// - Deliver the termination event in the `terminating` state, and
-			//   transition from `terminating` to `terminated`.
+			// - Check if the signal is terminating, and transition from `terminating`
+			//   to `terminated` if it is. Deliver the termination event after the
+			//   transitioning.
 			//
-			//   Both `sendLock` and `updateLock` must be acquired. The state must
-			//   also be checked again after the locks are acquired. Fail gracefully
-			//   if the state has changed since the relaxed read, i.e. a concurrent
-			//   sender has already handled the termination event.
+			//   Both `sendLock` and `updateLock` must be acquired. The check can be
+			//   relaxed, but the state must be checked again after the locks are
+			//   acquired. Fail gracefully if the state has changed since the relaxed
+			//   read, i.e. a concurrent sender has already handled the termination
+			//   event.
 			//
 			// Exploiting the relaxation of reads, please note that false positives
 			// are intentionally allowed in the `terminating` checks below. As a

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -68,8 +68,8 @@ public final class Signal<Value, Error: Swift.Error> {
 				// for termination events. Specifically:
 				//
 				// `interrupted`
-				// It is kind of a special snowflake, as it can inadvertently be sent by
-				// downstream consumers as part of the `SignalProducer` mechanics.
+				// It can inadvertently be sent by downstream consumers as part of the
+				// `SignalProducer` mechanics.
 				//
 				// `completed`
 				// If a downstream consumer weakly references an object, invocation of
@@ -83,8 +83,7 @@ public final class Signal<Value, Error: Swift.Error> {
 				// the disposal would be delegated to the current sender, or
 				// occasionally one of the senders waiting on `sendLock`.
 				if let state = signal.state.swap(nil) {
-					terminationState = SignalTerminationState(state: state,
-					                                          event: event)
+					terminationState = SignalTerminationState(state: state, event: event)
 
 					// Writes to `terminationState` are implicitly synchronized. So we do
 					// not need to guard it with locks.

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -270,7 +270,7 @@ class PropertySpec: QuickSpec {
 				let queue: DispatchQueue
 
 				if #available(macOS 10.10, *) {
-					queue = DispatchQueue.global(qos: .userInitiated)
+					queue = DispatchQueue.global(qos: .userInteractive)
 				} else {
 					queue = DispatchQueue.global(priority: .high)
 				}

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -265,6 +265,39 @@ class PropertySpec: QuickSpec {
 				property = nil
 				expect(isEnded) == true
 			}
+
+			it("should not deadlock") {
+				let queue: DispatchQueue
+
+				if #available(macOS 10.10, *) {
+					queue = DispatchQueue.global(qos: .userInitiated)
+				} else {
+					queue = DispatchQueue.global(priority: .high)
+				}
+
+				let group = DispatchGroup()
+
+				DispatchQueue.concurrentPerform(iterations: 500) { _ in
+					let source = MutableProperty(1)
+					var target = Optional(MutableProperty(1))
+
+					let semaphore = DispatchSemaphore(value: 0)
+
+					target! <~ source
+
+					queue.async(group: group) {
+						semaphore.wait()
+						target = nil
+					}
+
+					queue.async(group: group) {
+						semaphore.signal()
+						source.value = 2
+					}
+				}
+
+				group.wait()
+			}
 		}
 
 		describe("Property") {

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-
+import Dispatch
 import Result
 import Nimble
 import Quick


### PR DESCRIPTION
Fixes #135 and #136.

As described in #136, and demonstrated by [the test case](https://github.com/ReactiveCocoa/ReactiveSwift/pull/137/commits/2d239c50e1b97b95874f5c52e9cdc43a5d11a299):
> 1. A strong release atomically drops the refCount to 0. But deinitialization does not start right away.
> 2. A weak retain - the binding's observer closure in this case - manages to increment the refCount before the strong release flags the object as deallocating.
> 3. The deinitialization is thus delayed until exiting the scope of the observer closure, i.e. within the sendLock.

In the context of binding:
```swift
signal
    .take(during: target.lifetime)
    .observeValues { [weak target] value in
        target?.consume(value)
    }
```

```
             Thread 1             |            Thread 2            
----------------------------------|--------------------------------
  1. Received new `value` event.  |
                                  |
  2. Acquired `sendLock`.         |
                                  |
                                  | 3. `swift_release` on `target`.
                                  |    Decrement refCount to 0.
  4. `swift_weakLoadStrong`       |
     on `target`.                 |
     Increment refCount to 1.     |
                                  |     
  5a. Invoke `consume`.           | 5b. CAS to mark deallocating
                                  |     flag failed
                                  |
  6. `swift_release`              | (Deinit of `target` is supposed
     Decrement refCount to 0.     |  to run on this thread, but
                                  |  Thread 1 has stolen it due to
  7. CAS to mark deallocating     |  the weak retain having won the
     Flag succeeded.              |  race.)
                                  |
  8. `target` starts deinit.      |
     `Lifetime.init` sends        |
     `completed`.                 |
                                  |
  9. Upstream `take(until:)`      |
     gets `completed`, and forward|
     it to the downstream.        |
                                  |
  10. Try to acquire `sendLock`,  |
      but it is held by (2).      |
      Deadlock.                   |
```


So the only solution - except using a recursive lock or going asynchronous - is to handle `completed` like `interrupted`. `failed` do not need this behavior (yet?), but it is more convenient to implement it for all termination events. Can be reverted if this feels an unpleasant change.