### PR TITLE
Automated documentation generation via CI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Packages
 
 # Carthage
 Carthage/Build
+
+# Jazzy
+docs

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -93,4 +93,3 @@ xcodebuild_arguments:
 author: ReactiveCocoa
 author_url: https://reactivecocoa.io/
 github_url: https://github.com/ReactiveCocoa/ReactiveSwift/
-dash_url: https://reactivecocoa.io/feeds/ReactiveSwift.xml

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,0 +1,96 @@
+custom_categories:
+  - name: Getting Started 
+    children:
+    - BasicOperators
+    - FrameworkOverview
+    - DebuggingTechniques
+  - name: Signal
+    children:
+    - Event
+    - EventProtocol
+    - Observer
+    - ObserverProtocol
+    - Signal
+    - SignalProtocol
+    - FlattenStrategy
+  - name: SignalProducer
+    children:
+    - SignalProducer
+    - SignalProducerProtocol
+    - timer(interval:on:)
+    - timer(interval:on:leeway:)
+  - name: Property
+    children:
+    - Property
+    - PropertyProtocol
+    - MutableProperty
+    - MutablePropertyProtocol
+  - name: Action
+    children:
+    - Action
+    - ActionError
+    - ActionProtocol
+  - name: Bindings
+    children:
+    - BindingSourceProtocol
+    - BindingTarget
+    - BindingTargetProtocol
+    - <~(_:_:)
+  - name: Schedulers
+    children:
+    - DateSchedulerProtocol
+    - ImmediateScheduler
+    - QueueScheduler
+    - SchedulerProtocol
+    - TestScheduler
+    - UIScheduler
+  - name: Reactive Extensions
+    children:
+    - Reactive
+    - ReactiveExtensionsProvider
+  - name: Lifetime
+    children:
+    - Lifetime
+  - name: Disposable
+    children:
+    - AnyDisposable
+    - ActionDisposable    
+    - Disposable
+    - CompositeDisposable
+    - ScopedDisposable 
+    - SerialDisposable
+    - SimpleDisposable
+    - +=(_:_:)
+  - name: Utilities 
+    children:
+    - Atomic
+    - AtomicProtocol
+    - Bag
+    - BagIterator
+    - RemovalToken
+    - EventLogger
+    - LoggingEvent
+    - Optional
+    - OptionalProtocol
+  - name: Documentations
+    children:
+    - DesignGuidelines
+    - DocumentingCode
+    - ReleaseProcess
+exclude:
+  - Documentation/ReleaseProcess.md
+  - Documentation/README.md
+theme: fullwidth 
+skip_undocumented: true
+readme: README.md
+documentation: Documentation/*
+hide_documentation_coverage: true
+xcodebuild_arguments:
+  - -workspace
+  - ReactiveSwift.xcworkspace
+  - -scheme
+  - ReactiveSwift-macOS
+author: ReactiveCocoa
+author_url: https://reactivecocoa.io/
+github_url: https://github.com/ReactiveCocoa/ReactiveSwift/
+dash_url: https://reactivecocoa.io/feeds/ReactiveSwift.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,12 @@ matrix:
         - swift build
         - swift test
       env: JOB=SWIFTPM_LINUX
+    - os: osx
+      language: generic
+      script:
+        - script/gen-docs
+      env:
+        - JOB=JAZZY_DOCS_GEN
 notifications:
   email: false
   slack:

--- a/Documentation/ReleaseProcess.md
+++ b/Documentation/ReleaseProcess.md
@@ -1,0 +1,9 @@
+## Release Process
+### All Releases
+1. Update the version number in ReactiveSwift.podspec, and commit to `master`.
+2. Create a GitHub release with the commit created in (1).
+3. Push the new Pod spec to the Pod Thunk.
+
+### Major and Point Releases with API changes
+3. Generate documentations using [Jazzy](https://github.com/realm/jazzy/).
+4. Open a PR in ReactiveCocoa.github.io. (TODO: Describe what needs to be changed.)

--- a/Documentation/ReleaseProcess.md
+++ b/Documentation/ReleaseProcess.md
@@ -1,9 +1,5 @@
 ## Release Process
-### All Releases
 1. Update the version number in ReactiveSwift.podspec, and commit to `master`.
-2. Create a GitHub release with the commit created in (1).
-3. Push the new Pod spec to the Pod Thunk.
-
-### Major and Point Releases with API changes
-3. Generate documentations using [Jazzy](https://github.com/realm/jazzy/).
-4. Open a PR in ReactiveCocoa.github.io. (TODO: Describe what needs to be changed.)
+1. Tag the commit, and fill in the release note.
+1. Push the new PodSpec to CocoaPods Trunk.
+1. Merge the documentation branch in ReactiveCocoa.github.io.

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -206,6 +206,7 @@ private struct ActionState {
 	}
 }
 
+/// A protocol used to constraint `Action` initializers.
 public protocol ActionProtocol: BindingTargetProtocol {
 	/// The type of argument to apply the action to.
 	associatedtype Input

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -247,6 +247,7 @@ internal final class RecursiveAtomic<Value>: AtomicProtocol {
 	}
 }
 
+/// A protocol used to constraint convenience `Atomic` methods and properties.
 public protocol AtomicProtocol: class {
 	associatedtype Value
 

--- a/Sources/Bag.swift
+++ b/Sources/Bag.swift
@@ -83,6 +83,7 @@ extension BagElement: CustomStringConvertible {
 	}
 }
 
+/// An iterator of `Bag`.
 public struct BagIterator<Element>: IteratorProtocol {
 	private let base: ContiguousArray<BagElement<Element>>
 	private var nextIndex: Int

--- a/Sources/Reactive.swift
+++ b/Sources/Reactive.swift
@@ -18,8 +18,9 @@ extension ReactiveExtensionsProvider {
 	}
 }
 
-// A `Reactive` proxy hosts reactive extensions to `Base`.
+/// A proxy which hosts reactive extensions of `Base`.
 public struct Reactive<Base> {
+	/// The `Base` instance the extensions would be invoked with.
 	public let base: Base
 
 	// Construct a proxy.

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -396,6 +396,7 @@ private final class TerminatingState<Value, Error: Swift.Error> {
 	}
 }
 
+/// A protocol used to constraint `Signal` operators.
 public protocol SignalProtocol {
 	/// The type of values being sent on the signal.
 	associatedtype Value

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -168,6 +168,7 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	}
 }
 
+/// A protocol used to constraint `SignalProducer` operators.
 public protocol SignalProducerProtocol {
 	/// The type of values being sent on the producer
 	associatedtype Value

--- a/script/gen-docs
+++ b/script/gen-docs
@@ -35,11 +35,13 @@ mkdir -p ./reactiveswift/docs/${TRAVIS_TAG}
 cp -r ../docs/. ./reactiveswift/docs/${TRAVIS_TAG}
 git add ./reactiveswift/docs/${TRAVIS_TAG}
 
-# Generate a new latest release redirect page.
-mkdir -p ./reactiveswift/docs/latest/
-/bin/cp -f ../script/latest-index.html.template ./reactiveswift/docs/latest/index.html
-sed -i.bak "s/{RELEASE_TAG}/${TRAVIS_TAG}/" reactiveswift/docs/latest/index.html
-git add reactiveswift/docs/latest/index.html
+# Ensure Jekyll is not running in `docs`.
+touch ./reactiveswift/docs/.nojekyll
+git add ./reactiveswift/docs/.nojekyll
+
+# Update the `latest` symlink.
+ln -sf ./reactiveswift/docs/{$TRAVIS_TAG}/ ./reactiveswift/docs/latest/
+git add ./reactiveswift/docs/latest/   
 
 # Commit and push to the fork.
 git commit -m "Documentation: ReactiveSwift ${TRAVIS_TAG}"

--- a/script/gen-docs
+++ b/script/gen-docs
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+if [[ -z "$TRAVIS_TAG" ]]; then
+    echo "Not a tag build. Abort."
+    exit 0
+fi
+
+echo "Documentation builder. The tag is \`${TRAVIS_TAG}\`."
+
+gem install jazzy
+jazzy
+
+if [[ $? -ne 0 ]]; then
+    echo "Jazzy has failed. Aborting the push."
+    exit 1
+fi
+
+brew install hub
+export GITHUB_TOKEN=${RAC_CIBOT_TOKEN}
+
+# Clone the master branch of the website.
+git clone -b master --depth 1 https://${RAC_CIBOT_TOKEN}@github.com/ReactiveCocoa/ReactiveCocoa.github.io.git RACSite
+cd ./RACSite
+
+# Fork the repo without fetching it.
+hub fork --no-remote
+git remote add cibot https://${RAC_CIBOT_TOKEN}@github.com/${RAC_CIBOT_USERNAME}/ReactiveCocoa.github.io.git 
+git checkout master
+
+# Create a new branch for the release.
+git checkout -b ras-${TRAVIS_TAG}
+
+# Copy the generated docs.
+mkdir -p ./reactiveswift/docs/${TRAVIS_TAG}
+cp -r ../docs/. ./reactiveswift/docs/${TRAVIS_TAG}
+git add ./reactiveswift/docs/${TRAVIS_TAG}
+
+# Generate a new latest release redirect page.
+mkdir -p ./reactiveswift/docs/latest/
+/bin/cp -f ../script/latest-index.html.template ./reactiveswift/docs/latest/index.html
+sed -i.bak "s/{RELEASE_TAG}/${TRAVIS_TAG}/" reactiveswift/docs/latest/index.html
+git add reactiveswift/docs/latest/index.html
+
+# Commit and push to the fork.
+git commit -m "Documentation: ReactiveSwift ${TRAVIS_TAG}"
+git push -u cibot ras-${TRAVIS_TAG}
+
+# Open a pull request in the main repo.
+hub pull-request -m "Documentation: ReactiveSwift ${TRAVIS_TAG}" -h "${RAC_CIBOT_USERNAME}:ras-${TRAVIS_TAG}"
+
+cd ..
+rm -rf ./RACSite

--- a/script/latest-index.html.template
+++ b/script/latest-index.html.template
@@ -1,0 +1,9 @@
+<html xmlns="http://www.w3.org/1999/xhtml">    
+	<head>      
+		<title>ReactiveSwift Documentation</title>      
+		<meta http-equiv="refresh" content="0;URL='http://reactivecocoa.io/reactiveswift/docs/{RELEASE_TAG}/'" />    
+	</head>
+	<body> 
+		If you have not been redirected, <a href="http://reactivecocoa.io/reactiveswift/docs/{RELEASE_TAG}/">click here</a>.
+	</body>
+</html>

--- a/script/latest-index.html.template
+++ b/script/latest-index.html.template
@@ -1,9 +1,0 @@
-<html xmlns="http://www.w3.org/1999/xhtml">    
-	<head>      
-		<title>ReactiveSwift Documentation</title>      
-		<meta http-equiv="refresh" content="0;URL='http://reactivecocoa.io/reactiveswift/docs/{RELEASE_TAG}/'" />    
-	</head>
-	<body> 
-		If you have not been redirected, <a href="http://reactivecocoa.io/reactiveswift/docs/{RELEASE_TAG}/">click here</a>.
-	</body>
-</html>


### PR DESCRIPTION
Enabled by [Jazzy](https://github.com/realm/jazzy).

Docs would be accessible at: http://reactivecocoa.io/reactiveswift/docs/latest/. CI would generate documentations with tag-triggered builds, and open a pull request in ReactiveCocoa.github.io with @ReactiveCocoaCI.

- [x] Categories
- [x] Include files under `Documentations`.
- [x] Automated generation & PR for tags.