### PR TITLE
Remove the `BindingTarget` hackery.

### DIFF
--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -259,8 +259,8 @@ public protocol ActionProtocol: BindingTargetProtocol {
 }
 
 extension ActionProtocol {
-	public func consume(_ value: Input) {
-		apply(value).start()
+	public var consume: (Input) -> Void {
+		return { [weak self] in self?.apply($0).start() }
 	}
 }
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -45,8 +45,8 @@ public protocol MutablePropertyProtocol: PropertyProtocol, BindingTargetProtocol
 
 /// Default implementation of `MutablePropertyProtocol` for `BindingTarget`.
 extension MutablePropertyProtocol {
-	public func consume(_ value: Value) {
-		self.value = value
+	public var consume: (Value) -> Void {
+		return { [weak self] in self?.value = $0 }
 	}
 }
 


### PR DESCRIPTION
There is a breaking bit, but should affect only those who conforms to `BindingTargetProtocol`.