### PR TITLE
Remove `*.xcworkspace` in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ build/*
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-*.xcworkspace
 !default.xcworkspace
 xcuserdata
 profile


### PR DESCRIPTION
If you use Carthage to include ReativeSwift in your project and you
check your `Carthage/Checkouts/` folder into git,

when `ReativeSwift.xcworkspace` is missing, you get a general "Build
Failed" error from Carthage. The problem is that, somehow the
`xcworkspace` is missing. However, there's no info from git since
`xcworkspace` is ignored in ReativeSwift's `.gitignore` file.

ReativeSwift does check in `ReactiveSwift.xcworkspace` file in git. This should
have no impact on the project. Hopefully this will make debugging
the Carthage build error mentioned above easier.

PS.

I spent a few hours on a Sunday morning pulling my hair out trying to figure out why Carthage wouldn't build my dependencies and then figured this out. Today, my teammate also ran into this problem.