### PR TITLE
Rename `negated` to `negate()`.

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -2,6 +2,27 @@ import Foundation
 import enum Result.NoError
 
 // MARK: Depreciated types in ReactiveSwift 1.x.
+extension SignalProtocol where Value == Bool {
+	@available(*, deprecated, renamed: "negate()")
+	public var negated: Signal<Bool, Error> {
+		return negate()
+	}
+}
+
+extension SignalProducerProtocol where Value == Bool {
+	@available(*, deprecated, renamed: "negate()")
+	public var negated: SignalProducer<Bool, Error> {
+		return negate()
+	}
+}
+
+extension PropertyProtocol where Value == Bool {
+	@available(*, deprecated, renamed: "negate()")
+	public var negated: Property<Bool> {
+		return negate()
+	}
+}
+
 @available(*, deprecated, renamed:"Scheduler")
 public typealias SchedulerProtocol = Scheduler
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -399,8 +399,8 @@ extension PropertyProtocol where Value == Bool {
 	/// Create a property that computes a logical NOT in the latest values of `self`.
 	///
 	/// - returns: A property that contains the logial NOT results.
-	public var negated: Property<Value> {
-		return self.lift { $0.negated }
+	public func negate() -> Property<Value> {
+		return self.lift { $0.negate() }
 	}
 	
 	/// Create a property that computes a logical AND between the latest values of `self`

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -2280,7 +2280,7 @@ extension SignalProtocol where Value == Bool {
 	/// Create a signal that computes a logical NOT in the latest values of `self`.
 	///
 	/// - returns: A signal that emits the logical NOT results.
-	public var negated: Signal<Value, Error> {
+	public func negate() -> Signal<Value, Error> {
 		return self.map(!)
 	}
 	

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1953,8 +1953,8 @@ extension SignalProducerProtocol where Value == Bool {
 	/// Create a producer that computes a logical NOT in the latest values of `self`.
 	///
 	/// - returns: A producer that emits the logical NOT results.
-	public var negated: SignalProducer<Value, Error> {
-		return self.lift { $0.negated }
+	public func negate() -> SignalProducer<Value, Error> {
+		return self.lift { $0.negate() }
 	}
 	
 	/// Create a producer that computes a logical AND between the latest values of `self`

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -1519,7 +1519,7 @@ class PropertySpec: QuickSpec {
 			describe("negated attribute") {
 				it("should return the negate of a value in a Boolean property") {
 					let property = MutableProperty(true)
-					expect(property.negated.value).to(beFalse())
+					expect(property.negate().value).to(beFalse())
 				}
 			}
 			

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -2458,7 +2458,7 @@ class SignalProducerSpec: QuickSpec {
 					observer.sendCompleted()
 				}
 				
-				producer.negated.startWithValues { value in
+				producer.negate().startWithValues { value in
 					expect(value).to(beFalse())
 				}
 			}

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -2896,7 +2896,7 @@ class SignalSpec: QuickSpec {
 		describe("negated attribute") {
 			it("should return the negate of a value in a Boolean signal") {
 				let (signal, observer) = Signal<Bool, NoError>.pipe()
-				signal.negated.observeValues { value in
+				signal.negate().observeValues { value in
 					expect(value).to(beFalse())
 				}
 				observer.send(value: true)


### PR DESCRIPTION
An unfortunate inconsistency that has already been shipped. 😅

Anyhow, it is renamed to `negate()` so that like its zero-arg operator friends, it gives a visual weight and sense of being factory, rather than being a cheap computed/stored value.