### PR TITLE
`Lifetime.observeEnded` and `take(during:)` fix.

### DIFF
--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -80,7 +80,7 @@ public final class Action<Input, Output, Error: Swift.Error> {
 		lifetime = Lifetime(deinitToken)
 		
 		// Retain the `property` for the created `Action`.
-		lifetime.ended.observeCompleted { _ = property }
+		lifetime.observeEnded { _ = property }
 
 		executeClosure = { state, input in execute(state as! State.Value, input) }
 

--- a/Sources/Lifetime.swift
+++ b/Sources/Lifetime.swift
@@ -20,7 +20,10 @@ public final class Lifetime {
 	/// MARK: Instance properties
 
 	/// A signal that sends a `completed` event when the lifetime ends.
-	public let ended: Signal<(), NoError>
+	///
+	/// - note: Consider using `Lifetime.observeEnded` if only a closure observer
+	///         is to be attached.
+ 	public let ended: Signal<(), NoError>
 
 	/// MARK: Initializers
 
@@ -43,6 +46,22 @@ public final class Lifetime {
 	///            associated object.
 	public convenience init(_ token: Token) {
 		self.init(ended: token.ended)
+	}
+
+	/// Observe the termination of `self`.
+	///
+	/// - parameters:
+	///   - action: The action to be invoked when `self` ends.
+	///
+	/// - returns: A disposable that detaches `action` from the lifetime, or `nil`
+	///            if `lifetime` has already ended.
+	@discardableResult
+	public func observeEnded(_ action: @escaping () -> Void) -> Disposable? {
+		return ended.observe { event in
+			if event.isTerminating {
+				action()
+			}
+		}
 	}
 
 	/// A token object which completes its signal when it deinitializes.

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1311,7 +1311,12 @@ extension SignalProtocol {
 	///
 	/// - returns: A signal that will deliver events until `lifetime` ends.
 	public func take(during lifetime: Lifetime) -> Signal<Value, Error> {
-		return take(until: lifetime.ended)
+		return Signal { observer in
+			let disposable = CompositeDisposable()
+			disposable += self.observe(observer)
+			disposable += lifetime.observeEnded(observer.sendCompleted)
+			return disposable
+		}
 	}
 
 	/// Forward events from `self` until `trigger` sends a `value` or

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -856,7 +856,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that will deliver events until `lifetime` ends.
 	public func take(during lifetime: Lifetime) -> SignalProducer<Value, Error> {
-		return take(until: lifetime.ended)
+		return lift { $0.take(during: lifetime) }
 	}
 
 	/// Forward events from `self` until `trigger` sends a `value` or `completed`

--- a/Tests/ReactiveSwiftTests/LifetimeSpec.swift
+++ b/Tests/ReactiveSwiftTests/LifetimeSpec.swift
@@ -1,6 +1,6 @@
 import Quick
 import Nimble
-@testable import ReactiveSwift
+import ReactiveSwift
 import Result
 
 final class LifetimeSpec: QuickSpec {

--- a/Tests/ReactiveSwiftTests/LifetimeSpec.swift
+++ b/Tests/ReactiveSwiftTests/LifetimeSpec.swift
@@ -1,6 +1,6 @@
 import Quick
 import Nimble
-import ReactiveSwift
+@testable import ReactiveSwift
 import Result
 
 final class LifetimeSpec: QuickSpec {
@@ -37,13 +37,45 @@ final class LifetimeSpec: QuickSpec {
 
 				(lifetime, token) = Lifetime.makeLifetime()
 
-				var isCompleted = false
-				lifetime.ended.observeCompleted { isCompleted = true }
+				var isEnded = false
+				lifetime.observeEnded { isEnded = true }
 
 				token = Lifetime.Token()
 				_ = token
 
-				expect(isCompleted) == true
+				expect(isEnded) == true
+			}
+
+			it("should notify its observers when the underlying token deinitializes") {
+				let object = MutableReference(TestObject())
+
+				var isEnded = false
+
+				object.value!.lifetime.observeEnded { isEnded = true }
+				expect(isEnded) == false
+
+				object.value = nil
+				expect(isEnded) == true
+			}
+
+			it("should notify its observers of the deinitialization of the underlying token even if the `Lifetime` object is retained") {
+				let object = MutableReference(TestObject())
+				let lifetime = object.value!.lifetime
+
+				var isEnded = false
+
+				lifetime.observeEnded { isEnded = true }
+				expect(isEnded) == false
+
+				object.value = nil
+				expect(isEnded) == true
+			}
+
+			it("should notify its observers of its deinitialization if it has already ended") {
+				var isEnded = false
+
+				Lifetime.empty.observeEnded { isEnded = true }
+				expect(isEnded) == true
 			}
 		}
 	}

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -253,7 +253,7 @@ class PropertySpec: QuickSpec {
 				var property = Optional(MutableProperty<Int>(1))
 
 				var isEnded = false
-				property!.lifetime.ended.observeCompleted {
+				property!.lifetime.observeEnded {
 					isEnded = true
 				}
 

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -923,7 +923,7 @@ class SignalProducerSpec: QuickSpec {
 
 			it("doesn't extend the lifetime of the throttle property") {
 				var completed = false
-				shouldThrottle.lifetime.ended.observeCompleted { completed = true }
+				shouldThrottle.lifetime.observeEnded { completed = true }
 
 				observer.send(value: 1)
 				shouldThrottle = nil

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -1713,7 +1713,7 @@ class SignalSpec: QuickSpec {
 
 			it("doesn't extend the lifetime of the throttle property") {
 				var completed = false
-				shouldThrottle.lifetime.ended.observeCompleted { completed = true }
+				shouldThrottle.lifetime.observeEnded { completed = true }
 
 				observer.send(value: 1)
 				shouldThrottle = nil


### PR DESCRIPTION
1. New methods and operator: ~~`attach`,~~ `observeEnded` ~~and `+=`~~.

   `ended` provides a full `Signal` interface that is overblown for the general use cases of `Lifetime`.

1. [Bugfix?] Safe observation ~~& deprecating `Lifetime.ended`.~~

   `ended.observeCompleted` does not handle the observations to a terminated `ended` Signal, and the action is simply ignored.

    [It should have been invoked regardless](https://github.com/ReactiveCocoa/ReactiveSwift/pull/229/files#diff-66075186b734efda335ddf4d9c209017R62), like how adding a `Disposable` to disposed `CompositeDisposable` would dispose of the disposable being added.

   ~~Composition of `Lifetime` is suggested to be done through lifetime operators instead, e.g. `and` and `or`, should the demand arise.~~

