### PR TITLE
ReactiveSwift 2.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
     - master
     # Credit: @Omnikron13, https://github.com/mojombo/semver/issues/32
     - /^(\d+\.\d+\.\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/
+    - master-next
 before_script:
   - git submodule update --init --recursive
 script:


### PR DESCRIPTION
`master-next` would be the target for reviewed PRs with breaking changes until Swift 3.1 is released, and we decide to stop any further work on ReactiveSwift 1.0.

🚄 [Goals of ReactiveSwift 2.0](https://github.com/ReactiveCocoa/ReactiveSwift#reactiveswift-20)