### PR TITLE
Suppress all warnings when building with CocoaPods.

### DIFF
--- a/ReactiveSwift.podspec
+++ b/ReactiveSwift.podspec
@@ -18,4 +18,6 @@ Pod::Spec.new do |s|
   # Directory glob for all Swift files
   s.source_files  = "Sources/*.{swift}"
   s.dependency 'Result', '~> 3.1'
+
+  s.pod_target_xcconfig = {"OTHER_SWIFT_FLAGS[config=Release]" => "-suppress-warnings" }
 end


### PR DESCRIPTION
Suppress all warnings when building with the Release configuration, so that the internal deprecation warnings would not be visible when ReactiveSwift is built using ~~Carthage and~~ CocoaPods.

SwiftPM does not provide a way to pass compiler flags, so it won't be covered by the patch.

Usage: #248, #254 