### PR TITLE
Release Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 🎉 [Getting Started](#getting-started)
 ⚠️ [Still using Swift 2.x?][]
 
+
+🚄 [Release Roadmap](#release-roadmap)
 ## What is ReactiveSwift?
 __ReactiveSwift__ offers composable, declarative and flexible primitives that are built around the grand concept of ___streams of values over time___. These primitives can be used to uniformly represent common Cocoa and generic programming patterns that are fundamentally an act of observation, e.g.:
 
@@ -331,6 +333,38 @@ We also provide a great Playground, so you can get used to ReactiveCocoa's opera
  
 ## Have a question?
 If you need any help, please visit our [GitHub issues][] or [Stack Overflow][]. Feel free to file an issue if you do not manage to find any solution from the archives.
+
+## Release Roadmap
+**Current Stable Release:**<br />[![GitHub release](https://img.shields.io/github/release/ReactiveCocoa/ReactiveSwift.svg)](https://github.com/ReactiveCocoa/ReactiveSwift/releases)
+
+### In Development: ReactiveSwift 1.0
+It targets Swift 3.0.x. The tentative schedule of a Gold Master release is January 2017.
+
+A Release Candidate would be released after an important bug fix and an API renaming PR are cleared, which should happen no later than Christmas 2016.
+
+A point release is expected with performance optimizations.
+
+### Plan of Record
+#### ReactiveSwift 2.0
+It targets Swift 3.1.x. The estimated schedule is Spring 2017.
+
+The release contains breaking changes. But they are not expected to affect the general mass of users, but only a few specific use cases.
+
+The primary goal of ReactiveSwift 2.0 is to remove single-implementation protocols, e.g. `SignalProtocol`, `SignalProducerProtocol`, that serve as a workaround to **concrete same-type requirements**.
+
+ReactiveSwift 2.0 may include other proposed breaking changes.
+
+As resilience would be enforced in Swift 4.0, it is important for us to have a clean and steady API to start with. The expectation is to **have the API cleanup and the reviewing to be concluded in ReactiveSwift 2.0**, before we move on to ReactiveSwift 3.0 and Swift 4.0. Any contribution to help realising this goal is welcomed.
+
+#### ReactiveSwift 3.0
+It targets Swift 4.0.x. The estimated schedule is late 2017.
+
+The release may contain breaking changes, depending on what features are being delivered by Swift 4.0.
+
+ReactiveSwift 3.0 would focus on two main goals:
+
+1. Swift 4.0 Resilience
+2. Adapt to new features introduced in Swift 4.0 Phase 2.
 
 [ReactiveCocoa]: https://github.com/ReactiveCocoa/ReactiveCocoa/#readme
 [Actions]: Documentation/FrameworkOverview.md#actions


### PR DESCRIPTION
Per the discussion with @mdiep, here is a tentative plan on 1.0 Gold Master, and two subsequent major releases (2.0/3.0) for Swift 3.1 and Swift 4.0.

Hopefully this would help communicate the major development goals of ReactiveSwift towards Swift 4.0, and help depending libraries and users with time constraints planning adoptions/migrations ahead.

:shipit: 

Any comment is appreciated!

/cc @ReactiveCocoa/reactiveswift 