### PR TITLE
Improved docs on EventLogger

### DIFF
--- a/Sources/EventLogger.swift
+++ b/Sources/EventLogger.swift
@@ -32,6 +32,12 @@ private func defaultEventLog(identifier: String, event: String, fileName: String
 }
 
 /// A type that represents an event logging function.
+/// Signature is:
+///		- identifier 
+///		- event
+///		- fileName
+///		- functionName
+///		- lineNumber
 public typealias EventLogger = (
 	_ identifier: String,
 	_ event: String,


### PR DESCRIPTION
Unfortunately, since Swift dropped named arguments on closures, Xcode provides no clues as to what they are.
All you can see when opening the compiled framework on Xcode is:
```swift
/// A type that represents an event logging function.
public typealias EventLogger = (String, String, String, String, Int) -> Swift.Void
```

So hopefully this will make it a bit easier to use.