### PR TITLE
`observe(on:)` for properties + gardening in `PropertyProtocol`.

### DIFF
--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		57A4D2461BA13F9700F7D4B1 /* tvOS-Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Framework.xcconfig"; sourceTree = "<group>"; };
 		57A4D2471BA13F9700F7D4B1 /* tvOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
 		7DFBED031CDB8C9500EE435B /* ReactiveSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactiveSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A06E9431E03C3F8001B1C63 /* Thread+LinuxSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Thread+LinuxSupport.swift"; sourceTree = "<group>"; };
 		9A090C131DA0309E00EE97CA /* Reactive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reactive.swift; sourceTree = "<group>"; };
 		9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnidirectionalBindingSpec.swift; sourceTree = "<group>"; };
 		9ABCB1841D2A5B5A00BCA243 /* Deprecations+Removals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Deprecations+Removals.swift"; sourceTree = "<group>"; };
@@ -508,6 +509,7 @@
 				D037672B19EDA75D00A782A9 /* Quick.framework */,
 				BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */,
 				D04725FB19E49ED7006002AA /* Info.plist */,
+				9A06E9431E03C3F8001B1C63 /* Thread+LinuxSupport.swift */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -52,15 +52,23 @@ extension MutablePropertyProtocol {
 /// A composed property would retain its ultimate source, but not
 /// any intermediate property during the composition.
 extension PropertyProtocol {
-	/// Lifts a unary SignalProducer operator to operate upon PropertyProtocol instead.
+	/// Lifts a unary SignalProducer operator to operate upon PropertyProtocol
+	/// instead.
+	///
+	/// - parameters:
+	///   - transform: A unary `SignalProducer` transform to apply on `self`.
 	fileprivate func lift<U>(_ transform: @escaping (SignalProducer<Value, NoError>) -> SignalProducer<U, NoError>) -> Property<U> {
-		return Property(self, transform: transform)
+		return Property(unsafeProducer: transform(self.producer))
 	}
 
-	/// Lifts a binary SignalProducer operator to operate upon PropertyProtocol instead.
+	/// Lifts a binary SignalProducer operator to operate upon PropertyProtocol
+	/// instead.
+	///
+	/// - parameters:
+	///   - transform: A binary `SignalProducer` operator.
 	fileprivate func lift<P: PropertyProtocol, U>(_ transform: @escaping (SignalProducer<Value, NoError>) -> (SignalProducer<P.Value, NoError>) -> SignalProducer<U, NoError>) -> (P) -> Property<U> {
 		return { otherProperty in
-			return Property(self, otherProperty, transform: transform)
+			return Property(unsafeProducer: transform(self.producer)(otherProperty.producer))
 		}
 	}
 
@@ -74,6 +82,42 @@ extension PropertyProtocol {
 	///            from `self`.
 	public func map<U>(_ transform: @escaping (Value) -> U) -> Property<U> {
 		return lift { $0.map(transform) }
+	}
+
+	/// Create a property which forwards all changes and deinitialization of
+	/// `self` onto the given scheduler, instead of whichever scheduler they
+	/// originally arrived upon.
+	///
+	/// - note: The producer of the resulting property would emit the current
+	///         value synchronously, so as to comply the has-one-value contract
+	///         of properties. To have also the initial value delivered on the
+	///         given scheduler, `start(on:)` must be applied to the producer.
+	///
+	/// - parameters:
+	///   - scheduler: A scheduler to deliver events on.
+	///
+	/// - returns: A property that forwards all events on the given scheduler.
+	public func observe(on scheduler: SchedulerProtocol) -> Property<Value> {
+		return lift { producer in
+			return SignalProducer { observer, disposable in
+				var hasReceivedFirst = false
+
+				disposable += producer.start { event in
+					if hasReceivedFirst {
+						// It is unnecessary to add the scheduler token to the producer
+						// disposable (which would need `SerialDisposable` to minimize
+						// the memory consumption), as the event emitter would block post-
+						// termination events anyway.
+						scheduler.schedule {
+							observer.action(event)
+						}
+					} else {
+						hasReceivedFirst = true
+						observer.action(event)
+					}
+				}
+			}
+		}
 	}
 
 	/// Combines the current value and the subsequent values of two `Property`s in
@@ -472,32 +516,6 @@ public final class Property<Value>: PropertyProtocol {
 		self.init(unsafeProducer: SignalProducer(values).prefix(value: initial))
 	}
 
-	/// Initialize a composed property by applying the unary `SignalProducer`
-	/// transform on `property`.
-	///
-	/// - parameters:
-	///   - property: The source property.
-	///   - transform: A unary `SignalProducer` transform to be applied on
-	///     `property`.
-	fileprivate convenience init<P: PropertyProtocol>(
-		_ property: P,
-		transform: @escaping (SignalProducer<P.Value, NoError>) -> SignalProducer<Value, NoError>
-	) {
-		self.init(unsafeProducer: transform(property.producer))
-	}
-
-	/// Initialize a composed property by applying the binary `SignalProducer`
-	/// transform on `firstProperty` and `secondProperty`.
-	///
-	/// - parameters:
-	///   - firstProperty: The first source property.
-	///   - secondProperty: The first source property.
-	///   - transform: A binary `SignalProducer` transform to be applied on
-	///             `firstProperty` and `secondProperty`.
-	fileprivate convenience init<P1: PropertyProtocol, P2: PropertyProtocol>(_ firstProperty: P1, _ secondProperty: P2, transform: @escaping (SignalProducer<P1.Value, NoError>) -> (SignalProducer<P2.Value, NoError>) -> SignalProducer<Value, NoError>) {
-		self.init(unsafeProducer: transform(firstProperty.producer)(secondProperty.producer))
-	}
-
 	/// Initialize a composed property from a producer that promises to send
 	/// at least one value synchronously in its start handler before sending any
 	/// subsequent event.
@@ -510,7 +528,7 @@ public final class Property<Value>: PropertyProtocol {
 	///
 	/// - parameters:
 	///   - unsafeProducer: The composed producer for creating the property.
-	private init(unsafeProducer: SignalProducer<Value, NoError>) {
+	fileprivate init(unsafeProducer: SignalProducer<Value, NoError>) {
 		// Share a replayed producer with `self.producer` and `self.signal` so
 		// they see a consistent view of the `self.value`.
 		// https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3042

--- a/Tests/ReactiveSwiftTests/SchedulerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SchedulerSpec.swift
@@ -14,17 +14,6 @@ import Quick
 @testable
 import ReactiveSwift
 
-#if os(Linux)
-	import func CoreFoundation._CFIsMainThread
-
-	private extension Thread {
-		// `isMainThread` is not implemented yet in swift-corelibs-foundation.
-		static var isMainThread: Bool {
-			return _CFIsMainThread()
-		}
-	}
-#endif
-
 class SchedulerSpec: QuickSpec {
 	override func spec() {
 		describe("ImmediateScheduler") {

--- a/Tests/ReactiveSwiftTests/Thread+LinuxSupport.swift
+++ b/Tests/ReactiveSwiftTests/Thread+LinuxSupport.swift
@@ -1,0 +1,11 @@
+#if os(Linux)
+	import Foundation
+	import func CoreFoundation._CFIsMainThread
+
+	extension Thread {
+		// `isMainThread` is not implemented yet in swift-corelibs-foundation.
+		internal static var isMainThread: Bool {
+			return _CFIsMainThread()
+		}
+	}
+#endif


### PR DESCRIPTION
Only the initial value is emitted synchronously — the rest of the events is forwarded to the specified scheduler.

As for why not lifting `SignalProducer.observe(on:)`, it forwards events emitted during the synchronous start process to the scheduler, which means the initial value is delivered asynchronously.