### PR TITLE
Reformulate unidirectional binding protocols.

### DIFF
--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -69,6 +69,9 @@
 		9A1D067D1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */; };
 		9A1D067E1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */; };
 		9A1D067F1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */; };
+		9A681A9E1E5A241B00B097CF /* DeprecationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */; };
+		9A681A9F1E5A241B00B097CF /* DeprecationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */; };
+		9A681AA01E5A241B00B097CF /* DeprecationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */; };
 		9A9100DF1E0E6E620093E346 /* ValidatingProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */; };
 		9A9100E01E0E6E670093E346 /* ValidatingProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */; };
 		9A9100E11E0E6E680093E346 /* ValidatingProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */; };
@@ -246,6 +249,7 @@
 		9A090C131DA0309E00EE97CA /* Reactive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reactive.swift; sourceTree = "<group>"; };
 		9A1A4F981E16961C006F3039 /* ValidatingPropertySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidatingPropertySpec.swift; sourceTree = "<group>"; };
 		9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnidirectionalBindingSpec.swift; sourceTree = "<group>"; };
+		9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationSpec.swift; sourceTree = "<group>"; };
 		9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidatingProperty.swift; sourceTree = "<group>"; };
 		9ABCB1841D2A5B5A00BCA243 /* Deprecations+Removals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Deprecations+Removals.swift"; sourceTree = "<group>"; };
 		A97451331B3A935E00F48E55 /* watchOS-Application.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Application.xcconfig"; sourceTree = "<group>"; };
@@ -512,6 +516,7 @@
 				C79B64731CD38B2B003F2376 /* TestLogger.swift */,
 				9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */,
 				9A1A4F981E16961C006F3039 /* ValidatingPropertySpec.swift */,
+				9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */,
 				D04725FA19E49ED7006002AA /* Supporting Files */,
 			);
 			name = ReactiveSwiftTests;
@@ -919,6 +924,7 @@
 				7DFBED291CDB8DE300EE435B /* SchedulerSpec.swift in Sources */,
 				7DFBED2A1CDB8DE300EE435B /* SignalLifetimeSpec.swift in Sources */,
 				7DFBED2B1CDB8DE300EE435B /* SignalProducerSpec.swift in Sources */,
+				9A681AA01E5A241B00B097CF /* DeprecationSpec.swift in Sources */,
 				7DFBED2C1CDB8DE300EE435B /* SignalProducerLiftingSpec.swift in Sources */,
 				7DFBED2D1CDB8DE300EE435B /* SignalSpec.swift in Sources */,
 				7DFBED2E1CDB8DE300EE435B /* FlattenSpec.swift in Sources */,
@@ -1001,6 +1007,7 @@
 				C79B64741CD38B2B003F2376 /* TestLogger.swift in Sources */,
 				CA6F28501C52626B001879D2 /* FlattenSpec.swift in Sources */,
 				4A0E11041D2A95200065D310 /* LifetimeSpec.swift in Sources */,
+				9A681A9E1E5A241B00B097CF /* DeprecationSpec.swift in Sources */,
 				CDCD247A1C277EEC00710AEE /* AtomicSpec.swift in Sources */,
 				579504331BB8A34200A5E482 /* BagSpec.swift in Sources */,
 				D0A226081A72E0E900D33B74 /* SignalSpec.swift in Sources */,
@@ -1055,6 +1062,7 @@
 				BFA6B94E1A7604D500C846D1 /* SignalProducerNimbleMatchers.swift in Sources */,
 				B696FB821A7640C00075236D /* TestError.swift in Sources */,
 				D8170FC21B100EBC004192AD /* FoundationExtensionsSpec.swift in Sources */,
+				9A681A9F1E5A241B00B097CF /* DeprecationSpec.swift in Sources */,
 				D0C3131419EF2B2000984962 /* SchedulerSpec.swift in Sources */,
 				C79B64751CD38B2B003F2376 /* TestLogger.swift in Sources */,
 				D0C3131219EF2B2000984962 /* DisposableSpec.swift in Sources */,

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -207,7 +207,7 @@ private struct ActionState {
 }
 
 /// A protocol used to constraint `Action` initializers.
