### PR TITLE
Drop the `Mutable` prefix of `MutableValidatingProperty`.

### DIFF
--- a/ReactiveSwift-UIExamples.playground/Pages/ValidatingProperty.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift-UIExamples.playground/Pages/ValidatingProperty.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ final class ViewModel {
 		static let usernameUnavailable = FormError(reason: "The username has been taken.")
 	}
 
-	let email: MutableValidatingProperty<String, FormError>
-	let emailConfirmation: MutableValidatingProperty<String, FormError>
+	let email: ValidatingProperty<String, FormError>
+	let emailConfirmation: ValidatingProperty<String, FormError>
 	let termsAccepted: MutableProperty<Bool>
 
 	let reasons: Signal<String, NoError>
@@ -21,11 +21,11 @@ final class ViewModel {
 	let submit: Action<(), (), FormError>
 
 	init(userService: UserService) {
-		email = MutableValidatingProperty<String, FormError>("") { input in
+		email = ValidatingProperty<String, FormError>("") { input in
 			return input.hasSuffix("@reactivecocoa.io") ? .success : .failure(.invalidEmail)
 		}
 
-		emailConfirmation = MutableValidatingProperty<String, FormError>("", with: email) { input, email in
+		emailConfirmation = ValidatingProperty<String, FormError>("", with: email) { input, email in
 			return input == email ? .success : .failure(.mismatchEmail)
 		}
 

--- a/Sources/ValidatingProperty.swift
+++ b/Sources/ValidatingProperty.swift
@@ -17,7 +17,7 @@ import Result
 /// root.value = "🎃"
 /// outer.result.value        // `.failure("🎃", .outerInvalid)`
 /// ```
-public final class MutableValidatingProperty<Value, ValidationError: Swift.Error>: MutablePropertyProtocol {
+public final class ValidatingProperty<Value, ValidationError: Swift.Error>: MutablePropertyProtocol {
 	private let getter: () -> Value
 	private let setter: (Value) -> Void
 
@@ -45,7 +45,7 @@ public final class MutableValidatingProperty<Value, ValidationError: Swift.Error
 	/// The lifetime of the property.
 	public let lifetime: Lifetime
 
-	/// Create a `MutableValidatingProperty` that presents a mutable validating
+	/// Create a `ValidatingProperty` that presents a mutable validating
 	/// view for an inner mutable property.
 	///
 	/// The proposed value is only committed when `success` is returned by the
@@ -91,7 +91,7 @@ public final class MutableValidatingProperty<Value, ValidationError: Swift.Error
 		}
 	}
 
-	/// Create a `MutableValidatingProperty` that validates mutations before
+	/// Create a `ValidatingProperty` that validates mutations before
 	/// committing them.
 	///
 	/// The proposed value is only committed when `success` is returned by the
@@ -108,7 +108,7 @@ public final class MutableValidatingProperty<Value, ValidationError: Swift.Error
 		self.init(MutableProperty(initial), validator)
 	}
 
-	/// Create a `MutableValidatingProperty` that presents a mutable validating
+	/// Create a `ValidatingProperty` that presents a mutable validating
 	/// view for an inner mutable property.
 	///
 	/// The proposed value is only committed when `success` is returned by the
@@ -152,7 +152,7 @@ public final class MutableValidatingProperty<Value, ValidationError: Swift.Error
 		}
 	}
 
-	/// Create a `MutableValidatingProperty` that validates mutations before
+	/// Create a `ValidatingProperty` that validates mutations before
 	/// committing them.
 	///
 	/// The proposed value is only committed when `success` is returned by the
@@ -171,7 +171,7 @@ public final class MutableValidatingProperty<Value, ValidationError: Swift.Error
 		self.init(MutableProperty(initial), with: other, validator)
 	}
 
-	/// Create a `MutableValidatingProperty` that presents a mutable validating
+	/// Create a `ValidatingProperty` that presents a mutable validating
 	/// view for an inner mutable property.
 	///
 	/// The proposed value is only committed when `success` is returned by the
@@ -185,13 +185,13 @@ public final class MutableValidatingProperty<Value, ValidationError: Swift.Error
 	///   - validator: The closure to invoke for any proposed value to `self`.
 	public convenience init<U, E: Swift.Error>(
 		_ inner: MutableProperty<Value>,
-		with other: MutableValidatingProperty<U, E>,
+		with other: ValidatingProperty<U, E>,
 		_ validator: @escaping (Value, U) -> ValidatorOutput<Value, ValidationError>
 	) {
 		self.init(inner, with: other, validator)
 	}
 
