### PR TITLE
[WIP] Composed properties internal refactoring + `observe(on:)`.

### DIFF
--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -5,6 +5,18 @@ import enum Result.NoError
 ///
 /// Only classes can conform to this protocol, because having a signal
 /// for changes over time implies the origin must have a unique identity.
+///
+/// A conforming type must:
+/// 1. ensure that the latest value is always visible before any observer is
+///    notified.
+///
+/// If a conforming type intends to serialize its getter and setter accesses, it
+/// must also:
+/// 1. support reentrancy;
+/// 2. ensure the observer call-out happens in the same protected section as the
+///    setter.
+/// 3. ensure the closures supplied to `withValue(_:)` are invoked synchronously
+///    with the protection of its synchronoization mechanism.
 public protocol PropertyProtocol: class, BindingSourceProtocol {
 	associatedtype Value
 
@@ -22,6 +34,10 @@ public protocol PropertyProtocol: class, BindingSourceProtocol {
 	/// completes when the property has deinitialized, or has no further
 	/// change.
 	var signal: Signal<Value, NoError> { get }
+
+	/// Perform an arbitrary action on the current value of the property.
+	/// Serialized properties should invoke `body` in its protected section.
+	func withValue<R>(_ body: (Value) throws -> R) rethrows -> R
 }
 
 extension PropertyProtocol {
@@ -44,6 +60,11 @@ extension MutablePropertyProtocol {
 	}
 }
 
+// Note on property composition operators:
+//
+// As the Property contract requires reentrancy, the order of invocation of
+// `withValue` is insignificant and should not lead to deadlocks.
+
 /// Protocol composition operators
 ///
 /// The producer and the signal of transformed properties would complete
@@ -52,15 +73,17 @@ extension MutablePropertyProtocol {
 /// A composed property would retain its ultimate source, but not
 /// any intermediate property during the composition.
 extension PropertyProtocol {
-	/// Lifts a unary SignalProducer operator to operate upon PropertyProtocol instead.
+	/// Lifts a unary stateful SignalProducer operator to operate upon
+	/// PropertyProtocol instead.
 	fileprivate func lift<U>(_ transform: @escaping (SignalProducer<Value, NoError>) -> SignalProducer<U, NoError>) -> Property<U> {
-		return Property(self, transform: transform)
+		return Property(unsafeValues: transform(self.values))
 	}
 
-	/// Lifts a binary SignalProducer operator to operate upon PropertyProtocol instead.
+	/// Lifts a binary stateful SignalProducer operator to operate upon
+	/// PropertyProtocol instead.
 	fileprivate func lift<P: PropertyProtocol, U>(_ transform: @escaping (SignalProducer<Value, NoError>) -> (SignalProducer<P.Value, NoError>) -> SignalProducer<U, NoError>) -> (P) -> Property<U> {
-		return { otherProperty in
-			return Property(self, otherProperty, transform: transform)
+		return { other in
+			return Property(unsafeValues: transform(self.values)(other.values))
 		}
 	}
 
@@ -73,7 +96,25 @@ extension PropertyProtocol {
 	/// - returns: A new instance of `AnyProperty` who's holds a mapped value
 	///            from `self`.
 	public func map<U>(_ transform: @escaping (Value) -> U) -> Property<U> {
-		return lift { $0.map(transform) }
+		return self.withValue { value in
+			return Property<U>(initial: transform(value),
+			                   then: self.signal.map(transform))
+		}
+	}
+
+	/// Create a property which forwards all events of `self` onto the given
+	/// scheduler, instead of whichever scheduler they originally arrived upon.
+	///
+	/// - parameters:
+	///   - scheduler: A scheduler to deliver events on.
+	///
+	/// - returns: A property that forwards all events on the given scheduler.
+	public func observe(on scheduler: SchedulerProtocol) -> Property<Value> {
+		return self.withValue { value in
+			return Property(initial: value,
+			                then: self.signal.observe(on: scheduler),
+			                producerTransform: { $0.start(on: scheduler) })
+		}
 	}
 
 	/// Combines the current value and the subsequent values of two `Property`s in
@@ -97,7 +138,12 @@ extension PropertyProtocol {
 	/// - returns: A property that holds a tuple containing values of `self` and
 	///            the given property.
 	public func zip<P: PropertyProtocol>(with other: P) -> Property<(Value, P.Value)> {
-		return lift(SignalProducer.zip(with:))(other)
+		return self.withValue { value in
+			return other.withValue { otherValue in
+				return Property(initial: (value, otherValue),
+				                then: self.signal.zip(with: other.signal))
+			}
+		}
 	}
 
 	/// Forward events from `self` with history: values of the returned property
@@ -396,8 +442,7 @@ public final class Property<Value>: PropertyProtocol {
 	private let disposable: Disposable?
 
 	private let _value: () -> Value
-	private let _producer: () -> SignalProducer<Value, NoError>
-	private let _signal: () -> Signal<Value, NoError>
+	private let box: PropertyBoxBase<Value>
 
 	/// The current value of the property.
 	public var value: Value {
@@ -407,15 +452,11 @@ public final class Property<Value>: PropertyProtocol {
 	/// A producer for Signals that will send the property's current
 	/// value, followed by all changes over time, then complete when the
 	/// property has deinitialized or has no further changes.
-	public var producer: SignalProducer<Value, NoError> {
-		return _producer()
-	}
+	public let producer: SignalProducer<Value, NoError>
 
 	/// A signal that will send the property's changes over time, then
 	/// complete when the property has deinitialized or has no further changes.
-	public var signal: Signal<Value, NoError> {
-		return _signal()
-	}
+	public let signal: Signal<Value, NoError>
 
 	/// Initializes a constant property.
 	///
@@ -424,8 +465,9 @@ public final class Property<Value>: PropertyProtocol {
 	public init(value: Value) {
 		disposable = nil
 		_value = { value }
-		_producer = { SignalProducer(value: value) }
-		_signal = { Signal<Value, NoError>.empty }
+		producer = SignalProducer(value: value)
+		signal = .empty
+		box = PropertyBox<Property<Value>>(constant: value)
 	}
 
 	/// Initializes an existential property which wraps the given property.
@@ -437,8 +479,9 @@ public final class Property<Value>: PropertyProtocol {
 	public init<P: PropertyProtocol>(capturing property: P) where P.Value == Value {
 		disposable = nil
 		_value = { property.value }
-		_producer = { property.producer }
-		_signal = { property.signal }
+		producer = property.producer
+		signal = property.signal
+		box = PropertyBox(property)
 	}
 
 	/// Initializes a composed property which reflects the given property.
@@ -448,7 +491,7 @@ public final class Property<Value>: PropertyProtocol {
 	/// - parameters:
 	///   - property: A property to be wrapped.
 	public convenience init<P: PropertyProtocol>(_ property: P) where P.Value == Value {
-		self.init(unsafeProducer: property.producer)
+		self.init(unsafeValues: property.producer)
 	}
 
 	/// Initializes a composed property that first takes on `initial`, then each
@@ -459,7 +502,7 @@ public final class Property<Value>: PropertyProtocol {
 	///   - values: A producer that will start immediately and send values to
 	///             the property.
 	public convenience init(initial: Value, then values: SignalProducer<Value, NoError>) {
-		self.init(unsafeProducer: values.prefix(value: initial))
+		self.init(unsafeValues: values.prefix(value: initial))
 	}
 
 	/// Initialize a composed property that first takes on `initial`, then each
@@ -469,70 +512,147 @@ public final class Property<Value>: PropertyProtocol {
 	///   - initialValue: Starting value for the property.
 	///   - values: A signal that will send values to the property.
 	public convenience init(initial: Value, then values: Signal<Value, NoError>) {
-		self.init(unsafeProducer: SignalProducer(values).prefix(value: initial))
+		self.init(initial: initial, then: values, producerTransform: { $0 })
 	}
 
-	/// Initialize a composed property by applying the unary `SignalProducer`
-	/// transform on `property`.
-	///
-	/// - parameters:
-	///   - property: The source property.
-	///   - transform: A unary `SignalProducer` transform to be applied on
-	///     `property`.
-	fileprivate convenience init<P: PropertyProtocol>(
-		_ property: P,
-		transform: @escaping (SignalProducer<P.Value, NoError>) -> SignalProducer<Value, NoError>
+	fileprivate init(
+		unsafeValues: SignalProducer<Value, NoError>,
+		producerTransform: (SignalProducer<Value, NoError>) -> SignalProducer<Value, NoError> = { $0 }
 	) {
-		self.init(unsafeProducer: transform(property.producer))
-	}
+		let cache = RecursiveAtomic<Value?>(nil)
 
-	/// Initialize a composed property by applying the binary `SignalProducer`
-	/// transform on `firstProperty` and `secondProperty`.
-	///
-	/// - parameters:
-	///   - firstProperty: The first source property.
-	///   - secondProperty: The first source property.
-	///   - transform: A binary `SignalProducer` transform to be applied on
-	///             `firstProperty` and `secondProperty`.
-	fileprivate convenience init<P1: PropertyProtocol, P2: PropertyProtocol>(_ firstProperty: P1, _ secondProperty: P2, transform: @escaping (SignalProducer<P1.Value, NoError>) -> (SignalProducer<P2.Value, NoError>) -> SignalProducer<Value, NoError>) {
-		self.init(unsafeProducer: transform(firstProperty.producer)(secondProperty.producer))
-	}
+		var propertySignal: Signal<Value, Error>!
+		var d: Disposable!
 
-	/// Initialize a composed property from a producer that promises to send
-	/// at least one value synchronously in its start handler before sending any
-	/// subsequent event.
-	///
-	/// - important: The producer and the signal of the created property would
-	///              complete only when the `unsafeProducer` completes.
-	///
-	/// - warning: If the producer fails its promise, a fatal error would be
-	///            raised.
-	///
-	/// - parameters:
-	///   - unsafeProducer: The composed producer for creating the property.
-	private init(unsafeProducer: SignalProducer<Value, NoError>) {
-		// Share a replayed producer with `self.producer` and `self.signal` so
-		// they see a consistent view of the `self.value`.
-		// https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3042
-		let producer = unsafeProducer.replayLazily(upTo: 1)
+		let replay = unsafeValues.replayLazily(upTo: 1)
 
-		let atomic = Atomic<Value?>(nil)
-		disposable = producer.startWithValues { atomic.value = $0 }
-
-		// Verify that an initial is sent. This is friendlier than deadlocking
-		// in the event that one isn't.
-		guard atomic.value != nil else {
-			fatalError("A producer promised to send at least one value. Received none.")
+		replay.startWithSignal { signal, _ in
+			d = signal.observeValues { cache.value = $0 }
+			propertySignal = signal
 		}
 
-		_value = { atomic.value! }
-		_producer = { producer }
-		_signal = { producer.startAndRetrieveSignal() }
+		guard cache.value != nil else {
+			fatalError("Expected a value being synchronously sent. Got none.")
+		}
+
+		_value = { cache.value! }
+		producer = producerTransform(replay)
+		signal = propertySignal
+		box = PropertyBox<Property<Value>>(cache)
+		disposable = d
+	}
+
+	fileprivate convenience init(
+		initial: Value,
+		then values: Signal<Value, NoError>,
+		producerTransform: (SignalProducer<Value, NoError>) -> SignalProducer<Value, NoError>
+	) {
+		let producer = SignalProducer<Value, NoError> { observer, disposable in
+			observer.send(value: initial)
+			disposable += values.propertyObserve(observer)
+		}
+
+		self.init(unsafeValues: producer, producerTransform: producerTransform)
+	}
+
+	public func withValue<R>(_ body: (Value) throws -> R) rethrows -> R {
+		return try box.withValue(body)
 	}
 
 	deinit {
 		disposable?.dispose()
 	}
+}
+
+extension PropertyProtocol {
+	internal var values: SignalProducer<Value, NoError> {
+		return SignalProducer { observer, disposable in
+			self.withValue { value in
+				observer.send(value: value)
+				disposable += self.signal.propertyObserve(observer)
+			}
+		}
+	}
+}
+
+extension SignalProtocol {
+	/// `observe` for property composition. It turns `interrupted` into
+	/// `completed`, and traps on `failed`.
+	@discardableResult
+	internal func propertyObserve(_ observer: Observer<Value, Error>) -> Disposable? {
+		return observe { event in
+			switch event {
+			case .value, .completed:
+				observer.action(event)
+
+			case .interrupted:
+				observer.sendCompleted()
+
+			case let .failed(error):
+				fatalError("Received `failed` event in a `Property` which should never fail. \(error)")
+			}
+		}
+	}
+}
+
+private final class Box<Value> {
+	let value: Value
+
+	init(_ value: Value) {
+		self.value = value
+	}
+}
+
+// The existential box for `PropertyProtocol.withValue`.
+private class PropertyBox<P: PropertyProtocol>: PropertyBoxBase<P.Value> {
+	private let base: PropertyBoxBacking<P>
+
+	fileprivate init(_ base: P) {
+		self.base = .property(base)
+	}
+
+	fileprivate init(_ atomic: RecursiveAtomic<P.Value?>) {
+		self.base = .composed(atomic)
+	}
+
+	fileprivate init(_ atomic: RecursiveAtomic<P.Value>) {
+		self.base = .composedStateless(atomic)
+	}
+
+	fileprivate init(constant: P.Value) {
+		self.base = .constant(constant)
+	}
+
+	fileprivate override func withValue<R>(_ body: (P.Value) throws -> R) rethrows -> R {
+		switch base {
+		case let .constant(value):
+			return try body(value)
+
+		case let .composed(atomic):
+			return try atomic.withValue { try body($0!) }
+
+		case let .composedStateless(atomic):
+			return try atomic.withValue(body)
+
+		case let .property(property):
+			return try property.withValue(body)
+		}
+	}
+}
+
+// The base class of the existential box.
+private class PropertyBoxBase<Value> {
+	fileprivate func withValue<R>(_ body: (Value) throws -> R) rethrows -> R {
+		fatalError("This method should have been overriden.")
+	}
+}
+
+// The backing the existential box.
+private enum PropertyBoxBacking<P: PropertyProtocol> {
+	case constant(P.Value)
+	case composed(RecursiveAtomic<P.Value?>)
+	case composedStateless(RecursiveAtomic<P.Value>)
+	case property(P)
 }
 
 /// A mutable property of type `Value` that allows observation of its changes.
@@ -612,25 +732,25 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 	/// Atomically modifies the variable.
 	///
 	/// - parameters:
-	///   - action: A closure that accepts old property value and returns a new
-	///             property value.
+	///   - body: A closure that accepts old property value and returns a new
+	///           property value.
 	///
-	/// - returns: The result of the action.
+	/// - returns: The result of the closure.
 	@discardableResult
-	public func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result {
-		return try atomic.modify(action)
+	public func modify<Result>(_ body: (inout Value) throws -> Result) rethrows -> Result {
+		return try atomic.modify(body)
 	}
 
 	/// Atomically performs an arbitrary action using the current value of the
 	/// variable.
 	///
 	/// - parameters:
-	///   - action: A closure that accepts current property value.
+	///   - body: A closure that accepts current property value.
 	///
-	/// - returns: the result of the action.
+	/// - returns: the result of the closure.
 	@discardableResult
-	public func withValue<Result>(action: (Value) throws -> Result) rethrows -> Result {
-		return try atomic.withValue(action)
+	public func withValue<Result>(_ body: (Value) throws -> Result) rethrows -> Result {
+		return try atomic.withValue(body)
 	}
 
 	deinit {

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -1246,7 +1246,7 @@ class PropertySpec: QuickSpec {
 						expect(mapped.value) == initialPropertyValue.characters.count
 						queue.resume()
 					}
-/*
+
 					it("should inherit the scheduler from its source properties") {
 						let queue = DispatchQueue(label: "PropertySpecTest")
 						let specific = DispatchSpecificKey<()>()
@@ -1278,7 +1278,7 @@ class PropertySpec: QuickSpec {
 						expect(counter).toEventually(equal(3))
 						expect(counter2).toEventually(equal(2))
 					}
-*/
+
 					it("should override the scheduler of its source properties") {
 						let queue1 = DispatchQueue(label: "PropertySpecTest")
 						let specific1 = DispatchSpecificKey<()>()


### PR DESCRIPTION
Preceded by #161.

~~The internal of `Property` drops one level down — it is now built around `Signal` and `PropertyProtocol.withValue`.~~

The internal of `Property` now relies on `PropertyProtocol.signal` and `PropertyProtocol.withValue` for composition.

The use of `unsafeProducer` in `map`, `observe(on:)` and `zip(with:)` is replaced with `Property(initial:then:producerTransform:)`.

`observe(on:)` is also included to demonstrate how it interacts with the new internal.

#### Breaking Change
`PropertyProtocol` has a new requirement: `withValue(_:)`.

Serialized properties should invoke the supplied action in its protected section. In other words, `withValue(_:)` implicitly exposes the lock without handing out a specific instance of it.

The documentation now also stresses that reentrancy is a strict requirement. This is not something new however — `MutableProperty` has set the bound.

#### What's the difference from `replayLazily`?
Less `Signal`s would be involved. At compile time there is also an apparent "current value", which can be used directly in stateless operators like `map` and `observe(on:)`.

But the notion of "unsafe" initializer still has to remain, because some operators are stateful and need to be "trained" with an initial value. e.g. `combineLatest(with:)`, `skipRepeats`.

**Bonus point:** `Property.signal` no longer needs to be started from the producer.

#### Special Notes on `observe(on:)`
There are two things that have to be decided on:

1. Should the current value be replayed on the supplied scheduler?

2. If (1) is yes, should the descendants of a property inherits (1) from its ancestor?

This branch currently assumes ~~_yes_ for (1), and _no_ for (2)~~ YES for both. For the (2) to work, it would still require the notion of producer persona in #161.