### PR TITLE
Let's make `Atomic` more simple, efficient and reusable

### DIFF
--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -125,12 +125,11 @@ internal struct UnsafeAtomicState<State: RawRepresentable>: AtomicStateProtocol 
 #endif
 }
 
-final class PosixThreadMutex: NSLocking {
-	private var mutex = pthread_mutex_t()
+private final class Lock {
+	private var mutex: pthread_mutex_t
 
-	init() {
-		let result = pthread_mutex_init(&mutex, nil)
-		precondition(result == 0, "Failed to initialize mutex with error \(result).")
+	private init(_ mutex: pthread_mutex_t) {
+		self.mutex = mutex
 	}
 
 	deinit {
@@ -138,29 +137,107 @@ final class PosixThreadMutex: NSLocking {
 		precondition(result == 0, "Failed to destroy mutex with error \(result).")
 	}
 
-	func lock() {
+	@inline(__always)
+	fileprivate func lock() {
 		let result = pthread_mutex_lock(&mutex)
 		precondition(result == 0, "Failed to lock \(self) with error \(result).")
 	}
 
-	func unlock() {
+	@inline(__always)
+	fileprivate func unlock() {
 		let result = pthread_mutex_unlock(&mutex)
 		precondition(result == 0, "Failed to unlock \(self) with error \(result).")
+	}
+
+	fileprivate static var nonRecursive: Lock {
+		var mutex = pthread_mutex_t()
+		let result = pthread_mutex_init(&mutex, nil)
+		precondition(result == 0, "Failed to initialize mutex with error \(result).")
+		return self.init(mutex)
+	}
+
+	fileprivate static var recursive: Lock {
+
+		func checkSuccess(_ instruction: @autoclosure () -> Int32, _ label: String) {
+			let result = instruction()
+			precondition(result == 0, "Failed to initialize \(label) with error: \(result).")
+		}
+
+		var attr = pthread_mutexattr_t()
+		checkSuccess(pthread_mutexattr_init(&attr), "mutex attributes")
+		checkSuccess(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE), "mutex attributes")
+		
+		defer { pthread_mutexattr_destroy(&attr) }
+
+		var mutex = pthread_mutex_t()
+		checkSuccess(pthread_mutex_init(&mutex, &attr), "mutex")
+
+		return self.init(mutex)
+	}
+}
+
+public enum AtomicLocking {
+	case recursive
+	case nonRecursive
+
+	fileprivate var lock: Lock {
+		switch self {
+		case .recursive: return Lock.recursive
+		case .nonRecursive: return Lock.nonRecursive
+		}
 	}
 }
 
 /// An atomic variable.
-public final class Atomic<Value>: AtomicProtocol {
-	private let lock: PosixThreadMutex
-	private var _value: Value
+public final class Atomic<Value> {
+	private let lock: Lock
+
+	private var _value: Value {
+		didSet {
+			didSetObserver?(_value)
+		}
+	}
+
+	private let didSetObserver: ((Value) -> Void)?
 
 	/// Initialize the variable with the given initial value.
-	/// 
+	///
 	/// - parameters:
 	///   - value: Initial value for `self`.
-	public init(_ value: Value) {
+	public convenience init(_ value: Value) {
+		self.init(value, locking: .nonRecursive, didSet: nil)
+	}
+
+	public init(_ value: Value, locking: AtomicLocking = .nonRecursive, didSet action: ((Value) -> Void)? = nil) {
 		_value = value
-		lock = PosixThreadMutex()
+		self.didSetObserver = action
+		self.lock = locking.lock
+	}
+
+	/// Atomically get or set the value of the variable.
+	public var value: Value {
+		get {
+			return withValue { $0 }
+		}
+
+		set(newValue) {
+			swap(newValue)
+		}
+	}
+
+	/// Atomically replace the contents of the variable.
+	///
+	/// - parameters:
+	///   - newValue: A new value for the variable.
+	///
+	/// - returns: The old value.
+	@discardableResult
+	public func swap(_ newValue: Value) -> Value {
+		return modify { (value: inout Value) in
+			let oldValue = value
+			value = newValue
+			return oldValue
+		}
 	}
 
 	/// Atomically modifies the variable.
@@ -190,98 +267,5 @@ public final class Atomic<Value>: AtomicProtocol {
 		defer { lock.unlock() }
 
 		return try action(_value)
-	}
-}
-
-
-/// An atomic variable which uses a recursive lock.
-internal final class RecursiveAtomic<Value>: AtomicProtocol {
-	private let lock: NSRecursiveLock
-	private var _value: Value
-	private let didSetObserver: ((Value) -> Void)?
-
-	/// Initialize the variable with the given initial value.
-	/// 
-	/// - parameters:
-	///   - value: Initial value for `self`.
-	///   - name: An optional name used to create the recursive lock.
-	///   - action: An optional closure which would be invoked every time the
-	///             value of `self` is mutated.
-	internal init(_ value: Value, name: StaticString? = nil, didSet action: ((Value) -> Void)? = nil) {
-		_value = value
-		lock = NSRecursiveLock()
-		lock.name = name.map(String.init(describing:))
-		didSetObserver = action
-	}
-
-	/// Atomically modifies the variable.
-	///
-	/// - parameters:
-	///   - action: A closure that takes the current value.
-	///
-	/// - returns: The result of the action.
-	@discardableResult
-	func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result {
-		lock.lock()
-		defer {
-			didSetObserver?(_value)
-			lock.unlock()
-		}
-
-		return try action(&_value)
-	}
-	
-	/// Atomically perform an arbitrary action using the current value of the
-	/// variable.
-	///
-	/// - parameters:
-	///   - action: A closure that takes the current value.
-	///
-	/// - returns: The result of the action.
-	@discardableResult
-	func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result {
-		lock.lock()
-		defer { lock.unlock() }
-
-		return try action(_value)
-	}
-}
-
-/// A protocol used to constraint convenience `Atomic` methods and properties.
-public protocol AtomicProtocol: class {
-	associatedtype Value
-
-	@discardableResult
-	func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result
-
-	@discardableResult
-	func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result
-}
-
-extension AtomicProtocol {	
-	/// Atomically get or set the value of the variable.
-	public var value: Value {
-		get {
-			return withValue { $0 }
-		}
-	
-		set(newValue) {
-			swap(newValue)
-		}
-	}
-
-	/// Atomically replace the contents of the variable.
-	///
-	/// - parameters:
-	///   - newValue: A new value for the variable.
-	///
-	/// - returns: The old value.
-	@discardableResult
-	public func swap(_ newValue: Value) -> Value {
-		return modify { (value: inout Value) in
-			let oldValue = value
-			value = newValue
-			return oldValue
-		}
 	}
 }

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -552,7 +552,7 @@ public final class Property<Value>: PropertyProtocol {
 public final class MutableProperty<Value>: MutablePropertyProtocol {
 	private let token: Lifetime.Token
 	private let observer: Signal<Value, NoError>.Observer
-	private let atomic: RecursiveAtomic<Value>
+	private let atomic: Atomic<Value>
 
 	/// The current value of the property.
 	///
@@ -604,9 +604,9 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 		/// Need a recursive lock around `value` to allow recursive access to
 		/// `value`. Note that recursive sets will still deadlock because the
 		/// underlying producer prevents sending recursive events.
-		atomic = RecursiveAtomic(initialValue,
-		                          name: "org.reactivecocoa.ReactiveSwift.MutableProperty",
-		                          didSet: observer.send(value:))
+		atomic = Atomic(initialValue,
+		                locking: .recursive,
+		                didSet: observer.send(value:))
 	}
 
 	/// Atomically replaces the contents of the variable.


### PR DESCRIPTION
`Atomic` is an important part of ReactiveSwift but it's also something additive for any project using `ReactiveSwift` since it's publicly available for instantiation and can be used outside RAC codebases. However, it's only provided in a non-recursive version even when internally there's also a recursive implementation.

The idea behind this PR is provide both a recursive and non-recursive versions of `Atomic` and simplify the current implementation by reducing types, promoting consistency and improve performance.

This is achieved by exposing a strategy about the locking wanted plus a new initializer. I think `didSet` can be useful in certain use cases, internally it's useful for example, and it could be something to publicly expose to provide an extra flexibility or we could left this out.

```swift
public enum AtomicLocking {
    case recursive
    case nonRecursive
}

public class Atomic<Value> {

    public convenience init(_ value: Value) {}

    public init(_ value: Value, locking: AtomicLocking = .nonRecursive, didSet action: ((Value) -> Void)? = nil)
}
```

Having a single `Atomic` with this kind of parameterization avoids having two types for each version: recursive and non-recursive, plus avoiding both a protocol and extension to share implementation between them when the only thing that changes is the lock used. This was originally discussed and introduced in https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3079.

This also promotes consistency since `Atomic` is currently using a POSIX's mutex but `RecursiveAtomic` is using a `NSRecursiveLock` instead of a POSIX's mutex configured as recursive. And there's also the question of performance.

## Performance Tests

#### Test
- Xcode 8.2.1
- Swift 3.0.2
- Compiled with `-O -whole-module-optimization`
- 10 million iterations

[Source Code](https://gist.github.com/dmcrodrigues/e879828a665dd3a723789a7516bf6933)

#### Results

##### 1. No recursive lock

- `NSRecursiveLock`: 0.662 sec. (1.521% STDEV)
- `pthread_mutex_t`: 0.506 sec. (2.167% STDEV)

##### 2. Lock with recursion = 2

- `NSRecursiveLock`:  1.209 sec. (1.284% STDEV) 
- `pthread_mutex_t`: 0.733 sec. (4.105% STDEV)

##### 3. Lock with recursion = 4

- `NSRecursiveLock`:  1.885 sec. (1.401% STDEV)
- `pthread_mutex_t`: 1.001 sec. (1.572% STDEV)

##### 4. Lock with recursion = 8

- `NSRecursiveLock`:  3.233 sec. (1.800% STDEV)
- `pthread_mutex_t`: 1.437 sec. (1.204% STDEV)

---

Like was expected, a POSIX's mutex configured as recursive shows it as being much more efficient than `NSRecursiveLock` especially when there's some recursion involved. 

I don't know the reasoning behind the adoption of `NSRecursiveLock` for `RecursiveAtomic` but considering results, adopting a POSIX's mutex seems a good option in terms of consistency and performance, unless there's some detail or limitation that I may not be aware.

In case of positive feedback about this change there's some documentation missing that should be added.