### PR TITLE
Port `groupBy` from REX

### DIFF
--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1943,7 +1943,7 @@ extension SignalProducerProtocol {
 	///            each value from the original producer to the inner producer corresponding 
 	///            to the group to which the value belongs to (as determined by the key)
 	public func group<Key: Hashable>(by grouping: @escaping (Value) -> Key) -> SignalProducer<(Key, SignalProducer<Value, Error>), Error> {
-		return SignalProducer<(Key, SignalProducer<Value, Error>), Error> { observer, disposable in
+		return SignalProducer { observer, disposable in
 			let groups = Atomic<[Key: Signal<Value, Error>.Observer]>([:])
 			
 			disposable += self.start { event in

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1942,7 +1942,7 @@ extension SignalProducerProtocol {
 	/// - returns: A producer of producers amits one producer for each group and forwards
 	///            each value from the original producer to the inner producer corresponding 
 	///            to the group to which the value belongs to (as determined by the key)
-	public func groupBy<Key: Hashable>(_ grouping: @escaping (Value) -> Key) -> SignalProducer<(Key, SignalProducer<Value, Error>), Error> {
+	public func group<Key: Hashable>(by grouping: @escaping (Value) -> Key) -> SignalProducer<(Key, SignalProducer<Value, Error>), Error> {
 		return SignalProducer<(Key, SignalProducer<Value, Error>), Error> { observer, disposable in
 			let groups = Atomic<[Key: Signal<Value, Error>.Observer]>([:])
 			

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1929,6 +1929,64 @@ extension SignalProducerProtocol {
 			}
 		}
 	}
+	
+	/// Creates a new `SignalProducer` that will bucket each received value into
+	/// a group based on the key returned from `grouping`. 
+	///
+	/// Termination events on the original signal are also forwarded to each
+	/// producer group.
+	///
+	/// - parameters:
+	///   - grouping: a closure that determines the grouping key for a given value
+	///
+	/// - returns: A producer of producers amits one producer for each group and forwards
+	///            each value from the original producer to the inner producer corresponding 
+	///            to the group to which the value belongs to (as determined by the key)
+	public func group<Key: Hashable>(by grouping: @escaping (Value) -> Key) -> SignalProducer<(Key, SignalProducer<Value, Error>), Error> {
+	public func groupBy<Key: Hashable>(_ grouping: @escaping (Value) -> Key) -> SignalProducer<(Key, SignalProducer<Value, Error>), Error> {
+		return SignalProducer<(Key, SignalProducer<Value, Error>), Error> { observer, disposable in
+			var groups: [Key: Signal<Value, Error>.Observer] = [:]
+			
+			let lock = NSRecursiveLock()
+			lock.name = "me.neilpa.rex.groupBy"
+			
+			self.start { event in
+				switch event {
+				case let .value(value):
+					let key = grouping(value)
+					
+					lock.lock()
+					var group = groups[key]
+					if group == nil {
+						let (signal, innerObserver) = Signal<Value, Error>.pipe()
+						let producer = SignalProducer(signal).replayLazily(upTo: Int.max)
+						
+						// Start the buffering immediately.
+						producer.start()
+						observer.send(value: (key, producer))
+						
+						groups[key] = innerObserver
+						group = innerObserver
+					}
+					lock.unlock()
+					
+					group!.send(value: value)
+					
+				case let .failed(error):
+					observer.send(error: error)
+					groups.values.forEach { $0.send(error: error) }
+					
+				case .completed:
+					observer.sendCompleted()
+					groups.values.forEach { $0.sendCompleted() }
+					
+				case .interrupted:
+					observer.sendInterrupted()
+					groups.values.forEach { $0.sendInterrupted() }
+				}
+			}
+		}
+	}
 }
 
 extension SignalProducerProtocol where Value == Bool {

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1946,7 +1946,7 @@ extension SignalProducerProtocol {
 		return SignalProducer<(Key, SignalProducer<Value, Error>), Error> { observer, disposable in
 			let groups = Atomic<[Key: Signal<Value, Error>.Observer]>([:])
 			
-			self.start { event in
+			disposable += self.start { event in
 				switch event {
 				case let .value(value):
 					let key = grouping(value)

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1958,7 +1958,7 @@ extension SignalProducerProtocol {
 							let producer = SignalProducer(signal).replayLazily(upTo: Int.max)
 							
 							// Start the buffering immediately.
-							producer.start()
+							producer.start().dispose()
 							observer.send(value: (key, producer))
 							
 							$0[key] = innerObserver

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1939,7 +1939,7 @@ extension SignalProducerProtocol {
 	/// - parameters:
 	///   - grouping: a closure that determines the grouping key for a given value
 	///
-	/// - returns: A producer of producers amits one producer for each group and forwards
+	/// - returns: A producer of producers that emits one producer for each group and forwards
 	///            each value from the original producer to the inner producer corresponding 
 	///            to the group to which the value belongs to (as determined by the key)
 	public func group<Key: Hashable>(by grouping: @escaping (Value) -> Key) -> SignalProducer<(Key, SignalProducer<Value, Error>), Error> {

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -1941,7 +1941,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 						} else {
 							group.startWithValues { odds.append($0)}
 						}
-				}
+					}
 				
 				observer.send(value: 1)
 				expect(evens) == []
@@ -1987,7 +1987,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 						case .failed:
 							break
 						}
-				}
+					}
 				
 				observer.send(value: 1)
 				observer.send(value: 2)
@@ -2026,7 +2026,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					case .failed:
 						break
 					}
-			}
+				}
 			
 			observer.send(value: 1)
 			observer.send(value: 2)
@@ -2063,7 +2063,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					case .failed:
 						break
 					}
-			}
+				}
 			
 			observer.send(value: 1)
 			observer.send(value: 2)
@@ -2101,7 +2101,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					case let .failed(e):
 						error = e
 					}
-			}
+				}
 			
 			observer.send(value: 1)
 			observer.send(value: 2)

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -2075,7 +2075,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			expect(oddCompleted) == true
 		}
 		
