### PR TITLE
Allow replayed producers to be restarted after termination

### DIFF
--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -121,6 +121,28 @@ public enum Event<Value, Error: Swift.Error> {
 	}
 }
 
+public enum TerminatingEvent<Error: Swift.Error> {
+	case completed
+	case failed(Error)
+	case interrupted
+
+	init?<Value>(_ event: Event<Value, Error>) {
+		switch event {
+		case .value:
+			return nil
+
+		case .completed:
+			self = .completed
+
+		case .interrupted:
+			self = .interrupted
+
+		case let .failed(error):
+			self = .failed(error)
+		}
+	}
+}
+
 public func == <Value: Equatable, Error: Equatable> (lhs: Event<Value, Error>, rhs: Event<Value, Error>) -> Bool {
 	switch (lhs, rhs) {
 	case let (.value(left), .value(right)):

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1867,7 +1867,7 @@ extension SignalProducerProtocol {
 					// Start the underlying producer if it has never been started.
 					start.swap(nil)?()
 
-					// Terminate the replay loop.
+					// Terminate the observation loop.
 					return
 
 				case let .failure(error):

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1830,9 +1830,10 @@ extension SignalProducerProtocol {
 		let lifetime = Lifetime(lifetimeToken)
 
 		let state = Atomic(ReplayState<Value, Error>(upTo: capacity))
+		let start = Atomic(true)
 
-		let start: Atomic<(() -> Void)?> = Atomic {
-			// Start the underlying producer.
+		// Start the underlying producer.
+		func startHandler() {
 			self
 				.take(during: lifetime)
 				.start { event in
@@ -1865,7 +1866,9 @@ extension SignalProducerProtocol {
 					}
 
 					// Start the underlying producer if it has never been started.
-					start.swap(nil)?()
+					if start.swap(false) {
+						startHandler()
+					}
 
 					// Terminate the observation loop.
 					return

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1850,12 +1850,11 @@ extension SignalProducerProtocol {
 			disposable += { _ = lifetimeToken }
 
 			while true {
-				var result: Result<RemovalToken?, ReplayError<Value>>!
-				state.modify {
-					result = $0.observe(observer)
+				let result = state.modify {
+					return $0.observe(observer)
 				}
 
-				switch result! {
+				switch result {
 				case let .success(token):
 					if let token = token {
 						disposable += {


### PR DESCRIPTION
Related to #97. I've been to get together a proof of concept of the API described in https://github.com/ReactiveCocoa/ReactiveSwift/issues/97#issuecomment-263199750, but running into subtle issues with the lifetime semantics of composed Properties (which use `replayLazily` internally).

Currently, the start handler goes out of scope the first time it is started, which means no strong reference is kept to the inner producer after starting. In order to allow the replayed producer to be restarted, we need to keep a reference to it (see `startHandler`), but keeping this reference around breaks a couple of tests verifying when a composed property sends a `completed` event.

It looks like `Property.init(unsafeProducer:)` is implicitly relying on the fact that `replayLazily` discards its reference to the inner producer after the first time it's started. I've tried a few different things, but I haven't been able to work out an alternate implementation of the initialiser that doesn't rely on that fact.

`Property` lifetime management still feels pretty hard! I _think_ in part because `SignalProducer` is a struct, I'm finding it difficult to reason about who owns a reference to what, and why the test is failing. I'd really appreciate some help working out what's going on here.