### PR TITLE
Deprecate `AtomicProtocol`.

### DIFF
--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -154,6 +154,17 @@ public final class Atomic<Value>: AtomicProtocol {
 	private let lock: PosixThreadMutex
 	private var _value: Value
 
+	/// Atomically get or set the value of the variable.
+	public var value: Value {
+		get {
+			return withValue { $0 }
+		}
+
+		set(newValue) {
+			swap(newValue)
+		}
+	}
+
 	/// Initialize the variable with the given initial value.
 	/// 
 	/// - parameters:
@@ -191,6 +202,21 @@ public final class Atomic<Value>: AtomicProtocol {
 
 		return try action(_value)
 	}
+
+	/// Atomically replace the contents of the variable.
+	///
+	/// - parameters:
+	///   - newValue: A new value for the variable.
+	///
+	/// - returns: The old value.
+	@discardableResult
+	public func swap(_ newValue: Value) -> Value {
+		return modify { (value: inout Value) in
+			let oldValue = value
+			value = newValue
+			return oldValue
+		}
+	}
 }
 
 
@@ -199,6 +225,17 @@ internal final class RecursiveAtomic<Value>: AtomicProtocol {
 	private let lock: NSRecursiveLock
 	private var _value: Value
 	private let didSetObserver: ((Value) -> Void)?
+
+	/// Atomically get or set the value of the variable.
+	public var value: Value {
+		get {
+			return withValue { $0 }
+		}
+
+		set(newValue) {
+			swap(newValue)
+		}
+	}
 
 	/// Initialize the variable with the given initial value.
 	/// 
@@ -244,30 +281,6 @@ internal final class RecursiveAtomic<Value>: AtomicProtocol {
 		defer { lock.unlock() }
 
 		return try action(_value)
-	}
-}
-
-/// A protocol used to constraint convenience `Atomic` methods and properties.
-public protocol AtomicProtocol: class {
-	associatedtype Value
-
-	@discardableResult
-	func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result
-
-	@discardableResult
-	func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result
-}
-
-extension AtomicProtocol {	
-	/// Atomically get or set the value of the variable.
-	public var value: Value {
-		get {
-			return withValue { $0 }
-		}
-	
-		set(newValue) {
-			swap(newValue)
-		}
 	}
 
 	/// Atomically replace the contents of the variable.

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -55,6 +55,46 @@ extension BindingTarget {
 	}
 }
 
+/// A protocol used to constraint convenience `Atomic` methods and properties.
+@available(*, deprecated, message:"The protocol has been deprecated, and will be removed in a future version.")
+public protocol AtomicProtocol: class {
+	associatedtype Value
+
+	@discardableResult
+	func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result
+
+	@discardableResult
+	func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result
+}
+
+extension AtomicProtocol {
+	/// Atomically get or set the value of the variable.
+	public var value: Value {
+		get {
+			return withValue { $0 }
+		}
+
+		set(newValue) {
+			swap(newValue)
+		}
+	}
+
+	/// Atomically replace the contents of the variable.
+	///
+	/// - parameters:
+	///   - newValue: A new value for the variable.
+	///
+	/// - returns: The old value.
+	@discardableResult
+	public func swap(_ newValue: Value) -> Value {
+		return modify { (value: inout Value) in
+			let oldValue = value
+			value = newValue
+			return oldValue
+		}
+	}
+}
+
 // MARK: Removed Types and APIs in ReactiveCocoa 5.0.
 
 // Renamed Protocols


### PR DESCRIPTION
Justification

1. The protocol has little value other than sharing implementations of atomic operators, if we assume different implementations mean different lock semantics.

2. Potential optimizations would require knowledge to the storage, which cannot be exposed through the protocol. The apparent way for these would be enum storage + concrete same type extensions.