### PR TITLE
[skip ci] Minor fixes in documentation

### DIFF
--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -349,9 +349,9 @@ lettersObserver.send(value: "a")    // prints "a"
 lettersObserver.send(value: "b")    // prints "b"
 numbersObserver.send(value: "2")    // nothing printed
 lettersObserver.send(value: "c")    // prints "c"
-lettersObserver.sendCompleted()     // prints "1, 2"
+lettersObserver.sendCompleted()     // nothing printed
 numbersObserver.send(value: "3")    // prints "3"
-numbersObserver.sendCompleted()
+numbersObserver.sendCompleted()     // nothing printed
 ```
 
 [Interactive visualisation of the `flatten(.concat)` operator.](http://neilpa.me/rac-marbles/#concat)

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -358,9 +358,15 @@ numbersObserver.sendCompleted()     // nothing printed
 
 ### Switching to the latest
 
-The `.latest` strategy forwards only values from the latest input event stream.
+The `.latest` strategy forwards only values or a failure from the latest input event stream.
 
 ```Swift
+let (lettersSignal, lettersObserver) = Signal<String, NoError>.pipe()
+let (numbersSignal, numbersObserver) = Signal<String, NoError>.pipe()
+let (signal, observer) = Signal<Signal<String, NoError>, NoError>.pipe()
+
+signal.flatten(.latest).observeValues { print($0) }
+
 observer.send(value: lettersSignal) // nothing printed
 numbersObserver.send(value: "1")    // nothing printed
 lettersObserver.send(value: "a")    // prints "a"


### PR DESCRIPTION
I caught an example that was still assuming the semantics of a cold signal after the migration to use hot signals (`Signal`).