-public protocol ActionProtocol: BindingTargetProtocol {
+public protocol ActionProtocol: BindingTargetProvider {
 	/// The type of argument to apply the action to.
 	associatedtype Input
 	/// The type of values returned by the action.
@@ -259,15 +259,13 @@ public protocol ActionProtocol: BindingTargetProtocol {
 	func apply(_ input: Input) -> SignalProducer<Output, ActionError<Error>>
 }
 
-extension ActionProtocol {
-	public func consume(_ value: Input) {
-		apply(value).start()
-	}
-}
-
 extension Action: ActionProtocol {
 	public var action: Action {
 		return self
+	}
+
+	public var bindingTarget: BindingTarget<Input> {
+		return BindingTarget(lifetime: lifetime) { [weak self] in self?.apply($0).start() }
 	}
 }
 

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -207,7 +207,7 @@ private struct ActionState {
 }
 
 /// A protocol used to constraint `Action` initializers.
-public protocol ActionProtocol: BindingTargetProvider {
+public protocol ActionProtocol: BindingTargetProvider, BindingTargetProtocol {
 	/// The type of argument to apply the action to.
 	associatedtype Input
 	/// The type of values returned by the action.

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -11,8 +11,32 @@ public typealias DateSchedulerProtocol = DateScheduler
 @available(*, deprecated, renamed:"BindingSource")
 public typealias BindingSourceProtocol = BindingSource
 
-@available(*, unavailable, message:"The protocol has been replaced by `BindingTargetProvider`.")
-public protocol BindingTargetProtocol {}
+@available(*, deprecated, message:"The protocol has been replaced by `BindingTargetProvider`, and will be removed in a future version.")
+public protocol BindingTargetProtocol: class, BindingTargetProvider {
+	var lifetime: Lifetime { get }
+
+	func consume(_ value: Value)
+}
+
+extension BindingTargetProtocol {
+	public var bindingTarget: BindingTarget<Value> {
+		return BindingTarget(lifetime: lifetime) { [weak self] in self?.consume($0) }
+	}
+}
+
+extension MutablePropertyProtocol {
+	@available(*, deprecated, message:"Use the regular setter.")
+	public func consume(_ value: Value) {
+		self.value = value
+	}
+}
+
+extension Action: BindingTargetProtocol {
+	@available(*, deprecated, message:"Use the regular SignalProducer.")
+	public func consume(_ value: Input) {
+		self.apply(value).start()
+	}
+}
 
 extension BindingTarget {
 	@available(*, deprecated, renamed:"action")

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -8,6 +8,29 @@ public typealias SchedulerProtocol = Scheduler
 @available(*, deprecated, renamed:"DateScheduler")
 public typealias DateSchedulerProtocol = DateScheduler
 
+@available(*, deprecated, renamed:"BindingSource")
+public typealias BindingSourceProtocol = BindingSource
+
+@available(*, unavailable, message:"The protocol has been replaced by `BindingTargetProvider`.")
+public protocol BindingTargetProtocol {}
+
+extension BindingTarget {
+	@available(*, deprecated, renamed:"action")
+	public func consume(_ value: Value) {
+		action(value)
+	}
+
+	@available(*, deprecated, renamed:"init(lifetime:action:)")
+	public init(lifetime: Lifetime, setter: @escaping (Value) -> Void, _ void: Void? = nil) {
+		self.init(lifetime: lifetime, action: setter)
+	}
+
+	@available(*, deprecated, renamed:"init(on:lifetime:action:)")
+	public init(on scheduler: Scheduler, lifetime: Lifetime, setter: @escaping (Value) -> Void, _ void: Void? = nil) {
+		self.init(on: scheduler, lifetime: lifetime, action: setter)
+	}
+}
+
 // MARK: Removed Types and APIs in ReactiveCocoa 5.0.
 
 // Renamed Protocols

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -5,7 +5,7 @@ import enum Result.NoError
 ///
 /// Only classes can conform to this protocol, because having a signal
 /// for changes over time implies the origin must have a unique identity.
-public protocol PropertyProtocol: class, BindingSourceProtocol {
+public protocol PropertyProtocol: class, BindingSource {
 	associatedtype Value
 
 	/// The current value of the property.
@@ -38,15 +38,18 @@ extension PropertyProtocol {
 }
 
 /// Represents an observable property that can be mutated directly.
-public protocol MutablePropertyProtocol: PropertyProtocol, BindingTargetProtocol {
+public protocol MutablePropertyProtocol: PropertyProtocol, BindingTargetProvider {
 	/// The current value of the property.
 	var value: Value { get set }
+
+	/// The lifetime of the property.
+	var lifetime: Lifetime { get }
 }
 
-/// Default implementation of `MutablePropertyProtocol` for `BindingTarget`.
+/// Default implementation of `BindingTargetProvider` for mutable properties.
 extension MutablePropertyProtocol {
-	public func consume(_ value: Value) {
-		self.value = value
+	public var bindingTarget: BindingTarget<Value> {
+		return BindingTarget(lifetime: lifetime) { [weak self] in self?.value = $0 }
 	}
 }
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -38,7 +38,7 @@ extension PropertyProtocol {
 }
 
 /// Represents an observable property that can be mutated directly.
-public protocol MutablePropertyProtocol: PropertyProtocol, BindingTargetProvider {
+public protocol MutablePropertyProtocol: PropertyProtocol, BindingTargetProvider, BindingTargetProtocol {
 	/// The current value of the property.
 	var value: Value { get set }
 

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -12,7 +12,7 @@ precedencegroup BindingPrecedence {
 infix operator <~ : BindingPrecedence
 
 /// Describes a source which can be bound.
-public protocol BindingSourceProtocol {
+public protocol BindingSource {
 	associatedtype Value
 	associatedtype Error: Swift.Error
 
@@ -21,14 +21,14 @@ public protocol BindingSourceProtocol {
 	func observe(_ observer: Observer<Value, Error>, during lifetime: Lifetime) -> Disposable?
 }
 
-extension Signal: BindingSourceProtocol {
+extension Signal: BindingSource {
 	@discardableResult
 	public func observe(_ observer: Observer, during lifetime: Lifetime) -> Disposable? {
 		return self.take(during: lifetime).observe(observer)
 	}
 }
 
-extension SignalProducer: BindingSourceProtocol {
+extension SignalProducer: BindingSource {
 	@discardableResult
 	public func observe(_ observer: ProducedSignal.Observer, during lifetime: Lifetime) -> Disposable? {
 		var disposable: Disposable!
@@ -44,16 +44,11 @@ extension SignalProducer: BindingSourceProtocol {
 	}
 }
 
-/// Describes a target which can be bound.
-public protocol BindingTargetProtocol: class {
+/// Describes an entity which be bond towards.
+public protocol BindingTargetProvider {
 	associatedtype Value
 
-	/// The lifetime of `self`. The binding operators use this to determine when
-	/// the binding should be torn down.
-	var lifetime: Lifetime { get }
-
-	/// Consume a value from the binding.
-	func consume(_ value: Value)
+	var bindingTarget: BindingTarget<Value> { get }
 }
 
 /// Binds a source to a target, updating the target's value to the latest
@@ -87,21 +82,12 @@ public protocol BindingTargetProtocol: class {
 ///            event.
 @discardableResult
 public func <~
-	<Target: BindingTargetProtocol, Source: BindingSourceProtocol>
-	(target: Target, source: Source) -> Disposable?
-	where Source.Value == Target.Value, Source.Error == NoError
+	<Provider: BindingTargetProvider, Source: BindingSource>
+	(provider: Provider, source: Source) -> Disposable?
+	where Source.Value == Provider.Value, Source.Error == NoError
 {
-	// Alter the semantics of `BindingTarget` to not require it to be retained.
-	// This is done here--and not in a separate function--so that all variants
-	// of `<~` can get this behavior.
-	let observer: Observer<Target.Value, NoError>
-	if let target = target as? BindingTarget<Target.Value> {
-		observer = Observer(value: { [setter = target.setter] in setter($0) })
-	} else {
-		observer = Observer(value: { [weak target] in target?.consume($0) })
-	}
-
-	return source.observe(observer, during: target.lifetime)
+	return source.observe(Observer(value: provider.bindingTarget.action),
+	                      during: provider.bindingTarget.lifetime)
 }
 
 /// Binds a source to a target, updating the target's value to the latest
@@ -135,35 +121,31 @@ public func <~
 ///            event.
 @discardableResult
 public func <~
-	<Target: BindingTargetProtocol, Source: BindingSourceProtocol>
-	(target: Target, source: Source) -> Disposable?
-	where Target.Value: OptionalProtocol, Source.Value == Target.Value.Wrapped, Source.Error == NoError
+	<Provider: BindingTargetProvider, Source: BindingSource>
+	(provider: Provider, source: Source) -> Disposable?
+	where Provider.Value: OptionalProtocol, Source.Value == Provider.Value.Wrapped, Source.Error == NoError
 {
-	// Alter the semantics of `BindingTarget` to not require it to be retained.
-	// This is done here--and not in a separate function--so that all variants
-	// of `<~` can get this behavior.
-	let observer: Observer<Source.Value, NoError>
-	if let target = target as? BindingTarget<Target.Value> {
-		observer = Observer(value: { [setter = target.setter] in setter(Target.Value(reconstructing: $0)) })
-	} else {
-		observer = Observer(value: { [weak target] in target?.consume(Target.Value(reconstructing: $0)) })
-	}
-
-	return source.observe(observer, during: target.lifetime)
+	let action = provider.bindingTarget.action
+	return source.observe(Observer(value: { action(Provider.Value(reconstructing: $0)) }),
+	                      during: provider.bindingTarget.lifetime)
 }
 
 /// A binding target that can be used with the `<~` operator.
-public final class BindingTarget<Value>: BindingTargetProtocol {
+public struct BindingTarget<Value>: BindingTargetProvider {
 	public let lifetime: Lifetime
-	fileprivate let setter: (Value) -> Void
+	public let action: (Value) -> Void
+
+	public var bindingTarget: BindingTarget<Value> {
+		return self
+	}
 
 	/// Creates a binding target.
 	///
 	/// - parameters:
 	///   - lifetime: The expected lifetime of any bindings towards `self`.
-	///   - setter: The action to consume values.
-	public init(lifetime: Lifetime, setter: @escaping (Value) -> Void) {
-		self.setter = setter
+	///   - action: The action to consume values.
+	public init(lifetime: Lifetime, action: @escaping (Value) -> Void) {
+		self.action = action
 		self.lifetime = lifetime
 	}
 
@@ -172,17 +154,13 @@ public final class BindingTarget<Value>: BindingTargetProtocol {
 	/// - parameters:
 	///   - scheduler: The scheduler on which the `setter` consumes the values.
 	///   - lifetime: The expected lifetime of any bindings towards `self`.
-	///   - setter: The action to consume values.
-	public convenience init(on scheduler: Scheduler, lifetime: Lifetime, setter: @escaping (Value) -> Void) {
+	///   - action: The action to consume values.
+	public init(on scheduler: Scheduler, lifetime: Lifetime, action: @escaping (Value) -> Void) {
 		let setter: (Value) -> Void = { value in
 			scheduler.schedule {
-				setter(value)
+				action(value)
 			}
 		}
-		self.init(lifetime: lifetime, setter: setter)
-	}
-
-	public func consume(_ value: Value) {
-		setter(value)
+		self.init(lifetime: lifetime, action: setter)
 	}
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -8,6 +8,7 @@ Quick.QCKMain([
     AtomicSpec.self,
     BagSpec.self,
     DisposableSpec.self,
+    DeprecationSpec.self,
     FlattenSpec.self,
     FoundationExtensionsSpec.self,
     LifetimeSpec.self,

--- a/Tests/ReactiveSwiftTests/DeprecationSpec.swift
+++ b/Tests/ReactiveSwiftTests/DeprecationSpec.swift
@@ -1,0 +1,35 @@
+import Quick
+import Nimble
+import ReactiveSwift
+import Result
+
+final class TestTarget: BindingTargetProtocol {
+	typealias Value = Int
+
+	var counter = 0
+
+	let (lifetime, token) = Lifetime.make()
+
+	func consume(_ value: Int) {
+		counter += 1
+	}
+}
+
+class DeprecationSpec: QuickSpec {
+	override func spec() {
+		describe("BindingTargetProtocol") {
+			it("should make the conforming type a valid BindingTargetProvider automatically") {
+				let target = TestTarget()
+				let property = MutableProperty<Int>(0)
+
+				expect(target.counter) == 0
+
+				target <~ property
+				expect(target.counter) == 1
+
+				property.value = 0
+				expect(target.counter) == 2
+			}
+		}
+	}
+}

--- a/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
+++ b/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
@@ -17,8 +17,8 @@ class UnidirectionalBindingSpec: QuickSpec {
 			beforeEach {
 				token = Lifetime.Token()
 				lifetime = Lifetime(token)
-				target = BindingTarget(lifetime: lifetime, setter: { value = $0 })
-				optionalTarget = BindingTarget(lifetime: lifetime, setter: { value = $0 })
+				target = BindingTarget(lifetime: lifetime, action: { value = $0 })
+				optionalTarget = BindingTarget(lifetime: lifetime, action: { value = $0 })
 				value = nil
 			}
 
@@ -27,24 +27,10 @@ class UnidirectionalBindingSpec: QuickSpec {
 					expect(target.lifetime).to(beIdenticalTo(lifetime))
 				}
 
-				it("should stay bound after deallocation") {
-					weak var weakTarget = target
-
-					let property = MutableProperty(1)
-					target <~ property
-					expect(value) == 1
-
-					target = nil
-
-					property.value = 2
-					expect(value) == 2
-					expect(weakTarget).to(beNil())
-				}
-
 				it("should trigger the supplied setter") {
 					expect(value).to(beNil())
 
-					target.consume(1)
+					target.action(1)
 					expect(value) == 1
 				}
 
@@ -65,24 +51,10 @@ class UnidirectionalBindingSpec: QuickSpec {
 					expect(optionalTarget.lifetime).to(beIdenticalTo(lifetime))
 				}
 
-				it("should stay bound after deallocation") {
-					weak var weakTarget = optionalTarget
-
-					let property = MutableProperty(1)
-					optionalTarget <~ property
-					expect(value) == 1
-
-					optionalTarget = nil
-
-					property.value = 2
-					expect(value) == 2
-					expect(weakTarget).to(beNil())
-				}
-
 				it("should trigger the supplied setter") {
 					expect(value).to(beNil())
 
-					optionalTarget.consume(1)
+					optionalTarget.action(1)
 					expect(value) == 1
 				}
 
@@ -101,7 +73,7 @@ class UnidirectionalBindingSpec: QuickSpec {
 			it("should not deadlock on the same queue") {
 				target = BindingTarget(on: UIScheduler(),
 				                       lifetime: lifetime,
-				                       setter: { value = $0 })
+				                       action: { value = $0 })
 
 				let property = MutableProperty(1)
 				target <~ property
@@ -113,7 +85,7 @@ class UnidirectionalBindingSpec: QuickSpec {
 
 				target = BindingTarget(on: UIScheduler(),
 				                       lifetime: lifetime,
-				                       setter: { value = $0 })
+				                       action: { value = $0 })
 
 				let property = MutableProperty(1)
 
@@ -137,7 +109,7 @@ class UnidirectionalBindingSpec: QuickSpec {
 
 				target = BindingTarget(on: UIScheduler(),
 				                       lifetime: lifetime,
-				                       setter: setter)
+				                       action: setter)
 
 				let scheduler: QueueScheduler
 				if #available(OSX 10.10, *) {


### PR DESCRIPTION
Related: #241

Just the implementation. Should appear as the same to general end users.

1. Renaming: `BindingSource` and `BindingTargetProvider`.

1. `BindingTargetProvider` now requires all conforming type to return a concrete `BindingTarget`. Moreover, `BindingTargetProvider` is no longer class bound.

1. The special mechanic for `BindingTarget` has been removed with (2) in place.