### PR TITLE
combineLatest(with:) drops events sent synchronously on start

### DIFF
--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -780,6 +780,18 @@ class SignalProducerSpec: QuickSpec {
 				expect(ids) == [1, 2]
 				expect(values._bridgeToObjectiveC()) == [[1, 2]]._bridgeToObjectiveC()
 			}
+
+			it("should combine synchronous events") {
+				var values: [String] = []
+
+				SignalProducer<Int, NoError>([1, 2])
+					.combineLatest(with: SignalProducer(value: 1))
+					.startWithValues { a, b in
+						values.append("\(a)-\(b)")
+					}
+
+				expect(values) == ["1-1", "2-1"]
+			}
 		}
 
 		describe("zip") {


### PR DESCRIPTION
When multiple events are sent synchronously in a `SignalProducer`'s start handler, `combineLatest(with:)` appears to be dropping events and only emitting the latest.

The test fails with

```
expected to equal <[1-1, 2-1]>, got <[2-1]>
```