### PR TITLE
Wait-free observers bag for `Signal`.

### DIFF
--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -52,7 +52,6 @@ public final class Signal<Value, Error: Swift.Error> {
 		let sendLock = NSLock()
 		sendLock.name = "org.reactivecocoa.ReactiveSwift.Signal"
 
-		@inline(__always)
 		func terminate(with state: SignalTerminationState<Value, Error>) {
 			state.send()
 			terminated = true
@@ -257,7 +256,6 @@ private final class SignalTerminationState<Value, Error: Swift.Error> {
 	}
 
 	/// Send the termination event to the observers.
-	@inline(__always)
 	func send() {
 		for observer in state.observers {
 			observer.action(event)

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -68,8 +68,8 @@ public final class Signal<Value, Error: Swift.Error> {
 				// for termination events. Specifically:
 				//
 				// `interrupted`
-				// It is kind of a special snowflake, as it can inadvertently be sent by
-				// downstream consumers as part of the `SignalProducer` mechanics.
+				// It can inadvertently be sent by downstream consumers as part of the
+				// `SignalProducer` mechanics.
 				//
 				// `completed`
 				// If a downstream consumer weakly references an object, invocation of
@@ -83,8 +83,7 @@ public final class Signal<Value, Error: Swift.Error> {
 				// the disposal would be delegated to the current sender, or
 				// occasionally one of the senders waiting on `sendLock`.
 				if let state = signal.state.swap(nil) {
-					terminationState = SignalTerminationState(state: state,
-					                                          event: event)
+					terminationState = SignalTerminationState(state: state, event: event)
 
 					// Writes to `terminationState` are implicitly synchronized. So we do
 					// not need to guard it with locks.

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -265,6 +265,39 @@ class PropertySpec: QuickSpec {
 				property = nil
 				expect(isEnded) == true
 			}
+
+			it("should not deadlock") {
+				let queue: DispatchQueue
+
+				if #available(macOS 10.10, *) {
+					queue = DispatchQueue.global(qos: .userInitiated)
+				} else {
+					queue = DispatchQueue.global(priority: .high)
+				}
+
+				let group = DispatchGroup()
+
+				DispatchQueue.concurrentPerform(iterations: 500) { _ in
+					let source = MutableProperty(1)
+					var target = Optional(MutableProperty(1))
+
+					let semaphore = DispatchSemaphore(value: 0)
+
+					target! <~ source
+
+					queue.async(group: group) {
+						semaphore.wait()
+						target = nil
+					}
+
+					queue.async(group: group) {
+						semaphore.signal()
+						source.value = 2
+					}
+				}
+
+				group.wait()
+			}
 		}
 
 		describe("Property") {

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-
+import Dispatch
 import Result
 import Nimble
 import Quick


### PR DESCRIPTION
1. Grabbing the observers is now wait-free, at the cost of insertion and removal of observers being more expensive. (Read-Copy-Update)
2. ~~Optimization for one-observer `Signal`s. (esp in `SignalProducer`)~~ _Gonna leave it for later._

#### Implementation note
Unless user explicitly synchronises the input and the removal of an observer, removing an observer would not free the observer from receiving events in a concurrent environment _immediately_, but only _eventually_. This has been the case since 3.x, since concurrent senders all grab a copy of the observer bag.

[Benchmark Source (A ported test from CwlSignal)](https://gist.github.com/andersio/70ded6fb313df4ebeed19e98b50ea77a)
i5 4258U, macOS 10.12.1, Xcode 8.1, `-Owholemodule`.

`master`
```
AsyncMap
Performance is 9.032114933 seconds versus expected 3.3. Rate is 110716.040198555 per second.

SingleSignal
Performance is 8.795302343 seconds versus expected 3.0. Rate is 1136970.57929553 per second.
```

`master` + Read Copy Update
```
AsyncMap
Performance is 6.655907553 seconds versus expected 3.3. Rate is 150242.471374061 per second.
SingleSignal
Performance is 5.766949619 seconds versus expected 3.0. Rate is 1734018.96334479 per second.
```