### PR TITLE
Rename scheduler protocols.

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -1,6 +1,13 @@
 import Foundation
 import enum Result.NoError
 
+// MARK: Depreciated types in ReactiveSwift 1.x.
+@available(*, deprecated, renamed:"Scheduler")
+public typealias SchedulerProtocol = Scheduler
+
+@available(*, deprecated, renamed:"DateScheduler")
+public typealias DateSchedulerProtocol = DateScheduler
+
 // MARK: Removed Types and APIs in ReactiveCocoa 5.0.
 
 // Renamed Protocols
@@ -22,10 +29,10 @@ public enum MutablePropertyType {}
 @available(*, unavailable, renamed:"ObserverProtocol")
 public enum ObserverType {}
 
-@available(*, unavailable, renamed:"SchedulerProtocol")
+@available(*, unavailable, renamed:"Scheduler")
 public enum SchedulerType {}
 
-@available(*, unavailable, renamed:"DateSchedulerProtocol")
+@available(*, unavailable, renamed:"DateScheduler")
 public enum DateSchedulerType {}
 
 @available(*, unavailable, renamed:"OptionalProtocol")
@@ -192,7 +199,7 @@ extension SignalProtocol {
 	public func skip(_ count: Int) -> Signal<Value, Error> { fatalError() }
 
 	@available(*, unavailable, renamed:"observe(on:)")
-	public func observeOn(_ scheduler: SchedulerProtocol) -> Signal<Value, Error> { fatalError() }
+	public func observeOn(_ scheduler: Scheduler) -> Signal<Value, Error> { fatalError() }
 
 	@available(*, unavailable, renamed:"combineLatest(with:)")
 	public func combineLatestWith<S: SignalProtocol>(_ otherSignal: S) -> Signal<(Value, S.Value), Error> { fatalError() }
@@ -216,7 +223,7 @@ extension SignalProtocol {
 	public func takeWhile(_ predicate: (Value) -> Bool) -> Signal<Value, Error> { fatalError() }
 
 	@available(*, unavailable, renamed:"timeout(after:raising:on:)")
-	public func timeoutWithError(_ error: Error, afterInterval: TimeInterval, onScheduler: DateSchedulerProtocol) -> Signal<Value, Error> { fatalError() }
+	public func timeoutWithError(_ error: Error, afterInterval: TimeInterval, onScheduler: DateScheduler) -> Signal<Value, Error> { fatalError() }
 
 	@available(*, unavailable, message: "This Signal may emit errors which must be handled explicitly, or observed using `observeResult(_:)`")
 	public func observeNext(_ next: (Value) -> Void) -> Disposable? { fatalError() }
@@ -253,10 +260,10 @@ extension SignalProducerProtocol {
 	public func retry(_ count: Int) -> SignalProducer<Value, Error> { fatalError() }
 
 	@available(*, unavailable, renamed:"observe(on:)")
-	public func observeOn(_ scheduler: SchedulerProtocol) -> SignalProducer<Value, Error> { fatalError() }
+	public func observeOn(_ scheduler: Scheduler) -> SignalProducer<Value, Error> { fatalError() }
 
 	@available(*, unavailable, renamed:"start(on:)")
-	public func startOn(_ scheduler: SchedulerProtocol) -> SignalProducer<Value, Error> { fatalError() }
+	public func startOn(_ scheduler: Scheduler) -> SignalProducer<Value, Error> { fatalError() }
 
 	@available(*, unavailable, renamed:"combineLatest(with:)")
 	public func combineLatestWith<U>(_ otherProducer: SignalProducer<U, Error>) -> SignalProducer<(Value, U), Error> { fatalError() }
@@ -295,7 +302,7 @@ extension SignalProducerProtocol {
 	public func takeWhile(_ predicate: (Value) -> Bool) -> SignalProducer<Value, Error> { fatalError() }
 
 	@available(*, unavailable, renamed:"timeout(after:raising:on:)")
-	public func timeoutWithError(_ error: Error, afterInterval: TimeInterval, onScheduler: DateSchedulerProtocol) -> SignalProducer<Value, Error> { fatalError() }
+	public func timeoutWithError(_ error: Error, afterInterval: TimeInterval, onScheduler: DateScheduler) -> SignalProducer<Value, Error> { fatalError() }
 
 	@available(*, unavailable, message:"This SignalProducer may emit errors which must be handled explicitly, or observed using `startWithResult(_:)`.")
 	public func startWithNext(_ next: (Value) -> Void) -> Disposable { fatalError() }
@@ -348,7 +355,7 @@ extension Property {
 	public convenience init(initialValue: Value, signal: Signal<Value, NoError>) { fatalError() }
 }
 
-extension DateSchedulerProtocol {
+extension DateScheduler {
 	@available(*, unavailable, renamed:"schedule(after:action:)")
 	func scheduleAfter(date: Date, _ action: () -> Void) -> Disposable? { fatalError() }
 
@@ -399,10 +406,10 @@ extension Reactive where Base: URLSession {
 // Free functions
 
 @available(*, unavailable, message:"timer(interval:on:) now uses DispatchTimeInterval")
-public func timer(interval: TimeInterval, on scheduler: DateSchedulerProtocol) -> SignalProducer<Date, NoError> { fatalError() }
+public func timer(interval: TimeInterval, on scheduler: DateScheduler) -> SignalProducer<Date, NoError> { fatalError() }
 
 @available(*, unavailable, message:"timer(interval:on:leeway:) now uses DispatchTimeInterval")
-public func timer(interval: TimeInterval, on scheduler: DateSchedulerProtocol, leeway: TimeInterval) -> SignalProducer<Date, NoError> { fatalError() }
+public func timer(interval: TimeInterval, on scheduler: DateScheduler, leeway: TimeInterval) -> SignalProducer<Date, NoError> { fatalError() }
 
 @available(*, unavailable, renamed:"Signal.combineLatest")
 public func combineLatest<A, B, Error>(_ a: Signal<A, Error>, _ b: Signal<B, Error>) -> Signal<(A, B), Error> { fatalError() }

--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -121,7 +121,7 @@ extension DispatchTimeInterval {
 	/// - note: This method is only used internally to "scale down" a time 
 	///			interval. Specifically it's used only to scale intervals to 10% 
 	///			of their original value for the default `leeway` parameter in 
-	///			`SchedulerProtocol.schedule(after:action:)` schedule and similar
+	///			`Scheduler.schedule(after:action:)` schedule and similar
 	///			other methods.
 	///
 	///			If seconds is over 200,000, 10% is ~2,000, and hence we end up

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -14,7 +14,7 @@ import Foundation
 #endif
 
 /// Represents a serial queue of work items.
-public protocol SchedulerProtocol {
+public protocol Scheduler {
 	/// Enqueues an action on the scheduler.
 	///
 	/// When the work is executed depends on the scheduler in use.
@@ -27,7 +27,7 @@ public protocol SchedulerProtocol {
 
 /// A particular kind of scheduler that supports enqueuing actions at future
 /// dates.
-public protocol DateSchedulerProtocol: SchedulerProtocol {
+public protocol DateScheduler: Scheduler {
 	/// The current date, as determined by this scheduler.
 	///
 	/// This can be implemented to deterministically return a known date (e.g.,
@@ -65,7 +65,7 @@ public protocol DateSchedulerProtocol: SchedulerProtocol {
 }
 
 /// A scheduler that performs all work synchronously.
-public final class ImmediateScheduler: SchedulerProtocol {
+public final class ImmediateScheduler: Scheduler {
 	public init() {}
 
 	/// Immediately calls passed in `action`.
@@ -86,7 +86,7 @@ public final class ImmediateScheduler: SchedulerProtocol {
 /// If the caller is already running on the main queue when an action is
 /// scheduled, it may be run synchronously. However, ordering between actions
 /// will always be preserved.
-public final class UIScheduler: SchedulerProtocol {
+public final class UIScheduler: Scheduler {
 	private static let dispatchSpecificKey = DispatchSpecificKey<UInt8>()
 	private static let dispatchSpecificValue = UInt8.max
 	private static var __once: () = {
@@ -168,7 +168,7 @@ public final class UIScheduler: SchedulerProtocol {
 }
 
 /// A scheduler backed by a serial GCD queue.
-public final class QueueScheduler: DateSchedulerProtocol {
+public final class QueueScheduler: DateScheduler {
 	/// A singleton `QueueScheduler` that always targets the main thread's GCD
 	/// queue.
 	///
@@ -326,7 +326,7 @@ public final class QueueScheduler: DateSchedulerProtocol {
 }
 
 /// A scheduler that implements virtualized time, for use in testing.
-public final class TestScheduler: DateSchedulerProtocol {
+public final class TestScheduler: DateScheduler {
 	private final class ScheduledAction {
 		let date: Date
 		let action: () -> Void

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -564,7 +564,7 @@ extension SignalProtocol {
 	///
 	/// - returns: A signal that sends values obtained using `transform` as this 
 	///            signal sends values.
-	public func lazyMap<U>(on scheduler: SchedulerProtocol, transform: @escaping (Value) -> U) -> Signal<U, Error> {
+	public func lazyMap<U>(on scheduler: Scheduler, transform: @escaping (Value) -> U) -> Signal<U, Error> {
 		return flatMap(.latest) { value in
 			return SignalProducer({ transform(value) })
 				.start(on: scheduler)
@@ -869,7 +869,7 @@ extension SignalProtocol {
 	///   - scheduler: A scheduler to deliver events on.
 	///
 	/// - returns: A signal that will yield `self` values on provided scheduler.
-	public func observe(on scheduler: SchedulerProtocol) -> Signal<Value, Error> {
+	public func observe(on scheduler: Scheduler) -> Signal<Value, Error> {
 		return Signal { observer in
 			return self.observe { event in
 				scheduler.schedule {
@@ -966,7 +966,7 @@ extension SignalProtocol {
 	///
 	/// - returns: A signal that will delay `value` and `completed` events and
 	///            will yield them on given scheduler.
-	public func delay(_ interval: TimeInterval, on scheduler: DateSchedulerProtocol) -> Signal<Value, Error> {
+	public func delay(_ interval: TimeInterval, on scheduler: DateScheduler) -> Signal<Value, Error> {
 		precondition(interval >= 0)
 
 		return Signal { observer in
@@ -1720,7 +1720,7 @@ extension SignalProtocol {
 	///
 	/// - returns: A signal that sends values at least `interval` seconds 
 	///            appart on a given scheduler.
-	public func throttle(_ interval: TimeInterval, on scheduler: DateSchedulerProtocol) -> Signal<Value, Error> {
+	public func throttle(_ interval: TimeInterval, on scheduler: DateScheduler) -> Signal<Value, Error> {
 		precondition(interval >= 0)
 
 		return Signal { observer in
@@ -1802,7 +1802,7 @@ extension SignalProtocol {
 	///   - scheduler: A scheduler to deliver events on.
 	///
 	/// - returns: A signal that sends values only while `shouldThrottle` is false.
-	public func throttle<P: PropertyProtocol>(while shouldThrottle: P, on scheduler: SchedulerProtocol) -> Signal<Value, Error>
+	public func throttle<P: PropertyProtocol>(while shouldThrottle: P, on scheduler: Scheduler) -> Signal<Value, Error>
 		where P.Value == Bool
 	{
 		return Signal { observer in
@@ -1887,7 +1887,7 @@ extension SignalProtocol {
 	///
 	/// - returns: A signal that sends values that are sent from `self` at least
 	///            `interval` seconds apart.
-	public func debounce(_ interval: TimeInterval, on scheduler: DateSchedulerProtocol) -> Signal<Value, Error> {
+	public func debounce(_ interval: TimeInterval, on scheduler: DateScheduler) -> Signal<Value, Error> {
 		precondition(interval >= 0)
 
 		let d = SerialDisposable()
@@ -2170,7 +2170,7 @@ extension SignalProtocol {
 	/// - returns: A signal that sends events for at most `interval` seconds,
 	///            then, if not `completed` - sends `error` with failed event
 	///            on `scheduler`.
-	public func timeout(after interval: TimeInterval, raising error: Error, on scheduler: DateSchedulerProtocol) -> Signal<Value, Error> {
+	public func timeout(after interval: TimeInterval, raising error: Error, on scheduler: DateScheduler) -> Signal<Value, Error> {
 		precondition(interval >= 0)
 
 		return Signal { observer in
@@ -2235,7 +2235,7 @@ extension SignalProtocol where Error == NoError {
 	public func timeout<NewError: Swift.Error>(
 		after interval: TimeInterval,
 		raising error: NewError,
-		on scheduler: DateSchedulerProtocol
+		on scheduler: DateScheduler
 	) -> Signal<Value, NewError> {
 		return self
 			.promoteErrors(NewError.self)

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -484,7 +484,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that, when started, sends values obtained using 
 	///            `transform` as this producer sends values.
-	public func lazyMap<U>(on scheduler: SchedulerProtocol, transform: @escaping (Value) -> U) -> SignalProducer<U, Error> {
+	public func lazyMap<U>(on scheduler: Scheduler, transform: @escaping (Value) -> U) -> SignalProducer<U, Error> {
 		return lift { $0.lazyMap(on: scheduler, transform: transform) }
 	}
 
@@ -648,7 +648,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that, when started, will yield `self` values on
 	///            provided scheduler.
-	public func observe(on scheduler: SchedulerProtocol) -> SignalProducer<Value, Error> {
+	public func observe(on scheduler: Scheduler) -> SignalProducer<Value, Error> {
 		return lift { $0.observe(on: scheduler) }
 	}
 
@@ -700,7 +700,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that, when started, will delay `value` and
 	///            `completed` events and will yield them on given scheduler.
-	public func delay(_ interval: TimeInterval, on scheduler: DateSchedulerProtocol) -> SignalProducer<Value, Error> {
+	public func delay(_ interval: TimeInterval, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
 		return lift { $0.delay(interval, on: scheduler) }
 	}
 
@@ -1097,7 +1097,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that sends values at least `interval` seconds
 	///            appart on a given scheduler.
-	public func throttle(_ interval: TimeInterval, on scheduler: DateSchedulerProtocol) -> SignalProducer<Value, Error> {
+	public func throttle(_ interval: TimeInterval, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
 		return lift { $0.throttle(interval, on: scheduler) }
 	}
 
@@ -1123,7 +1123,7 @@ extension SignalProducerProtocol {
 	///   - scheduler: A scheduler to deliver events on.
 	///
 	/// - returns: A producer that sends values only while `shouldThrottle` is false.
-	public func throttle<P: PropertyProtocol>(while shouldThrottle: P, on scheduler: SchedulerProtocol) -> SignalProducer<Value, Error>
+	public func throttle<P: PropertyProtocol>(while shouldThrottle: P, on scheduler: Scheduler) -> SignalProducer<Value, Error>
 		where P.Value == Bool
 	{
 		// Using `Property.init(_:)` avoids capturing a strong reference
@@ -1150,7 +1150,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that sends values that are sent from `self` at
 	///            least `interval` seconds apart.
-	public func debounce(_ interval: TimeInterval, on scheduler: DateSchedulerProtocol) -> SignalProducer<Value, Error> {
+	public func debounce(_ interval: TimeInterval, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
 		return lift { $0.debounce(interval, on: scheduler) }
 	}
 
@@ -1170,7 +1170,7 @@ extension SignalProducerProtocol {
 	/// - returns: A producer that sends events for at most `interval` seconds,
 	///            then, if not `completed` - sends `error` with `failed` event
 	///            on `scheduler`.
-	public func timeout(after interval: TimeInterval, raising error: Error, on scheduler: DateSchedulerProtocol) -> SignalProducer<Value, Error> {
+	public func timeout(after interval: TimeInterval, raising error: Error, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
 		return lift { $0.timeout(after: interval, raising: error, on: scheduler) }
 	}
 }
@@ -1230,7 +1230,7 @@ extension SignalProducerProtocol where Error == NoError {
 	public func timeout<NewError: Swift.Error>(
 		after interval: TimeInterval,
 		raising error: NewError,
-		on scheduler: DateSchedulerProtocol
+		on scheduler: DateScheduler
 	) -> SignalProducer<Value, NewError> {
 		return lift { $0.timeout(after: interval, raising: error, on: scheduler) }
 	}
@@ -1462,7 +1462,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that will deliver events on given `scheduler` when
 	///            started.
-	public func start(on scheduler: SchedulerProtocol) -> SignalProducer<Value, Error> {
+	public func start(on scheduler: Scheduler) -> SignalProducer<Value, Error> {
 		return SignalProducer { observer, compositeDisposable in
 			compositeDisposable += scheduler.schedule {
 				self.startWithSignal { signal, signalDisposable in
@@ -2124,7 +2124,7 @@ private struct ReplayState<Value, Error: Swift.Error> {
 ///   - scheduler: A scheduler to deliver events on.
 ///
 /// - returns: A producer that sends `NSDate` values every `interval` seconds.
-public func timer(interval: DispatchTimeInterval, on scheduler: DateSchedulerProtocol) -> SignalProducer<Date, NoError> {
+public func timer(interval: DispatchTimeInterval, on scheduler: DateScheduler) -> SignalProducer<Date, NoError> {
 	// Apple's "Power Efficiency Guide for Mac Apps" recommends a leeway of
 	// at least 10% of the timer interval.
 	return timer(interval: interval, on: scheduler, leeway: interval * 0.1)
@@ -2147,7 +2147,7 @@ public func timer(interval: DispatchTimeInterval, on scheduler: DateSchedulerPro
 ///             recommends a leeway of at least 10% of the timer interval.
 ///
 /// - returns: A producer that sends `NSDate` values every `interval` seconds.
-public func timer(interval: DispatchTimeInterval, on scheduler: DateSchedulerProtocol, leeway: DispatchTimeInterval) -> SignalProducer<Date, NoError> {
+public func timer(interval: DispatchTimeInterval, on scheduler: DateScheduler, leeway: DispatchTimeInterval) -> SignalProducer<Date, NoError> {
 	precondition(interval.timeInterval >= 0)
 	precondition(leeway.timeInterval >= 0)
 

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -173,7 +173,7 @@ public final class BindingTarget<Value>: BindingTargetProtocol {
 	///   - scheduler: The scheduler on which the `setter` consumes the values.
 	///   - lifetime: The expected lifetime of any bindings towards `self`.
 	///   - setter: The action to consume values.
-	public convenience init(on scheduler: SchedulerProtocol, lifetime: Lifetime, setter: @escaping (Value) -> Void) {
+	public convenience init(on scheduler: Scheduler, lifetime: Lifetime, setter: @escaping (Value) -> Void) {
 		let setter: (Value) -> Void = { value in
 			scheduler.schedule {
 				setter(value)


### PR DESCRIPTION
Since there isn't a name conflict, the protocols should drop the suffix per the Swift API Guidelines. The renaming is source compatible.