### PR TITLE
Signal availability

### DIFF
--- a/Sources/Bag.swift
+++ b/Sources/Bag.swift
@@ -46,9 +46,13 @@ public struct Bag<Element> {
 			}
 		}
 	}
+
+	public func index(of token: RemovalToken) -> Index? {
+		return elements.index(where: { $0.token === token })
+	}
 }
 
-extension Bag: Collection {
+extension Bag: MutableCollection {
 	public typealias Index = Array<Element>.Index
 
 	public var startIndex: Index {
@@ -60,7 +64,12 @@ extension Bag: Collection {
 	}
 
 	public subscript(index: Index) -> Element {
-		return elements[index].value
+		get {
+			return elements[index].value
+		}
+		set {
+			elements[index].value = newValue
+		}
 	}
 
 	public func index(after i: Index) -> Index {
@@ -73,7 +82,7 @@ extension Bag: Collection {
 }
 
 private struct BagElement<Value> {
-	let value: Value
+	var value: Value
 	let token: RemovalToken
 }
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -418,6 +418,127 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
+		describe("stateless signals") {
+			func testOperator(_ signal: Signal<Int, NoError>, sink: @escaping (Int) -> Void) -> Signal<Int, NoError> {
+				return Signal(.stateless) { observer, channel in
+					return signal.observe(channel, Observer { event in
+						observer.action(event.map { value in
+							sink(value)
+							return value
+						})
+					})
+				}
+			}
+
+			it("should deactivate its side effects when it has no observers") {
+				var values: [Int] = []
+
+				let (signal, observer) = Signal<Int, NoError>.pipe()
+				let transformed = testOperator(signal) { values.append($0) }
+
+				expect(values) == []
+
+				observer.send(value: 0)
+				expect(values) == []
+
+				let disposable1 = transformed.observe(Observer())
+				observer.send(value: 1)
+				expect(values) == [1]
+
+				disposable1?.dispose()
+				observer.send(value: 2)
+				expect(values) == [1]
+
+				let disposable2 = transformed.observe(Observer())
+				observer.send(value: 3)
+				expect(values) == [1, 3]
+
+				disposable2?.dispose()
+				observer.send(value: 4)
+				expect(values) == [1, 3]
+			}
+
+			it("should deactivate its side effects when it has no observers") {
+				var valuesA: [Int] = []
+				var valuesB: [Int] = []
+
+				let (signal, observer) = Signal<Int, NoError>.pipe()
+				let a = testOperator(signal) { valuesA.append($0) }
+				let b = testOperator(a) { valuesB.append($0) }
+
+				expect(valuesA) == []
+				expect(valuesB) == []
+
+				observer.send(value: 0)
+				expect(valuesA) == []
+				expect(valuesB) == []
+
+				let disposable1 = b.observe(Observer())
+				observer.send(value: 1)
+				expect(valuesA) == [1]
+				expect(valuesB) == [1]
+
+				disposable1?.dispose()
+				observer.send(value: 2)
+				expect(valuesA) == [1]
+				expect(valuesB) == [1]
+
+				let disposable2 = b.observe(Observer())
+				observer.send(value: 3)
+				expect(valuesA) == [1, 3]
+				expect(valuesB) == [1, 3]
+
+				disposable2?.dispose()
+				observer.send(value: 4)
+				expect(valuesA) == [1, 3]
+				expect(valuesB) == [1, 3]
+			}
+
+			it("should not deactivate its side effects when it has no observers") {
+				var valuesA: [Int] = []
+				var valuesB1: [Int] = []
+				var valuesB2: [Int] = []
+
+				let (signal, observer) = Signal<Int, NoError>.pipe()
+				let a = testOperator(signal) { valuesA.append($0) }
+				let b1 = testOperator(a) { valuesB1.append($0) }
+				let b2 = testOperator(a) { valuesB2.append($0) }
+
+				expect(valuesA) == []
+				expect(valuesB1) == []
+				expect(valuesB2) == []
+
+				observer.send(value: 0)
+				expect(valuesA) == []
+				expect(valuesB1) == []
+				expect(valuesB2) == []
+
+				let disposable1 = b1.observe(Observer())
+				observer.send(value: 1)
+				expect(valuesA) == [1]
+				expect(valuesB1) == [1]
+				expect(valuesB2) == []
+
+				let disposable2 = b2.observe(Observer())
+				observer.send(value: 2)
+				expect(valuesA) == [1, 2]
+				expect(valuesB1) == [1, 2]
+				expect(valuesB2) == [2]
+
+				disposable1?.dispose()
+				observer.send(value: 3)
+				expect(valuesA) == [1, 2, 3]
+				expect(valuesB1) == [1, 2]
+				expect(valuesB2) == [2, 3]
+
+				disposable2?.dispose()
+				observer.send(value: 4)
+				expect(valuesA) == [1, 2, 3]
+				expect(valuesB1) == [1, 2]
+				expect(valuesB2) == [2, 3]
+			}
+		}
+
 		describe("trailing closure") {
 			it("receives next values") {
 				var values = [Int]()


### PR DESCRIPTION
Implements #163.

Enable and disable the input side effect — that pipes values into a given `Signal` — in response to the number of active observers in the `Signal`.

It is designed for operators that can be proved to be memoryless in systems theory, e.g. `map`. Operators which transform the latest `value` event based on histories should not use the feature.

### Summary
1. Normal observers attached through `observe(_:)` and shorthands are always active.

1. Any `Signal` must handle the activation and deactivation of its observers.

1. Only if a `Signal` is declared stateless when initialized, it may notify to its upstreams its own activation and deactivation to enable or disable its input side effect. The notification channel is established by observing its upstreams with its `SignalChannel` (i.e. the new two-argument `observe(_:_:)`).

### Breaking change
If a `Signal` constructed by stateless operators, the side effect would not be evaluated when it has no observers even if the `Signal` is retained.

It is a further restriction on top of the current rule of automatic disposal.

```swift
var count = 0
let (signal, observer) = Signal<Int, NoError>.pipe()

// A mapped signal that is retained but without observer.
let mapped = signal.map { count += $0; return $0 + 1 }

observe.send(value: 10)

// Currently: Pass
// This PR: Assertion failure - count is zero.
assert(count == 10)

// Adding an observer activates the signal.
mapped.observe { _ in }
observe.send(value: 5)

// Currently: Pass
// This PR: Assertion failure - count is 5.
assert(count == 15)
```

### Use cases
* `Action`: all `map`-derived `Signal`s no longer occupy any CPU time, unless they are really being observed.