### PR TITLE
Rename the result enum cases of validating property.

### DIFF
--- a/ReactiveSwift-UIExamples.playground/Pages/ValidatingProperty.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift-UIExamples.playground/Pages/ValidatingProperty.xcplaygroundpage/Contents.swift
@@ -22,11 +22,11 @@ final class ViewModel {
 
 	init(userService: UserService) {
 		email = ValidatingProperty<String, FormError>("") { input in
-			return input.hasSuffix("@reactivecocoa.io") ? .success : .failure(.invalidEmail)
+			return input.hasSuffix("@reactivecocoa.io") ? .valid : .invalid(.invalidEmail)
 		}
 
 		emailConfirmation = ValidatingProperty<String, FormError>("", with: email) { input, email in
-			return input == email ? .success : .failure(.mismatchEmail)
+			return input == email ? .valid : .invalid(.mismatchEmail)
 		}
 
 		termsAccepted = MutableProperty(false)
@@ -44,7 +44,7 @@ final class ViewModel {
 		let validatedEmail = Property.combineLatest(email.result,
 		                                            emailConfirmation.result,
 		                                            termsAccepted)
-			.map { e, ec, t in e.value.flatMap { !ec.isFailure && t ? $0 : nil } }
+			.map { e, ec, t in e.value.flatMap { !ec.isInvalid && t ? $0 : nil } }
 
 		// The action to be invoked when the submit button is pressed.
 		// It enables only if all the controls have passed their validations.

--- a/Tests/ReactiveSwiftTests/ValidatingPropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/ValidatingPropertySpec.swift
@@ -13,12 +13,12 @@ class ValidatingPropertySpec: QuickSpec {
 
 				beforeEach {
 					root = MutableProperty(0)
-					validated = ValidatingProperty(root) { $0 >= 0 ? ($0 == 100 ? .substitution(Int.max, .default) : .success) : .failure(.default) }
+					validated = ValidatingProperty(root) { $0 >= 0 ? ($0 == 100 ? .coerced(Int.max, .default) : .valid) : .invalid(.default) }
 
 					validated.result.signal.observeValues { validationResult = FlattenedResult($0) }
 
 					expect(validated.value) == 0
-					expect(FlattenedResult(validated.result.value)) == FlattenedResult.success(0)
+					expect(FlattenedResult(validated.result.value)) == FlattenedResult.valid(0)
 					expect(validationResult).to(beNil())
 				}
 
@@ -40,14 +40,14 @@ class ValidatingPropertySpec: QuickSpec {
 					validated.value = 10
 
 					expect(validated.value) == 10
-					expect(validationResult) == .success(10)
+					expect(validationResult) == .valid(10)
 				}
 
 				it("should denote the substitution") {
 					validated.value = 100
 
 					expect(validated.value) == Int.max
-					expect(validationResult) == .substitution(Int.max, 100, .default)
+					expect(validationResult) == .coerced(Int.max, 100, .default)
 				}
 
 				it("should block invalid values") {
@@ -61,7 +61,7 @@ class ValidatingPropertySpec: QuickSpec {
 					root.value = 10
 
 					expect(validated.value) == 10
-					expect(validationResult) == .success(10)
+					expect(validationResult) == .valid(10)
 
 					root.value = -10
 
@@ -77,8 +77,7 @@ class ValidatingPropertySpec: QuickSpec {
 
 				beforeEach {
 					other = MutableProperty("")
-
-					validated = ValidatingProperty(0, with: other) { $0 >= 0 && $1 == "🎃" ? ($0 == 100 ? .substitution(Int.max, .default) : .success) : .failure(.default) }
+					validated = ValidatingProperty(0, with: other) { $0 >= 0 && $1 == "🎃" ? ($0 == 100 ? .coerced(Int.max, .default) : .valid) : .invalid(.default) }
 
 					validated.result.signal.observeValues { validationResult = FlattenedResult($0) }
 
@@ -103,7 +102,7 @@ class ValidatingPropertySpec: QuickSpec {
 					validated.value = 10
 
 					expect(validated.value) == 10
-					expect(validationResult) == .success(10)
+					expect(validationResult) == .valid(10)
 				}
 
 				it("should block invalid values") {
@@ -118,7 +117,7 @@ class ValidatingPropertySpec: QuickSpec {
 					validated.value = 100
 
 					expect(validated.value) == Int.max
-					expect(validationResult) == .substitution(Int.max, 100, .default)
+					expect(validationResult) == .coerced(Int.max, 100, .default)
 				}
 
 				it("should automatically revalidate the latest failed value if the dependency changes") {
@@ -130,7 +129,7 @@ class ValidatingPropertySpec: QuickSpec {
 					other.value = "🎃"
 
 					expect(validated.value) == 10
-					expect(validationResult) == .success(10)
+					expect(validationResult) == .valid(10)
 				}
 
 				it("should automatically revalidate the latest substituted value if the dependency changes") {
@@ -142,7 +141,7 @@ class ValidatingPropertySpec: QuickSpec {
 					other.value = "🎃"
 
 					expect(validated.value) == Int.max
-					expect(validationResult) == .substitution(Int.max, 100, .default)
+					expect(validationResult) == .coerced(Int.max, 100, .default)
 
 					validated.value = -1
 
@@ -157,9 +156,9 @@ class ValidatingPropertySpec: QuickSpec {
 				var validationResult: FlattenedResult<Int>?
 
 				beforeEach {
-					other = ValidatingProperty("") { $0.hasSuffix("🎃") && $0 != "🎃" ? .success : .failure(.error2) }
+					other = ValidatingProperty("") { $0.hasSuffix("🎃") && $0 != "🎃" ? .valid : .invalid(.error2) }
 
-					validated = ValidatingProperty(0, with: other) { $0 >= 0 && $1.hasSuffix("🎃") ? ($0 == 100 ? .substitution(Int.max, .default) : .success) : .failure(.default) }
+					validated = ValidatingProperty(0, with: other) { $0 >= 0 && $1.hasSuffix("🎃") ? ($0 == 100 ? .coerced(Int.max, .default) : .valid) : .invalid(.default) }
 
 					validated.result.signal.observeValues { validationResult = FlattenedResult($0) }
 
@@ -184,7 +183,7 @@ class ValidatingPropertySpec: QuickSpec {
 					validated.value = 10
 
 					expect(validated.value) == 10
-					expect(validationResult) == .success(10)
+					expect(validationResult) == .valid(10)
 				}
 
 				it("should block invalid values") {
@@ -199,7 +198,7 @@ class ValidatingPropertySpec: QuickSpec {
 					validated.value = 100
 
 					expect(validated.value) == Int.max
-					expect(validationResult) == .substitution(Int.max, 100, .default)
+					expect(validationResult) == .coerced(Int.max, 100, .default)
 				}
 
 				it("should automatically revalidate the latest failed value if the dependency changes") {
@@ -211,7 +210,7 @@ class ValidatingPropertySpec: QuickSpec {
 					other.value = "🎃"
 
 					expect(validated.value) == 10
-					expect(validationResult) == .success(10)
+					expect(validationResult) == .valid(10)
 				}
 
 				it("should automatically revalidate the latest substituted value if the dependency changes") {
@@ -223,7 +222,7 @@ class ValidatingPropertySpec: QuickSpec {
 					other.value = "🎃"
 
 					expect(validated.value) == Int.max
-					expect(validationResult) == .substitution(Int.max, 100, .default)
+					expect(validationResult) == .coerced(Int.max, 100, .default)
 
 					validated.value = -1
 
@@ -243,15 +242,15 @@ class ValidatingPropertySpec: QuickSpec {
 					expect(FlattenedResult(other.result.value)) == FlattenedResult.error2("🎃")
 
 					expect(validated.value) == 10
-					expect(validationResult) == .success(10)
+					expect(validationResult) == .valid(10)
 
 					other.value = "👻🎃"
 
 					expect(other.value) == "👻🎃"
-					expect(FlattenedResult(other.result.value)) == FlattenedResult.success("👻🎃")
+					expect(FlattenedResult(other.result.value)) == FlattenedResult.valid("👻🎃")
 
 					expect(validated.value) == 10
-					expect(validationResult) == .success(10)
+					expect(validationResult) == .valid(10)
 				}
 			}
 		}
@@ -262,18 +261,19 @@ private enum FlattenedResult<Value: Equatable>: Equatable {
 	case errorDefault(Value)
 	case error1(Value)
 	case error2(Value)
-	case success(Value)
-	case substitution(Value, Value, TestError?)
+
+	case valid(Value)
+	case coerced(Value, Value, TestError?)
 
 	init(_ result: ValidationResult<Value, TestError>) {
 		switch result {
-		case let .success(value):
-			self = .success(value)
+		case let .valid(value):
+			self = .valid(value)
 
-		case let .substitution(substitutedValue, proposedValue, error):
-			self = .substitution(substitutedValue, proposedValue, error)
+		case let .coerced(substitutedValue, proposedValue, error):
+			self = .coerced(substitutedValue, proposedValue, error)
 
-		case let .failure(value, error):
+		case let .invalid(value, error):
 			switch error {
 			case .default:
 				self = .errorDefault(value)
@@ -293,9 +293,9 @@ private enum FlattenedResult<Value: Equatable>: Equatable {
 			return lhsValue == rhsValue
 		case (let .error2(lhsValue), let .error2(rhsValue)):
 			return lhsValue == rhsValue
-		case (let .success(lhsValue), let .success(rhsValue)):
+		case (let .valid(lhsValue), let .valid(rhsValue)):
 			return lhsValue == rhsValue
-		case (let .substitution(lhsSubstitution, lhsProposed, lhsError), let .substitution(rhsSubstitution, rhsProposed, rhsError)):
+		case (let .coerced(lhsSubstitution, lhsProposed, lhsError), let .coerced(rhsSubstitution, rhsProposed, rhsError)):
 			return lhsSubstitution == rhsSubstitution && lhsProposed == rhsProposed && lhsError == rhsError
 		default:
 			return false


### PR DESCRIPTION
* `success` becomes `valid`.
* `substitution` becomes `coercedValid`.
* `failure` becomes `invalid`.

The names were taken directly from [Cocoa Bindings and Key Value Validation](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CocoaBindings/Concepts/MessageFlow.html#//apple_ref/doc/uid/TP40002149-BCICADHC). The main concern from me which drives the change is that the word `substitution` is _ambiguous_, while it in fact mimics the "coerced valid value" in Key Value Validation.