### PR TITLE
Fixed the unbound memory growth of unidirectional bindings.

### DIFF
--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -32,8 +32,8 @@ public protocol PropertyProtocol: class, BindingSourceProtocol {
 
 extension PropertyProtocol {
 	@discardableResult
-	public func observe(_ observer: Observer<Value, NoError>) -> Disposable? {
-		return producer.observe(observer)
+	public func observe(_ observer: Observer<Value, NoError>, during lifetime: Lifetime) -> Disposable? {
+		return producer.observe(observer, during: lifetime)
 	}
 }
 


### PR DESCRIPTION
```swift
	if let disposable = disposable {
		target.lifetime.ended.observeCompleted { disposable.dispose() }
	}
```
would leave the disposable of a disposed binding in the lifetime signal forever (until the lifetime ends).

I also notice one thing — `observe` would show up in the code completion of `Property` and `SignalProducer`, but neither use this term. Perhaps it would be better to rename it to `bind(_:during:)`.