-		it("should terminate correctly receiving an error event") {
+		it("should terminate correctly receiving a failed event") {
 			let (signal, observer) = Signal<Int, TestError>.pipe()
 			let producer = SignalProducer<Int, TestError>(signal)
 			var interrupted = false

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -1934,7 +1934,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var evens: [Int] = []
 				var odds: [Int] = []
 				let disposable = producer
-					.groupBy { $0 % 2 == 0 }
+					.group { $0 % 2 == 0 }
 					.startWithValues { key, group in
 						if key {
 							group.startWithValues { evens.append($0)}
@@ -1971,7 +1971,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var oddsInterrupted = false
 				
 				let disposable = producer
-					.groupBy { $0 % 2 == 0 }
+					.group { $0 % 2 == 0 }
 					.start { event in
 						switch event {
 						case let .value(key, group):
@@ -2010,7 +2010,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			var oddsInterrupted = false
 			
 			producer
-				.groupBy { $0 % 2 == 0 }
+				.group { $0 % 2 == 0 }
 				.start { event in
 					switch event {
 					case let .value(key, group):
@@ -2047,7 +2047,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			var oddCompleted = false
 			
 			producer
-				.groupBy { $0 % 2 == 0 }
+				.group { $0 % 2 == 0 }
 				.start { event in
 					switch event {
 					case let .value(key, group):
@@ -2085,7 +2085,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			var oddsError: TestError? = nil
 			
 			producer
-				.groupBy { $0 % 2 == 0 }
+				.group { $0 % 2 == 0 }
 				.start { event in
 					switch event {
 					case let .value(key, group):


### PR DESCRIPTION
As per #197, this is a Port of `groupBy` from [REX](https://github.com/RACCommunity/Rex/pull/159/).

I've only changed it to use `Atomic` instead of the `NSRecursiveLock`