### PR TITLE
Allow recursive value sending in MutableProperty.

### DIFF
--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -583,19 +583,40 @@ public final class Property<Value>: PropertyProtocol {
 public final class MutableProperty<Value>: MutablePropertyProtocol {
 	private let token: Lifetime.Token
 	private let observer: Signal<Value, NoError>.Observer
-	private let atomic: RecursiveAtomic<Value>
+	private let lock: CountingRecursiveLock
+	private let storage: Storage<Value>
+
+	private var recursiveQueue: Storage<[Value]>
 
 	/// The current value of the property.
 	///
 	/// Setting this to a new value will notify all observers of `signal`, or
 	/// signals created using `producer`.
+	///
+	/// - note: Both the getter and the setter can be called recursively.
 	public var value: Value {
 		get {
-			return atomic.withValue { $0 }
+			lock.readLock()
+			let value = storage.value
+			lock.readUnlock()
+			return value
 		}
 
 		set {
-			swap(newValue)
+			lock.writeLock()
+			storage.value = newValue
+
+			if lock.recursiveWriteDepth == 1 {
+				observer.send(value: newValue)
+
+				while !recursiveQueue.value.isEmpty {
+					observer.send(value: recursiveQueue.value.removeFirst())
+				}
+			} else {
+				recursiveQueue.value.append(newValue)
+			}
+
+			lock.writeUnlock()
 		}
 	}
 
@@ -610,16 +631,50 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 	/// followed by all changes over time, then complete when the property has
 	/// deinitialized.
 	public var producer: SignalProducer<Value, NoError> {
-		return SignalProducer { [atomic, weak self] producerObserver, producerDisposable in
-			atomic.withValue { value in
-				if let strongSelf = self {
-					producerObserver.send(value: value)
-					producerDisposable += strongSelf.signal.observe(producerObserver)
-				} else {
-					producerObserver.send(value: value)
-					producerObserver.sendCompleted()
+		return SignalProducer { [storage, lock, weak self] producerObserver, producerDisposable in
+			lock.readLock()
+
+			if let strongSelf = self {
+				// FIXME: Remove the relay when #140 is landed.
+				// https://github.com/ReactiveCocoa/ReactiveSwift/pull/140
+				let recursiveQueue: Storage<[Value]> = Storage([])
+				let (relaySignal, relayObserver) = Signal<Value, NoError>.pipe()
+
+				var pair = Optional((recursiveQueue, lock))
+
+				producerDisposable += strongSelf.signal.observe { event in
+					switch event {
+					case .value:
+						// The produced `Signal` is contended *only* if it is started when
+						// the write depth is non-zero. For the rest of the time, the
+						// contention would have already been tackled by `value.set`.
+						//
+						// `pair` is cleared after the latest value is replayed.
+						if let (recursiveQueue, lock) = pair, lock.recursiveWriteDepth != 0 {
+							recursiveQueue.value.append(event.value!)
+						} else {
+							relayObserver.action(event)
+						}
+
+					case .completed, .failed, .interrupted:
+						relayObserver.action(event)
+					}
 				}
+
+				producerDisposable += relaySignal.signal.observe(producerObserver)
+				relayObserver.send(value: storage.value)
+
+				while !recursiveQueue.value.isEmpty {
+					relayObserver.send(value: recursiveQueue.value.removeFirst())
+				}
+
+				pair = nil
+			} else {
+				producerObserver.send(value: storage.value)
+				producerObserver.sendCompleted()
 			}
+
+			lock.readUnlock()
 		}
 	}
 
@@ -628,16 +683,15 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 	/// - parameters:
 	///   - initialValue: Starting value for the mutable property.
 	public init(_ initialValue: Value) {
+		recursiveQueue = Storage([])
+
 		(signal, observer) = Signal.pipe()
+
 		token = Lifetime.Token()
 		lifetime = Lifetime(token)
 
-		/// Need a recursive lock around `value` to allow recursive access to
-		/// `value`. Note that recursive sets will still deadlock because the
-		/// underlying producer prevents sending recursive events.
-		atomic = RecursiveAtomic(initialValue,
-		                          name: "org.reactivecocoa.ReactiveSwift.MutableProperty",
-		                          didSet: observer.send(value:))
+		lock = CountingRecursiveLock(name: "org.reactivecocoa.ReactiveSwift.MutableProperty")
+		storage = Storage(initialValue)
 	}
 
 	/// Atomically replaces the contents of the variable.
@@ -648,10 +702,18 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 	/// - returns: The previous property value.
 	@discardableResult
 	public func swap(_ newValue: Value) -> Value {
-		return atomic.swap(newValue)
+		return modify { value in
+			let old = value
+			value = newValue
+			return old
+		}
 	}
 
 	/// Atomically modifies the variable.
+	///
+	/// - note: Mutations should only be made through the `inout` reference.
+	///         Any nested invocation to mutating methods would raise an
+	///         assertion.
 	///
 	/// - parameters:
 	///   - action: A closure that accepts old property value and returns a new
@@ -660,7 +722,24 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 	/// - returns: The result of the action.
 	@discardableResult
 	public func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result {
-		return try atomic.modify(action)
+		lock.writeLock()
+
+		// Mutating a variable when it is passed as an `inout` parameter leads to
+		// undefined behavior. So reentrancy has to be disabled.
+		let result = try lock.unsafeDisableReentrancy { try action(&storage.value) }
+
+		if lock.recursiveWriteDepth == 1 {
+			observer.send(value: storage.value)
+
+			while !recursiveQueue.value.isEmpty {
+				observer.send(value: recursiveQueue.value.removeFirst())
+			}
+		} else {
+			recursiveQueue.value.append(storage.value)
+		}
+
+		lock.writeUnlock()
+		return result
 	}
 
 	/// Atomically performs an arbitrary action using the current value of the
@@ -672,10 +751,21 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 	/// - returns: the result of the action.
 	@discardableResult
 	public func withValue<Result>(action: (Value) throws -> Result) rethrows -> Result {
-		return try atomic.withValue(action)
+		lock.readLock()
+		let result = try action(storage.value)
+		lock.readUnlock()
+		return result
 	}
 
 	deinit {
 		observer.sendCompleted()
+	}
+}
+
+private final class Storage<Value> {
+	var value: Value
+
+	init(_ initial: Value) {
+		value = initial
 	}
 }


### PR DESCRIPTION
This PR adds the ability to set the value of `MutableProperty` recursively. Note that it does not change the `Signal` contract which prohibits recursive value sending. It would only become part of the Property contract.

This means the following snippet is now valid:
```swift
property.producer.startWithValues { value in
    if !fulfilsTerminationCondition {
        property.value = action(value)
    }
}
```

#### Use Case

Conflict resolution in an asynchronous bidirectional binding. For example, when `propertyA` emits a `value` event, the binding observes it and [may subsequently overwrite it synchronously with a new conflict-resolved value based on the merge policy](https://github.com/ReactiveCocoa/ReactiveSwift/blob/58f55b990e89f7e1b3c6803122099fe3050ab212/Documentation/BidirectionalBindings.md#consistency-guarantees).

While it is possible to perform the writeback asynchronously, it could result in windows of visible conflicting values that is hard to workaround.