### PR TITLE
Opt-in recursive value sending for `Signal`.

### DIFF
--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -126,6 +126,18 @@ final class PosixThreadMutex: NSLocking {
 		let result = pthread_mutex_unlock(&mutex)
 		precondition(result == 0, "Failed to unlock \(self) with error \(result).")
 	}
+
+	func `try`() -> Bool {
+		let result = pthread_mutex_trylock(&mutex)
+		switch result {
+		case 0:
+			return true
+		case EBUSY:
+			return false
+		default:
+			preconditionFailure("Failed to unlock \(self) with error \(result).")
+		}
+	}
 }
 
 /// An atomic variable.


### PR DESCRIPTION
[Recursive lock based signal recursion was disabled back in the days of 3.0](https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2042). At that time the queue-drain strategy had been put off the table, despite it being adopted in RxJava et al.

This PR proposes to reintroduce signal recursion as an _option_ in ReactiveSwift, in the form of `pipe(recursive: true)`. The created `Signal` maintains the FIFO order of events by buffering all value sending attempts during the delivery of a given event.

There are legitimate use cases IMO that could benefit from it. For example, one can no longer safely resign a `UITextField` as the first responder in observers of `continuousTextValues` in ReactiveCocoa (https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3452), since `resignFirstReponder` would attempt to send an end-of-editing event while the `Signal` is still being locked on the same thread. The recursion option would help in this case.

By default, `Signal` would still prohibit recursive sending of values.