### PR TITLE
Deprecate `ObserverProtocol`.

### DIFF
--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -7,6 +7,7 @@
 //
 
 /// A protocol for type-constrained extensions of `Observer`.
+@available(*, deprecated, message: "The protocol will be removed in a future version of ReactiveSwift. Use Observer directly.")
 public protocol ObserverProtocol {
 	associatedtype Value
 	associatedtype Error: Swift.Error
@@ -73,9 +74,7 @@ public final class Observer<Value, Error: Swift.Error> {
 			}
 		}
 	}
-}
 
-extension Observer: ObserverProtocol {
 	/// Puts a `value` event into `self`.
 	///
 	/// - parameters:
@@ -102,3 +101,5 @@ extension Observer: ObserverProtocol {
 		action(.interrupted)
 	}
 }
+
+extension Observer: ObserverProtocol {}


### PR DESCRIPTION
Anonymous closure and instance method reference are predominantly used as observers to `Signal`s. `ObserverProtocol` ideally would be instead interoperating different _types_ as an observer, which doesn't seem a capacity that is demanded for.

It hasn't been in use for years either.