### PR TITLE
Add bindingTarget to MutableProperty

### DIFF
--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 GitHub. All rights reserved.
 //
 
+import Dispatch
 import Foundation
 
 import Result


### PR DESCRIPTION
This PR adds a helpful `bindingTarget` function to `MutableProperty` that allows for the easy creation of "lenses" on a property that contains a simple value type.

For example, you could use it like this:

``` swift
final class SomeViewModel {
  let size = MutableProperty<CGSize>(CGSize(width: 720, height: 480))
  
  let width: BindingTarget<CGFloat>
  let height: BindingTarget<CGFloat>

  init() {
    width = size.bindingTarget { newWidth, size in
      return CGSize(width: newWidth, height: size.height)
    }
    height = size.bindingTarget { newHeight, size in
      return CGSize(width: size.width, height: newHeight)
    }
  }
}
```

Then, your view controller could simply bind a control's values directly into the width/height binding targets, and the `size` property is the single source of truth.

The benefit of exposing `bindingTarget` is that the `modify` operation is used internally to ensure that the value is atomically set on the underlying property, and the returned `BindingTarget` instance follows the `lifetime` of its parent `MutableProperty`.