### PR TITLE
Revert `Observer` to be a `struct`.

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -209,7 +209,7 @@ extension CompositeDisposable {
 
 extension Observer {
 	@available(*, unavailable, renamed: "init(value:failed:completed:interrupted:)")
-	public convenience init(
+	public init(
 		next: ((Value) -> Void)? = nil,
 		failed: ((Error) -> Void)? = nil,
 		completed: (() -> Void)? = nil,

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -8,7 +8,7 @@
 
 /// An Observer is a simple wrapper around a function which can receive Events
 /// (typically from a Signal).
-public final class Observer<Value, Error: Swift.Error> {
+public struct Observer<Value, Error: Swift.Error> {
 	public typealias Action = (Event<Value, Error>) -> Void
 
 	/// An action that will be performed upon arrival of the event.
@@ -33,7 +33,7 @@ public final class Observer<Value, Error: Swift.Error> {
 	///                observed.
 	///   - interruped: Optional closure executed when an `interrupted` event is
 	///                 observed.
-	public convenience init(
+	public init(
 		value: ((Value) -> Void)? = nil,
 		failed: ((Error) -> Void)? = nil,
 		completed: (() -> Void)? = nil,

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1935,10 +1935,12 @@ extension SignalProducer {
 			// have terminated.
 			disposable += { _ = lifetimeToken }
 
+			let token = ReplayState<Value, Error>.Token()
+
 			while true {
 				var result: Result<RemovalToken?, ReplayError<Value>>!
 				state.modify {
-					result = $0.observe(observer)
+					result = $0.observe(observer, with: token)
 				}
 
 				switch result! {
@@ -2027,6 +2029,8 @@ private struct ReplayError<Value>: Error {
 }
 
 private struct ReplayState<Value, Error: Swift.Error> {
+	fileprivate final class Token {}
+
 	let capacity: Int
 
 	/// All cached values.
@@ -2060,16 +2064,17 @@ private struct ReplayState<Value, Error: Swift.Error> {
 	///
 	/// - parameters:
 	///   - observer: The observer to be registered.
+	///   - token: The token to uniquely identify the observation.
 	///
 	/// - returns: If the observer is successfully attached, a `Result.success`
 	///            with the corresponding removal token would be returned.
 	///            Otherwise, a `Result.failure` with a `ReplayError` would be
 	///            returned.
-	mutating func observe(_ observer: Signal<Value, Error>.Observer) -> Result<RemovalToken?, ReplayError<Value>> {
+	mutating func observe(_ observer: Signal<Value, Error>.Observer, with token: Token) -> Result<RemovalToken?, ReplayError<Value>> {
 		// Since the only use case is `replayLazily`, which always creates a unique
 		// `Observer` for every produced signal, we can use the ObjectIdentifier of
 		// the `Observer` to track them directly.
-		let id = ObjectIdentifier(observer)
+		let id = ObjectIdentifier(token)
 
 		switch replayBuffers[id] {
 		case .none where !values.isEmpty:


### PR DESCRIPTION
1. While closures work like a reference type (in regard to their contexts), neither we rely on it with irreplaceable use cases, nor should we assume closures to have an identity as the language does not expose it.

2. Using `struct` allows the closure reference to be stored in place, instead of requiring an extra level of pointer indirection. This would reduce the memory footprint considerably by 32 bytes less per attached observer (isa, refcount, funcRef & contextRef).