### PR TITLE
Fix infinite feedback loop between Action states

### DIFF
--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -102,8 +102,8 @@ public final class Action<Input, Output, Error: Swift.Error> {
 				}
 			}
 
-		self.isEnabled = state.map { $0.isEnabled }
-		self.isExecuting = state.map { $0.isExecuting }
+		self.isEnabled = state.map { $0.isEnabled }.skipRepeats()
+		self.isExecuting = state.map { $0.isExecuting }.skipRepeats()
 	}
 
 	/// Initializes an action that will be conditionally enabled, and creates a

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-
+import Dispatch
 import Result
 import Nimble
 import Quick

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -114,6 +114,36 @@ class ActionSpec: QuickSpec {
 				expect(action.isExecuting.value) == false
 			}
 
+			if #available(macOS 10.10, *) {
+				it("should not loop indefinitely") {
+					let condition = MutableProperty(1)
+
+					let action = Action<Void, Void, NoError>(state: condition, enabledIf: { $0 == 0 }) { _ in
+						return .empty
+					}
+
+					let disposable = CompositeDisposable()
+
+					waitUntil(timeout: 0.01) { done in
+						let target = DispatchQueue(label: "test target queue")
+						let highPriority = QueueScheduler(qos: .userInitiated, targeting: target)
+						let lowPriority = QueueScheduler(qos: .default, targeting: target)
+
+						disposable += action.isExecuting.producer
+							.observe(on: highPriority)
+							.startWithValues { _ in
+								condition.value = 10
+							}
+
+						disposable += lowPriority.schedule {
+							done()
+						}
+					}
+
+					disposable.dispose()
+				}
+			}
+
 			describe("completed") {
 				beforeEach {
 					enabled.value = true


### PR DESCRIPTION
Fixes #220.

There is a potentially circular relationship between `Action.isEnabled` and `Action.isExecuting`. It's valid for users to observe properites on `Action` and feed the output back into the action state, and in turn influence `Action.isEnabled`.

This resolves an issue where:

1. The user supplies a condition as the action enabled state
2. Any property derived from the internal `Action.state` is observed
3. Synchronously, the observer updates the user-supplied state property
4. Which updates the internal `state` property
5. Which causes an externally-observable event to fire, returning to (3), indefinitely.

The reason for this manifesting as an infinite loop, rather than an infinite recursion, is the internal use of a `replayLazily` in `Property`: each time a side effect on the user-supplied property occurs, that queues up another event inside the replayed signal producer, and the observer is never attached because there is always a buffered event to consume.

The issue was that multiple events were firing synchronously when observing `Action.isExecuting`, even though the executing state had never changed. The fix is to skip repeats on `Action.isEnabled` and `Action.isExecuting`, so that observers are only ever notified if the value actually changes, instead of whenever something triggeres a side-effect on the internal state.