### PR TITLE
Context-aware `Observer`.

### DIFF
--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -393,7 +393,7 @@ extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Err
 			}
 		}
 		
-		return observe { event in
+		return self.observe(with: observer) { event, observer in
 			switch event {
 			case let .value(value):
 				state.modify { $0.queue.append(value.producer) }
@@ -522,7 +522,7 @@ extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Err
 			}
 		}
 
-		return self.observe { event in
+		return self.observe(with: observer) { event, observer in
 			switch event {
 			case let .value(producer):
 				producer.startWithSignal { innerSignal, innerDisposable in
@@ -634,7 +634,7 @@ extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Err
 	fileprivate func observeSwitchToLatest(_ observer: Observer<Value.Value, Error>, _ latestInnerDisposable: SerialDisposable) -> Disposable? {
 		let state = Atomic(LatestState<Value, Error>())
 
-		return self.observe { event in
+		return self.observe(with: observer) { event, observer in
 			switch event {
 			case let .value(innerProducer):
 				innerProducer.startWithSignal { innerSignal, innerDisposable in
@@ -921,7 +921,7 @@ extension SignalProtocol {
 	}
 
 	fileprivate func observeFlatMapError<F>(_ handler: @escaping (Error) -> SignalProducer<Value, F>, _ observer: Observer<Value, F>, _ serialDisposable: SerialDisposable) -> Disposable? {
-		return self.observe { event in
+		return self.observe(with: observer) { event, observer in
 			switch event {
 			case let .value(value):
 				observer.send(value: value)

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -29,8 +29,22 @@ public protocol ObserverProtocol {
 public final class Observer<Value, Error: Swift.Error> {
 	public typealias Action = (Event<Value, Error>) -> Void
 
+	/// The context associated with the observer.
+	internal let context: ObserverContext
+
 	/// An action that will be performed upon arrival of the event.
 	public let action: Action
+
+	/// An initializer that accepts a closure accepting an event for the
+	/// observer.
+	///
+	/// - parameters:
+	///   - context: The context associated with the observer.
+	///   - action: A closure to lift over received event.
+	internal init(_ context: ObserverContext, _ action: @escaping Action) {
+		self.context = context
+		self.action = action
+	}
 
 	/// An initializer that accepts a closure accepting an event for the 
 	/// observer.
@@ -38,6 +52,7 @@ public final class Observer<Value, Error: Swift.Error> {
 	/// - parameters:
 	///   - action: A closure to lift over received event.
 	public init(_ action: @escaping Action) {
+		self.context = .anonymous
 		self.action = action
 	}
 
@@ -101,4 +116,9 @@ extension Observer: ObserverProtocol {
 	public func sendInterrupted() {
 		action(.interrupted)
 	}
+}
+
+internal enum ObserverContext {
+	case anonymous
+	case signalInput
 }

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -62,7 +62,7 @@ public final class Signal<Value, Error: Swift.Error> {
 		sendLock = NSLock()
 		sendLock.name = "org.reactivecocoa.ReactiveSwift.Signal.sendLock"
 
-		let observer = Observer { [weak self] event in
+		let observer = Observer(.signalInput) { [weak self] event in
 			guard let signal = self else {
 				return
 			}
@@ -420,6 +420,47 @@ extension Signal: SignalProtocol {
 }
 
 extension SignalProtocol {
+	/// Attach an observer to `self`, with the given transform applied on every
+	/// event being delivered to `observer`.
+	///
+	/// - parameters:
+	///   - observer: The observer to attach to `self`.
+	///   - transform: A closure that maps events of `self` to the event type
+	///                which `observer` can accept.
+	///
+	/// - returns: An optional `Disposable` which can be used to stop the
+	///            invocation of the callback. Disposing of the Disposable will
+	///            have no effect on the Signal itself.
+	@discardableResult
+	public func observe<U, E: Swift.Error>(
+		with observer: Observer<U, E>,
+		_ transform: @escaping (Event<Value, Error>) -> Event<U, E>
+	) -> Disposable? {
+		return self.observe(Observer(observer.context) { event in
+			observer.action(transform(event))
+		})
+	}
+
+	/// Attach an observer to `self`, with the given action invoked upon every
+	/// event being delivered.
+	///
+	/// - parameters:
+	///   - observer: The observer to attach to `self`.
+	///   - action: A closure that is invoked for every event of `self`.
+	///
+	/// - returns: An optional `Disposable` which can be used to stop the
+	///            invocation of the callback. Disposing of the Disposable will
+	///            have no effect on the Signal itself.
+	@discardableResult
+	public func observe<U, E: Swift.Error>(
+		with observer: Observer<U, E>,
+		_ action: @escaping (Event<Value, Error>, Observer<U, E>) -> Void
+	) -> Disposable? {
+		return self.observe(Observer(observer.context) { event in
+			action(event, observer)
+		})
+	}
+
 	/// Convenience override for observe(_:) to allow trailing-closure style
 	/// invocations.
 	///
@@ -528,9 +569,7 @@ extension SignalProtocol {
 	/// - returns: A signal that will send new values.
 	public func map<U>(_ transform: @escaping (Value) -> U) -> Signal<U, Error> {
 		return Signal { observer in
-			return self.observe { event in
-				observer.action(event.map(transform))
-			}
+			return self.observe(with: observer) { $0.map(transform) }
 		}
 	}
 
@@ -543,9 +582,7 @@ extension SignalProtocol {
 	/// - returns: A signal that will send new type of errors.
 	public func mapError<F>(_ transform: @escaping (Error) -> F) -> Signal<Value, F> {
 		return Signal { observer in
-			return self.observe { event in
-				observer.action(event.mapError(transform))
-			}
+			return self.observe(with: observer) { $0.mapError(transform) }
 		}
 	}
 
@@ -559,7 +596,7 @@ extension SignalProtocol {
 	///            predicate.
 	public func filter(_ predicate: @escaping (Value) -> Bool) -> Signal<Value, Error> {
 		return Signal { observer in
-			return self.observe { (event: Event<Value, Error>) -> Void in
+			return self.observe(with: observer) { event, observer in
 				guard let value = event.value else {
 					observer.action(event)
 					return
@@ -603,7 +640,7 @@ extension SignalProtocol {
 
 			var taken = 0
 
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				guard let value = event.value else {
 					observer.action(event)
 					return
@@ -728,7 +765,7 @@ extension SignalProtocol {
 		return Signal { observer in
 			let state = CollectState<Value>()
 
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				switch event {
 				case let .value(value):
 					state.append(value)
@@ -793,7 +830,7 @@ extension SignalProtocol {
 		return Signal { observer in
 			let state = CollectState<Value>()
 
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				switch event {
 				case let .value(value):
 					if predicate(state.values, value) {
@@ -824,7 +861,7 @@ extension SignalProtocol {
 	/// - returns: A signal that will yield `self` values on provided scheduler.
 	public func observe(on scheduler: SchedulerProtocol) -> Signal<Value, Error> {
 		return Signal { observer in
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				scheduler.schedule {
 					observer.action(event)
 				}
@@ -840,7 +877,7 @@ private final class CombineLatestState<Value> {
 
 extension SignalProtocol {
 	private func observeWithStates<U>(_ signalState: CombineLatestState<Value>, _ otherState: CombineLatestState<U>, _ lock: NSLock, _ observer: Signal<(), Error>.Observer) -> Disposable? {
-		return self.observe { event in
+		return self.observe(with: observer) { event, observer in
 			switch event {
 			case let .value(value):
 				lock.lock()
@@ -923,7 +960,7 @@ extension SignalProtocol {
 		precondition(interval >= 0)
 
 		return Signal { observer in
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				switch event {
 				case .failed, .interrupted:
 					scheduler.schedule {
@@ -957,7 +994,7 @@ extension SignalProtocol {
 		return Signal { observer in
 			var skipped = 0
 
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				if case .value = event, skipped < count {
 					skipped += 1
 				} else {
@@ -980,7 +1017,7 @@ extension SignalProtocol {
 	/// - returns: A signal that sends events as its values.
 	public func materialize() -> Signal<Event<Value, Error>, NoError> {
 		return Signal { observer in
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				observer.send(value: event)
 
 				switch event {
@@ -1005,7 +1042,7 @@ extension SignalProtocol where Value: EventProtocol, Error == NoError {
 	/// - returns: A signal that sends values carried by `self` events.
 	public func dematerialize() -> Signal<Value.Value, Value.Error> {
 		return Signal<Value.Value, Value.Error> { observer in
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				switch event {
 				case let .value(innerEvent):
 					observer.action(innerEvent.event)
@@ -1053,7 +1090,7 @@ extension SignalProtocol {
 
 			_ = disposed.map(disposable.add)
 
-			disposable += signal.observe { receivedEvent in
+			disposable += signal.observe(with: observer) { receivedEvent -> Event<Value, Error> in
 				event?(receivedEvent)
 
 				switch receivedEvent {
@@ -1074,7 +1111,7 @@ extension SignalProtocol {
 					terminated?()
 				}
 
-				observer.action(receivedEvent)
+				return receivedEvent
 			}
 
 			return disposable
@@ -1108,7 +1145,7 @@ extension SignalProtocol {
 			let state = Atomic(SampleState<Value>())
 			let disposable = CompositeDisposable()
 
-			disposable += self.observe { event in
+			disposable += self.observe(with: observer) { event, observer in
 				switch event {
 				case let .value(value):
 					state.modify {
@@ -1133,7 +1170,7 @@ extension SignalProtocol {
 				}
 			}
 			
-			disposable += sampler.observe { event in
+			disposable += sampler.observe(with: observer) { event, observer in
 				switch event {
 				case .value(let samplerValue):
 					if let value = state.value.latestValue {
@@ -1201,11 +1238,13 @@ extension SignalProtocol {
 			let state = Atomic<U?>(nil)
 			let disposable = CompositeDisposable()
 
-			disposable += samplee.observeValues { value in
-				state.value = value
+			disposable += samplee.observe(with: observer) { event, observer in
+				if let value = event.value {
+					state.value = value
+				}
 			}
 
-			disposable += self.observe { event in
+			disposable += self.observe(with: observer) { event, observer in
 				switch event {
 				case let .value(value):
 					if let value2 = state.value {
@@ -1278,7 +1317,7 @@ extension SignalProtocol {
 			let disposable = CompositeDisposable()
 			disposable += self.observe(observer)
 
-			disposable += trigger.observe { event in
+			disposable += trigger.observe(with: observer) { event, observer in
 				switch event {
 				case .value, .completed:
 					observer.sendCompleted()
@@ -1306,7 +1345,7 @@ extension SignalProtocol {
 		return Signal { observer in
 			let disposable = SerialDisposable()
 			
-			disposable.inner = trigger.observe { event in
+			disposable.inner = trigger.observe(with: observer) { event, observer in
 				switch event {
 				case .value, .completed:
 					disposable.inner = self.observe(observer)
@@ -1382,7 +1421,7 @@ extension SignalProtocol {
 		return Signal { observer in
 			var accumulator = initial
 
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				observer.action(event.map { value in
 					accumulator = combine(accumulator, value)
 					return accumulator
@@ -1446,7 +1485,7 @@ extension SignalProtocol {
 		return Signal { observer in
 			var shouldSkip = true
 
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				switch event {
 				case let .value(value):
 					shouldSkip = shouldSkip && predicate(value)
@@ -1488,9 +1527,9 @@ extension SignalProtocol {
 			}
 
 			disposable += signalDisposable
-			disposable += signal.observe { event in
+			disposable += signal.observe(with: observer) { event -> Event<Value, Error> in
 				signalDisposable?.dispose()
-				observer.action(event)
+				return event
 			}
 
 			return disposable
@@ -1510,7 +1549,7 @@ extension SignalProtocol {
 			var buffer: [Value] = []
 			buffer.reserveCapacity(count)
 
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				switch event {
 				case let .value(value):
 					// To avoid exceeding the reserved capacity of the buffer, 
@@ -1546,7 +1585,7 @@ extension SignalProtocol {
 	///            pass the given `predicate`.
 	public func take(while predicate: @escaping (Value) -> Bool) -> Signal<Value, Error> {
 		return Signal { observer in
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				if let value = event.value, !predicate(value) {
 					observer.sendCompleted()
 				} else {
@@ -1605,7 +1644,7 @@ extension SignalProtocol {
 			let onFailed = observer.send(error:)
 			let onInterrupted = observer.sendInterrupted
 
-			disposable += self.observe { event in
+			disposable += self.observe(with: observer) { event, observer in
 				switch event {
 				case let .value(value):
 					state.modify {
@@ -1627,7 +1666,7 @@ extension SignalProtocol {
 				}
 			}
 
-			disposable += other.observe { event in
+			disposable += other.observe(with: observer) { event, observer in
 				switch event {
 				case let .value(value):
 					state.modify {
@@ -1683,7 +1722,7 @@ extension SignalProtocol {
 			let disposable = CompositeDisposable()
 			disposable += schedulerDisposable
 
-			disposable += self.observe { event in
+			disposable += self.observe(with: observer) { event, observer in
 				guard let value = event.value else {
 					schedulerDisposable.inner = scheduler.schedule {
 						observer.action(event)
@@ -1792,7 +1831,7 @@ extension SignalProtocol {
 					}
 				}
 
-			disposable += self.observe { event in
+			disposable += self.observe(with: observer) { event, observer in
 				let eventToSend = state.modify { state -> Event<Value, Error>? in
 					switch event {
 					case let .value(value):
@@ -1873,7 +1912,7 @@ extension SignalProtocol {
 			var seenValues: Set<Identity> = []
 			
 			return self
-				.observe { event in
+				.observe(with: observer) { event, observer in
 					switch event {
 					case let .value(value):
 						let identity = transform(value)
@@ -2146,7 +2185,7 @@ extension SignalProtocol where Error == NoError {
 	/// - returns: A signal that has an instantiatable `ErrorType`.
 	public func promoteErrors<F: Swift.Error>(_: F.Type) -> Signal<Value, F> {
 		return Signal { observer in
-			return self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				switch event {
 				case let .value(value):
 					observer.send(value: value)
@@ -2247,7 +2286,7 @@ extension SignalProtocol {
 	///            `Result` is `success`ful, `failed` events otherwise.
 	public func attemptMap<U>(_ operation: @escaping (Value) -> Result<U, Error>) -> Signal<U, Error> {
 		return Signal { observer in
-			self.observe { event in
+			return self.observe(with: observer) { event, observer in
 				switch event {
 				case let .value(value):
 					operation(value).analysis(


### PR DESCRIPTION
_Part of the initiative of Signal adaptivity (#163), and refactoring of interrupt propagation (#144). Preceded by #222._
_____

This PR proposes to make `Observer` aware of its context internally. Two new variants of `observe` are introduced to enable propagation of the context, especially in the implementation of operators.

In other words, with the PR, all `Signal` compositions should attach the event emitter _directly_ to the upstream `Signal`. Currently, it is done by invoking the event emitter in an anonymous `Observer` — this breaks the implicit context propagation.

`ObserverContext` at this moment is only a placeholder. `ObserverContext.signalInput` would be used by future work to associate a _reversed back channel_ for ~~`Signal` adaptivity (#163) and~~ interrupt propagation (#144).

```swift
extension SignalProtocol {
	/// Attach an observer to `self`, with the given transform applied on every
	/// event being delivered to `observer`.
	///
	/// - parameters:
	///   - observer: The observer to attach to `self`.
	///   - transform: A closure that maps events of `self` to the event type
	///                which `observer` can accept.
	///
	/// - returns: An optional `Disposable` which can be used to stop the
	///            invocation of the callback. Disposing of the Disposable will
	///            have no effect on the Signal itself.
	@discardableResult
	public func observe<U, E: Swift.Error>(
		with observer: Observer<U, E>,
		_ transform: @escaping (Event<Value, Error>) -> Event<U, E>
	) -> Disposable?

	/// Attach an observer to `self`, with the given action invoked upon every
	/// event being delivered.
	///
	/// - parameters:
	///   - observer: The observer to attach to `self`.
	///   - action: A closure that is invoked for every event of `self`.
	///
	/// - returns: An optional `Disposable` which can be used to stop the
	///            invocation of the callback. Disposing of the Disposable will
	///            have no effect on the Signal itself.
	@discardableResult
	public func observe<U, E: Swift.Error>(
		with observer: Observer<U, E>,
		_ action: @escaping (Event<Value, Error>, Observer<U, E>) -> Void
	) -> Disposable?
}
```
While the observer argument in `(Event<Value, Error>, Observer<U, E>) -> Void` is not absolutely necessary, it mimics the signature of `withExtendedLifetime` and similar free functions, and accepts function references that would otherwise need to be reabstracted for capturing `observer`.

#### API changes
The proposed changes alone are addictive in ReactiveSwift 1.x.

If interrupt propagation is to be handled by the proposed _reversed back channel_, it would be at least mandatory for all lifted `Signal` operators, thus being a breaking change due to lifting being publicly available. 