### PR TITLE
Minor documentation markup update

### DIFF
--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -11,22 +11,6 @@ import Foundation
 import MachO
 #endif
 
-/// Represents a finite state machine that can transit from one state to
-/// another.
-internal protocol AtomicStateProtocol {
-	associatedtype State: RawRepresentable
-
-	/// Try to transition from the expected current state to the specified next
-	/// state.
-	///
-	/// - parameters:
-	///   - expected: The expected state.
-	///   - next: The state to transition to.
-	///
-	/// - returns: `true` if the transition succeeds. `false` otherwise.
-	func tryTransition(from expected: State, to next: State) -> Bool
-}
-
 /// A simple, generic lock-free finite state machine.
 ///
 /// - warning: `deinitialize` must be called to dispose of the consumed memory.

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -11,6 +11,22 @@ import Foundation
 import MachO
 #endif
 
+/// Represents a finite state machine that can transit from one state to
+/// another.
+internal protocol AtomicStateProtocol {
+	associatedtype State: RawRepresentable
+
+	/// Try to transition from the expected current state to the specified next
+	/// state.
+	///
+	/// - parameters:
+	///   - expected: The expected state.
+	///   - next: The state to transition to.
+	///
+	/// - returns: `true` if the transition succeeds. `false` otherwise.
+	func tryTransition(from expected: State, to next: State) -> Bool
+}
+
 /// A simple, generic lock-free finite state machine.
 ///
 /// - warning: `deinitialize` must be called to dispose of the consumed memory.
@@ -39,9 +55,8 @@ internal struct UnsafeAtomicState<State: RawRepresentable> where State.RawValue 
 	/// - parameters:
 	///   - expected: The expected state.
 	///
-	/// - returns:
-	///   `true` if the current state matches the expected state. `false`
-	///   otherwise.
+	/// - returns: `true` if the current state matches the expected state.
+	///            `false` otherwise.
 	internal func `is`(_ expected: State) -> Bool {
 		return OSAtomicCompareAndSwap32Barrier(expected.rawValue,
 		                                       expected.rawValue,
@@ -55,8 +70,7 @@ internal struct UnsafeAtomicState<State: RawRepresentable> where State.RawValue 
 	///   - expected: The expected state.
 	///   - next: The state to transition to.
 	///
-	/// - returns:
-	///   `true` if the transition succeeds. `false` otherwise.
+	/// - returns: `true` if the transition succeeds. `false` otherwise.
 	internal func tryTransition(from expected: State, to next: State) -> Bool {
 		return OSAtomicCompareAndSwap32Barrier(expected.rawValue,
 		                                       next.rawValue,
@@ -81,9 +95,8 @@ internal struct UnsafeAtomicState<State: RawRepresentable> where State.RawValue 
 	/// - parameters:
 	///   - expected: The expected state.
 	///
-	/// - returns:
-	///   `true` if the current state matches the expected state. `false`
-	///   otherwise.
+	/// - returns: `true` if the current state matches the expected state.
+	///            `false` otherwise.
 	internal func `is`(_ expected: State) -> Bool {
 		return value.modify { $0 == expected.rawValue }
 	}
@@ -94,8 +107,7 @@ internal struct UnsafeAtomicState<State: RawRepresentable> where State.RawValue 
 	/// - parameters:
 	///   - expected: The expected state.
 	///
-	/// - returns:
-	///   `true` if the transition succeeds. `false` otherwise.
+	/// - returns: `true` if the transition succeeds. `false` otherwise.
 	internal func tryTransition(from expected: State, to next: State) -> Bool {
 		return value.modify { value in
 			if value == expected.rawValue {
@@ -149,7 +161,7 @@ public final class Atomic<Value> {
 	}
 
 	/// Initialize the variable with the given initial value.
-	/// 
+	///
 	/// - parameters:
 	///   - value: Initial value for `self`.
 	public init(_ value: Value) {
@@ -221,7 +233,7 @@ internal final class RecursiveAtomic<Value> {
 	}
 
 	/// Initialize the variable with the given initial value.
-	/// 
+	///
 	/// - parameters:
 	///   - value: Initial value for `self`.
 	///   - name: An optional name used to create the recursive lock.

--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -31,8 +31,7 @@ private enum DisposableState: Int32 {
 extension UnsafeAtomicState where State == DisposableState {
 	/// Try to transition from `active` to `disposed`.
 	///
-	/// - returns:
-	///   `true` if the transition succeeds. `false` otherwise.
+	/// - returns: `true` if the transition succeeds. `false` otherwise.
 	@inline(__always)
 	fileprivate func tryDispose() -> Bool {
 		return tryTransition(from: .active, to: .disposed)

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -236,8 +236,8 @@ public final class Signal<Value, Error: Swift.Error> {
 
 	/// Swap the generator disposable with `nil`.
 	///
-	/// - returns:
-	///   The generator disposable, or `nil` if it has been disposed of.
+	/// - returns: The generator disposable, or `nil` if it has been disposed
+	///            of.
 	private func swapDisposable() -> Disposable? {
 		if let d = generatorDisposable {
 			generatorDisposable = nil

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2061,10 +2061,10 @@ private struct ReplayState<Value, Error: Swift.Error> {
 	/// - parameters:
 	///   - observer: The observer to be registered.
 	///
-	/// - returns:
-	///   If the observer is successfully attached, a `Result.success` with the
-	///   corresponding removal token would be returned. Otherwise, a
-	///   `Result.failure` with a `ReplayError` would be returned.
+	/// - returns: If the observer is successfully attached, a `Result.success`
+	///            with the corresponding removal token would be returned.
+	///            Otherwise, a `Result.failure` with a `ReplayError` would be
+	///            returned.
 	mutating func observe(_ observer: Signal<Value, Error>.Observer) -> Result<RemovalToken?, ReplayError<Value>> {
 		// Since the only use case is `replayLazily`, which always creates a unique
 		// `Observer` for every produced signal, we can use the ObjectIdentifier of


### PR DESCRIPTION
Make `returns:` delimiter contain documentation on same line.