-	/// Create a `MutableValidatingProperty` that validates mutations before
+	/// Create a `ValidatingProperty` that validates mutations before
 	/// committing them.
 	///
 	/// The proposed value is only committed when `success` is returned by the
@@ -204,7 +204,7 @@ public final class MutableValidatingProperty<Value, ValidationError: Swift.Error
 	///   - validator: The closure to invoke for any proposed value to `self`.
 	public convenience init<U, E: Swift.Error>(
 		_ initial: Value,
-		with other: MutableValidatingProperty<U, E>,
+		with other: ValidatingProperty<U, E>,
 		_ validator: @escaping (Value, U) -> ValidatorOutput<Value, ValidationError>
 	) {
 		// Capture only `other.result` but not `other`.

--- a/Tests/ReactiveSwiftTests/ValidatingPropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/ValidatingPropertySpec.swift
@@ -5,15 +5,15 @@ import Result
 
 class ValidatingPropertySpec: QuickSpec {
 	override func spec() {
-		describe("MutableValidatingProperty") {
+		describe("ValidatingProperty") {
 			describe("no dependency") {
 				var root: MutableProperty<Int>!
-				var validated: MutableValidatingProperty<Int, TestError>!
+				var validated: ValidatingProperty<Int, TestError>!
 				var validationResult: FlattenedResult<Int>?
 
 				beforeEach {
 					root = MutableProperty(0)
-					validated = MutableValidatingProperty(root) { $0 >= 0 ? ($0 == 100 ? .substitution(Int.max, .default) : .success) : .failure(.default) }
+					validated = ValidatingProperty(root) { $0 >= 0 ? ($0 == 100 ? .substitution(Int.max, .default) : .success) : .failure(.default) }
 
 					validated.result.signal.observeValues { validationResult = FlattenedResult($0) }
 
@@ -72,13 +72,13 @@ class ValidatingPropertySpec: QuickSpec {
 
 			describe("a MutablePropertyProtocol dependency") {
 				var other: MutableProperty<String>!
-				var validated: MutableValidatingProperty<Int, TestError>!
+				var validated: ValidatingProperty<Int, TestError>!
 				var validationResult: FlattenedResult<Int>?
 
 				beforeEach {
 					other = MutableProperty("")
 
-					validated = MutableValidatingProperty(0, with: other) { $0 >= 0 && $1 == "🎃" ? ($0 == 100 ? .substitution(Int.max, .default) : .success) : .failure(.default) }
+					validated = ValidatingProperty(0, with: other) { $0 >= 0 && $1 == "🎃" ? ($0 == 100 ? .substitution(Int.max, .default) : .success) : .failure(.default) }
 
 					validated.result.signal.observeValues { validationResult = FlattenedResult($0) }
 
@@ -151,15 +151,15 @@ class ValidatingPropertySpec: QuickSpec {
 				}
 			}
 
-			describe("a MutableValidatingProperty dependency") {
-				var other: MutableValidatingProperty<String, TestError>!
-				var validated: MutableValidatingProperty<Int, TestError>!
+			describe("a ValidatingProperty dependency") {
+				var other: ValidatingProperty<String, TestError>!
+				var validated: ValidatingProperty<Int, TestError>!
 				var validationResult: FlattenedResult<Int>?
 
 				beforeEach {
-					other = MutableValidatingProperty("") { $0.hasSuffix("🎃") && $0 != "🎃" ? .success : .failure(.error2) }
+					other = ValidatingProperty("") { $0.hasSuffix("🎃") && $0 != "🎃" ? .success : .failure(.error2) }
 
-					validated = MutableValidatingProperty(0, with: other) { $0 >= 0 && $1.hasSuffix("🎃") ? ($0 == 100 ? .substitution(Int.max, .default) : .success) : .failure(.default) }
+					validated = ValidatingProperty(0, with: other) { $0 >= 0 && $1.hasSuffix("🎃") ? ($0 == 100 ? .substitution(Int.max, .default) : .success) : .failure(.default) }
 
 					validated.result.signal.observeValues { validationResult = FlattenedResult($0) }
 


### PR DESCRIPTION
Pros

1. `ValidatingProperty` is shorter.

1. A hypothetical "read-only" `ValidatingProperty` is essentially a pass-thru wrapper plus a `Property<ValidationResult>`. Moreover, it can be named as *validated* property instead.

Cons

1. `Validating` does not strongly imply `Mutable`. But having a `Mutable` prefix is not really important IMO, unless there is a clash in name or semantics.