### PR TITLE
Deprecate strategy and remove `NoError` constraint from `flatten` when the value is a `Sequence`

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -233,8 +233,10 @@ extension SignalProtocol where Error == NoError {
 }
 
 extension SignalProtocol where Value: Sequence {
-	@available(*, unavailable, renamed: "flatten()")
-	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Iterator.Element, Error> { fatalError() }
+	@available(*, deprecated, message: "Use flatten() instead")
+	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Iterator.Element, Error> {
+		return self.flatMap(strategy, transform: SignalProducer.init)
+	}
 }
 
 extension SignalProducerProtocol {
@@ -313,8 +315,10 @@ extension SignalProducerProtocol where Error == NoError {
 }
 
 extension SignalProducerProtocol where Value: Sequence {
-	@available(*, unavailable, renamed: "flatten()")
-	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Iterator.Element, Error> { fatalError() }
+	@available(*, deprecated, message: "Use flatten() instead")
+	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Iterator.Element, Error> {
+		return self.flatMap(strategy, transform: SignalProducer.init)
+	}
 }
 
 extension SignalProducer {

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -232,6 +232,11 @@ extension SignalProtocol where Error == NoError {
 	public func observeNext(_ next: (Value) -> Void) -> Disposable? { fatalError() }
 }
 
+extension SignalProtocol where Value: Sequence {
+	@available(*, unavailable, renamed: "flatten()")
+	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Iterator.Element, Error> { fatalError() }
+}
+
 extension SignalProducerProtocol {
 	@available(*, unavailable, renamed:"take(first:)")
 	public func take(_ count: Int) -> SignalProducer<Value, Error> { fatalError() }
@@ -305,6 +310,11 @@ extension SignalProducerProtocol where Value: OptionalProtocol {
 extension SignalProducerProtocol where Error == NoError {
 	@available(*, unavailable, renamed: "startWithValues")
 	public func startWithNext(_ value: @escaping (Value) -> Void) -> Disposable { fatalError() }
+}
+
+extension SignalProducerProtocol where Value: Sequence {
+	@available(*, unavailable, renamed: "flatten()")
+	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Iterator.Element, Error> { fatalError() }
 }
 
 extension SignalProducer {

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -245,11 +245,11 @@ extension SignalProtocol where Value: SignalProtocol, Value.Error == NoError {
 	}
 }
 
-extension SignalProtocol where Value: Sequence, Error == NoError {
+extension SignalProtocol where Value: Sequence {
 	/// Flattens the `sequence` value sent by `signal` according to
 	/// the semantics of the given strategy.
 	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Iterator.Element, Error> {
-		return self.flatMap(strategy) { .init($0) }
+		return self.flatMap(strategy, transform: SignalProducer.init)
 	}
 }
 
@@ -312,11 +312,11 @@ extension SignalProducerProtocol where Value: SignalProtocol, Value.Error == NoE
 	}
 }
 
-extension SignalProducerProtocol where Value: Sequence, Error == NoError {
+extension SignalProducerProtocol where Value: Sequence {
 	/// Flattens the `sequence` value sent by `producer` according to
 	/// the semantics of the given strategy.
 	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Iterator.Element, Error> {
-		return self.flatMap(strategy) { .init($0) }
+		return self.flatMap(strategy, transform: SignalProducer.init)
 	}
 }
 

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -246,10 +246,9 @@ extension SignalProtocol where Value: SignalProtocol, Value.Error == NoError {
 }
 
 extension SignalProtocol where Value: Sequence {
-	/// Flattens the `sequence` value sent by `signal` according to
-	/// the semantics of the given strategy.
-	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Iterator.Element, Error> {
-		return self.flatMap(strategy, transform: SignalProducer.init)
+	/// Flattens the `sequence` value sent by `signal`.
+	public func flatten() -> Signal<Value.Iterator.Element, Error> {
+		return self.flatMap(.merge, transform: SignalProducer.init)
 	}
 }
 
@@ -313,10 +312,9 @@ extension SignalProducerProtocol where Value: SignalProtocol, Value.Error == NoE
 }
 
 extension SignalProducerProtocol where Value: Sequence {
-	/// Flattens the `sequence` value sent by `producer` according to
-	/// the semantics of the given strategy.
-	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Iterator.Element, Error> {
-		return self.flatMap(strategy, transform: SignalProducer.init)
+	/// Flattens the `sequence` value sent by `signal`.
+	public func flatten() -> SignalProducer<Value.Iterator.Element, Error> {
+		return self.flatMap(.merge, transform: SignalProducer.init)
 	}
 }
 

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -261,7 +261,7 @@ class FlattenSpec: QuickSpec {
 				var observedValues = [Int]()
 				
 				signal
-					.flatten(.concat)
+					.flatten()
 					.observeValues { value in
 						observedValues.append(value)
 					}
@@ -272,7 +272,7 @@ class FlattenSpec: QuickSpec {
 
 			it("works with Sequence as a value and any arbitrary error") {
 				_ = Signal<[Int], TestError>.empty
-					.flatten(.latest)
+					.flatten()
 			}
 
 			it("works with Property and any arbitrary error") {
@@ -451,7 +451,7 @@ class FlattenSpec: QuickSpec {
 				
 				let producer = SignalProducer<[Int], NoError>(value: sequence)
 				producer
-					.flatten(.latest)
+					.flatten()
 					.startWithValues { value in
 						observedValues.append(value)
 					}
@@ -461,7 +461,7 @@ class FlattenSpec: QuickSpec {
 
 			it("works with Sequence as a value and any arbitrary error") {
 				_ = SignalProducer<[Int], TestError>.empty
-					.flatten(.latest)
+					.flatten()
 			}
 
 			it("works with Property and any arbitrary error") {

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -255,7 +255,7 @@ class FlattenSpec: QuickSpec {
 				expect(observed) == 4
 			}
 			
-			it("works with SequenceType as a value") {
+			it("works with Sequence as a value") {
 				let (signal, innerObserver) = Signal<[Int], NoError>.pipe()
 				let sequence = [1, 2, 3]
 				var observedValues = [Int]()
@@ -268,6 +268,11 @@ class FlattenSpec: QuickSpec {
 				
 				innerObserver.send(value: sequence)
 				expect(observedValues) == sequence
+			}
+
+			it("works with Sequence as a value and any arbitrary error") {
+				_ = Signal<[Int], TestError>.empty
+					.flatten(.latest)
 			}
 
 			it("works with Property and any arbitrary error") {
@@ -440,7 +445,7 @@ class FlattenSpec: QuickSpec {
 				expect(observed) == 4
 			}
 			
-			it("works with SequenceType as a value") {
+			it("works with Sequence as a value") {
 				let sequence = [1, 2, 3]
 				var observedValues = [Int]()
 				
@@ -452,6 +457,11 @@ class FlattenSpec: QuickSpec {
 					}
 				
 				expect(observedValues) == sequence
+			}
+
+			it("works with Sequence as a value and any arbitrary error") {
+				_ = SignalProducer<[Int], TestError>.empty
+					.flatten(.latest)
 			}
 
 			it("works with Property and any arbitrary error") {


### PR DESCRIPTION
Fixes #198. Originally suggested in #197.