### PR TITLE
Remove unnecessary `@inline`

### DIFF
--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -58,7 +58,6 @@ internal struct UnsafeAtomicState<State: RawRepresentable>: AtomicStateProtocol 
 	/// - returns:
 	///   `true` if the current state matches the expected state. `false`
 	///   otherwise.
-	@inline(__always)
 	internal func `is`(_ expected: State) -> Bool {
 		return OSAtomicCompareAndSwap32Barrier(expected.rawValue,
 		                                       expected.rawValue,
@@ -73,7 +72,6 @@ internal struct UnsafeAtomicState<State: RawRepresentable>: AtomicStateProtocol 
 	///
 	/// - returns:
 	///   `true` if the transition succeeds. `false` otherwise.
-	@inline(__always)
 	internal func tryTransition(from expected: State, to next: State) -> Bool {
 		return OSAtomicCompareAndSwap32Barrier(expected.rawValue,
 		                                       next.rawValue,


### PR DESCRIPTION
Swift 3.1 beta complains that these methods are not qualified to have `@inline(__always)` because `value` is not public:

> Atomic.swift:65:42: Let 'value' is private and cannot be referenced from an '`@inline(__always)`' function

Since `@inline(__always)` is not officially supported, this needs to be fixed here, rather than in Swift. See [here](https://bugs.swift.org/browse/SR-4013?focusedCommentId=21981&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-21981).

Related commit in Swift:
https://github.com/apple/swift/commit/50b5d01dd7a023b4d7c7a77019c1c26ee507da03

According to that commit message, it seems that `@inline` is now only for public, resilient API.