### PR TITLE
Pitch: Deprecate ActionProtocol

### DIFF
--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -207,6 +207,7 @@ private struct ActionState {
 }
 
 /// A protocol used to constraint `Action` initializers.
+@available(swift, deprecated: 3.1, message: "This protocol is no longer necessary and will be removed in a future version of ReactiveSwift. Use Action directly instead.")
 public protocol ActionProtocol: BindingTargetProtocol {
 	/// The type of argument to apply the action to.
 	associatedtype Input

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -33,7 +33,7 @@ internal protocol AtomicStateProtocol {
 internal struct UnsafeAtomicState<State: RawRepresentable>: AtomicStateProtocol where State.RawValue == Int32 {
 	internal typealias Transition = (expected: State, next: State)
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-	private let value: UnsafeMutablePointer<Int32>
+	internal let value: UnsafeMutablePointer<Int32>
 
 	/// Create a finite state machine with the specified initial state.
 	///


### PR DESCRIPTION
...instead of removing it completely. See the discussion on #245 for context. I'm proposing this change as an alternative for discussion: there are some issues with this approach, so I thought it would be good to have something concrete to discuss.

Benefits:

- Mergeable into master now, suitable for inclusion in the next minor release.
- `ActionProtocol` is an implementation detail, but isn't clearly documented as such. There are possibly users making use of it in ways we didn't intend (I was once one of them).

**Update:** See https://github.com/ReactiveCocoa/ReactiveSwift/pull/248#issuecomment-277496797.

<strike>
Downsides:

- Because conditionally compiled code has to be syntactically valid, we essentially have to duplicate the extension. I experimented with using an internal typealias to work around this limitation, but it was unfortunately a dead-end.

I don't have much of a problem with the amount of duplication in this case. But it's pretty clear to me that this approach won't scale all that well to `SignalProtocol` and `SignalProducerProtocol`, whose extensions currently house all of the operator definitions. There would be a _lot_ of duplication. There are certainly techniques we could use to avoid duplicating the implementations (reducing the duplication to declarations only), but they might not be pretty.
</strike>