### PR TITLE
Fix scheduler's markup documentation

### DIFF
--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -20,7 +20,7 @@ public protocol SchedulerProtocol {
 	/// When the work is executed depends on the scheduler in use.
 	///
 	/// - parameters:
-	///   - action: Action to schedule.
+	///   - action: The action to be scheduled.
 	///
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
@@ -40,8 +40,8 @@ public protocol DateSchedulerProtocol: SchedulerProtocol {
 	/// Schedules an action for execution at or after the given date.
 	///
 	/// - parameters:
-	///   - date: Starting time.
-	///   - action: Closure of the action to perform.
+	///   - date: The start date.
+	///   - action: A closure of the action to be performed.
 	///
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
@@ -52,10 +52,10 @@ public protocol DateSchedulerProtocol: SchedulerProtocol {
 	/// given date.
 	///
 	/// - parameters:
-	///   - date: Starting time.
-	///   - interval: Repetition interval.
+	///   - date: The start date.
+	///   - interval: A repetition interval.
 	///   - leeway: Some delta for repetition.
-	///   - action: Closure of the action to perform.
+	///   - action: A closure of the action to be performed.
 	///
 	///	- note: If you plan to specify an `interval` value greater than 200,000
 	///			seconds, use `schedule(after:interval:leeway:action)` instead
@@ -74,7 +74,7 @@ public final class ImmediateScheduler: SchedulerProtocol {
 	/// Immediately calls passed in `action`.
 	///
 	/// - parameters:
-	///   - action: Closure of the action to perform.
+	///   - action: A closure of the action to be performed.
 	///
 	/// - returns: `nil`.
 	@discardableResult
@@ -117,7 +117,7 @@ public final class UIScheduler: SchedulerProtocol {
 	/// the action is called instantly.
 	///
 	/// - parameters:
-	///   - action: Closure of the action to perform on the main thread.
+	///   - action: A closure of the action to be performed on the main thread.
 	///
 	/// - returns: `Disposable` that can be used to cancel the work before it
 	///            begins.
@@ -195,7 +195,7 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	///
 	/// - parameters:
 	///   - qos: Dispatch queue's QoS value.
-	///   - name: Name for the queue in the form of reverse domain.
+	///   - name: A name for the queue in the form of reverse domain.
 	///   - targeting: (Optional) The queue on which this scheduler's work is
 	///     targeted
 	@available(OSX 10.10, *)
@@ -214,7 +214,7 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	/// Schedules action for dispatch on internal queue
 	///
 	/// - parameters:
-	///   - action: Closure of the action to schedule.
+	///   - action: A closure of the action to be scheduled.
 	///
 	/// - returns: `Disposable` that can be used to cancel the work before it
 	///            begins.
@@ -243,8 +243,8 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	/// Schedules an action for execution at or after the given date.
 	///
 	/// - parameters:
-	///   - date: Starting time.
-	///   - action: Closure of the action to perform.
+	///   - date: The start date.
+	///   - action: A closure of the action to be performed.
 	///
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
@@ -266,8 +266,8 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	/// provided.
 	///
 	/// - parameters:
-	///   - date: Date to schedule the first action for.
-	///   - interval: Repetition interval.
+	///   - date: A date to schedule the first action for.
+	///   - interval: A repetition interval.
 	///   - action: Closure of the action to repeat.
 	///
 	///	- note: If you plan to specify an `interval` value greater than 200,000 
@@ -287,10 +287,10 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	/// beginning at the given start time.
 	///
 	/// - parameters:
-	///   - date: Date to schedule the first action for.
-	///   - interval: Repetition interval.
+	///   - date: A date to schedule the first action for.
+	///   - interval: A repetition interval.
 	///   - leeway: Some delta for repetition interval.
-	///   - action: Closure of the action to repeat.
+	///   - action: A closure of the action to repeat.
 	///
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
@@ -388,8 +388,8 @@ public final class TestScheduler: DateSchedulerProtocol {
 	/// Schedules an action for execution after some delay.
 	///
 	/// - parameters:
-	///   - delay: Delay for execution.
-	///   - action: Closure of the action to perform.
+	///   - delay: A delay for execution.
+	///   - action: A closure of the action to perform.
 	///
 	/// - returns: Optional disposable that can be used to cancel the work
 	///            before it begins.
@@ -401,8 +401,8 @@ public final class TestScheduler: DateSchedulerProtocol {
 	/// Schedules an action for execution at or after the given date.
 	///
 	/// - parameters:
-	///   - date: Starting date.
-	///   - action: Closure of the action to perform.
+	///   - date: A starting date.
+	///   - action: A closure of the action to perform.
 	///
 	/// - returns: Optional disposable that can be used to cancel the work
 	///            before it begins.
@@ -415,10 +415,10 @@ public final class TestScheduler: DateSchedulerProtocol {
 	/// given start date.
 	///
 	/// - parameters:
-	///   - date: Date to schedule the first action for.
-	///   - interval: Repetition interval.
+	///   - date: A date to schedule the first action for.
+	///   - interval: A repetition interval.
 	///   - disposable: A disposable.
-	///   - action: Closure of the action to repeat.
+	///   - action: A closure of the action to repeat.
 	///
 	///	- note: If you plan to specify an `interval` value greater than 200,000
 	///			seconds, use `schedule(after:interval:leeway:action)` instead
@@ -439,10 +439,10 @@ public final class TestScheduler: DateSchedulerProtocol {
 	/// interval, beginning at the given interval counted from `currentDate`.
 	///
 	/// - parameters:
-	///   - delay: Delay for action's dispatch.
-	///   - interval: Repetition interval.
+	///   - delay: A delay for action's dispatch.
+	///   - interval: A repetition interval.
 	///	  - leeway: Some delta for repetition interval.
-	///   - action: Closure of the action to repeat.
+	///   - action: A closure of the action to repeat.
 	///
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
@@ -455,10 +455,10 @@ public final class TestScheduler: DateSchedulerProtocol {
 	/// provided leeway, beginning at the given start date.
 	///
 	/// - parameters:
-	///   - date: Date to schedule the first action for.
-	///   - interval: Repetition interval.
+	///   - date: A date to schedule the first action for.
+	///   - interval: A repetition interval.
 	///	  - leeway: Some delta for repetition interval.
-	///   - action: Closure of the action to repeat.
+	///   - action: A closure of the action to repeat.
 	///
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///	           before it begins.
@@ -515,7 +515,7 @@ public final class TestScheduler: DateSchedulerProtocol {
 	}
 
 	/// Dequeues and executes all scheduled actions, leaving the scheduler's
-	/// date at `NSDate.distantFuture()`.
+	/// date at `Date.distantFuture()`.
 	public func run() {
 		advance(to: Date.distantFuture)
 	}
@@ -524,7 +524,7 @@ public final class TestScheduler: DateSchedulerProtocol {
 	/// This simulates that user changes device date.
 	///
 	/// - parameters:
-	///   - interval: Interval by which the current date will be retreated.
+	///   - interval: An interval by which the current date will be retreated.
 	public func rewind(by interval: DispatchTimeInterval) {
 		lock.lock()
 		

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -19,6 +19,9 @@ public protocol SchedulerProtocol {
 	///
 	/// When the work is executed depends on the scheduler in use.
 	///
+	/// - parameters:
+	///   - action: Action to schedule.
+	///
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
@@ -50,8 +53,8 @@ public protocol DateSchedulerProtocol: SchedulerProtocol {
 	///
 	/// - parameters:
 	///   - date: Starting time.
-	///   - repeatingEvery: Repetition interval.
-	///   - withLeeway: Some delta for repetition.
+	///   - interval: Repetition interval.
+	///   - leeway: Some delta for repetition.
 	///   - action: Closure of the action to perform.
 	///
 	///	- note: If you plan to specify an `interval` value greater than 200,000
@@ -259,12 +262,12 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	}
 
 	/// Schedules a recurring action at the given interval and beginning at the
-	/// given start time. A reasonable default timer interval leeway is
+	/// given start date. A reasonable default timer interval leeway is
 	/// provided.
 	///
 	/// - parameters:
 	///   - date: Date to schedule the first action for.
-	///   - repeatingEvery: Repetition interval.
+	///   - interval: Repetition interval.
 	///   - action: Closure of the action to repeat.
 	///
 	///	- note: If you plan to specify an `interval` value greater than 200,000 
@@ -285,7 +288,7 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	///
 	/// - parameters:
 	///   - date: Date to schedule the first action for.
-	///   - repeatingEvery: Repetition interval.
+	///   - interval: Repetition interval.
 	///   - leeway: Some delta for repetition interval.
 	///   - action: Closure of the action to repeat.
 	///
@@ -382,10 +385,10 @@ public final class TestScheduler: DateSchedulerProtocol {
 		return schedule(ScheduledAction(date: currentDate, action: action))
 	}
 
-	/// Schedules an action for execution at or after the given date.
+	/// Schedules an action for execution after some delay.
 	///
 	/// - parameters:
-	///   - date: Starting date.
+	///   - delay: Delay for execution.
 	///   - action: Closure of the action to perform.
 	///
 	/// - returns: Optional disposable that can be used to cancel the work
@@ -395,17 +398,26 @@ public final class TestScheduler: DateSchedulerProtocol {
 		return schedule(after: currentDate.addingTimeInterval(delay), action: action)
 	}
 
+	/// Schedules an action for execution at or after the given date.
+	///
+	/// - parameters:
+	///   - date: Starting date.
+	///   - action: Closure of the action to perform.
+	///
+	/// - returns: Optional disposable that can be used to cancel the work
+	///            before it begins.
 	@discardableResult
 	public func schedule(after date: Date, action: @escaping () -> Void) -> Disposable? {
 		return schedule(ScheduledAction(date: date, action: action))
 	}
 
 	/// Schedules a recurring action at the given interval, beginning at the
-	/// given start time
+	/// given start date.
 	///
 	/// - parameters:
 	///   - date: Date to schedule the first action for.
-	///   - repeatingEvery: Repetition interval.
+	///   - interval: Repetition interval.
+	///   - disposable: A disposable.
 	///   - action: Closure of the action to repeat.
 	///
 	///	- note: If you plan to specify an `interval` value greater than 200,000
@@ -423,12 +435,12 @@ public final class TestScheduler: DateSchedulerProtocol {
 		}
 	}
 
-	/// Schedules a recurring action at the given interval, beginning at the
-	/// given interval (counted from `currentDate`).
+	/// Schedules a recurring action after given delay repeated at the given,
+	/// interval, beginning at the given interval counted from `currentDate`.
 	///
 	/// - parameters:
-	///   - interval: Interval to add to `currentDate`.
-	///   - repeatingEvery: Repetition interval.
+	///   - delay: Delay for action's dispatch.
+	///   - interval: Repetition interval.
 	///	  - leeway: Some delta for repetition interval.
 	///   - action: Closure of the action to repeat.
 	///
@@ -440,11 +452,11 @@ public final class TestScheduler: DateSchedulerProtocol {
 	}
 
 	/// Schedules a recurring action at the given interval with
-	/// provided leeway, beginning at the given start time.
+	/// provided leeway, beginning at the given start date.
 	///
 	/// - parameters:
 	///   - date: Date to schedule the first action for.
-	///   - repeatingEvery: Repetition interval.
+	///   - interval: Repetition interval.
 	///	  - leeway: Some delta for repetition interval.
 	///   - action: Closure of the action to repeat.
 	///


### PR DESCRIPTION
After changing some parameter names for scheduler instance methods markup reported "No description" for those parameters. This PR fixes the issue.