### PR TITLE
Move `timer` to `SignalProducer`.

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -1,5 +1,13 @@
 import Foundation
+import Dispatch
 import enum Result.NoError
+
+// MARK: Unavailable methods in ReactiveSwift 2.0.
+@available(*, unavailable, renamed:"SignalProducer.timer")
+public func timer(interval: DispatchTimeInterval, on scheduler: DateScheduler) -> SignalProducer<Date, NoError> { fatalError() }
+
+@available(*, unavailable, renamed:"SignalProducer.timer")
+public func timer(interval: DispatchTimeInterval, on scheduler: DateScheduler, leeway: DispatchTimeInterval) -> SignalProducer<Date, NoError> { fatalError() }
 
 // MARK: Obsolete types in ReactiveSwift 2.0.
 @available(*, unavailable, message: "This protocol has been removed. Constrain `Action` directly instead.")

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2147,54 +2147,56 @@ private struct ReplayState<Value, Error: Swift.Error> {
 	}
 }
 
-/// Create a repeating timer of the given interval, with a reasonable default
-/// leeway, sending updates on the given scheduler.
-///
-/// - note: This timer will never complete naturally, so all invocations of
-///         `start()` must be disposed to avoid leaks.
-///
-/// - precondition: `interval` must be non-negative number.
-///
-///	- note: If you plan to specify an `interval` value greater than 200,000
-///			seconds, use `timer(interval:on:leeway:)` instead
-///			and specify your own `leeway` value to avoid potential overflow.
-///
-/// - parameters:
-///   - interval: An interval between invocations.
-///   - scheduler: A scheduler to deliver events on.
-///
-/// - returns: A producer that sends `NSDate` values every `interval` seconds.
-public func timer(interval: DispatchTimeInterval, on scheduler: DateScheduler) -> SignalProducer<Date, NoError> {
-	// Apple's "Power Efficiency Guide for Mac Apps" recommends a leeway of
-	// at least 10% of the timer interval.
-	return timer(interval: interval, on: scheduler, leeway: interval * 0.1)
-}
+extension SignalProducer where Value == Date, Error == NoError {
+	/// Create a repeating timer of the given interval, with a reasonable default
+	/// leeway, sending updates on the given scheduler.
+	///
+	/// - note: This timer will never complete naturally, so all invocations of
+	///         `start()` must be disposed to avoid leaks.
+	///
+	/// - precondition: `interval` must be non-negative number.
+	///
+	///	- note: If you plan to specify an `interval` value greater than 200,000
+	///			seconds, use `timer(interval:on:leeway:)` instead
+	///			and specify your own `leeway` value to avoid potential overflow.
+	///
+	/// - parameters:
+	///   - interval: An interval between invocations.
+	///   - scheduler: A scheduler to deliver events on.
+	///
+	/// - returns: A producer that sends `NSDate` values every `interval` seconds.
+	public static func timer(interval: DispatchTimeInterval, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
+		// Apple's "Power Efficiency Guide for Mac Apps" recommends a leeway of
+		// at least 10% of the timer interval.
+		return timer(interval: interval, on: scheduler, leeway: interval * 0.1)
+	}
 
-/// Creates a repeating timer of the given interval, sending updates on the
-/// given scheduler.
-///
-/// - note: This timer will never complete naturally, so all invocations of
-///         `start()` must be disposed to avoid leaks.
-///
-/// - precondition: `interval` must be non-negative number.
-///
-/// - precondition: `leeway` must be non-negative number.
-///
-/// - parameters:
-///   - interval: An interval between invocations.
-///   - scheduler: A scheduler to deliver events on.
-///   - leeway: Interval leeway. Apple's "Power Efficiency Guide for Mac Apps"
-///             recommends a leeway of at least 10% of the timer interval.
-///
-/// - returns: A producer that sends `NSDate` values every `interval` seconds.
-public func timer(interval: DispatchTimeInterval, on scheduler: DateScheduler, leeway: DispatchTimeInterval) -> SignalProducer<Date, NoError> {
-	precondition(interval.timeInterval >= 0)
-	precondition(leeway.timeInterval >= 0)
+	/// Creates a repeating timer of the given interval, sending updates on the
+	/// given scheduler.
+	///
+	/// - note: This timer will never complete naturally, so all invocations of
+	///         `start()` must be disposed to avoid leaks.
+	///
+	/// - precondition: `interval` must be non-negative number.
+	///
+	/// - precondition: `leeway` must be non-negative number.
+	///
+	/// - parameters:
+	///   - interval: An interval between invocations.
+	///   - scheduler: A scheduler to deliver events on.
+	///   - leeway: Interval leeway. Apple's "Power Efficiency Guide for Mac Apps"
+	///             recommends a leeway of at least 10% of the timer interval.
+	///
+	/// - returns: A producer that sends `NSDate` values every `interval` seconds.
+	public static func timer(interval: DispatchTimeInterval, on scheduler: DateScheduler, leeway: DispatchTimeInterval) -> SignalProducer<Value, Error> {
+		precondition(interval.timeInterval >= 0)
+		precondition(leeway.timeInterval >= 0)
 
-	return SignalProducer { observer, compositeDisposable in
-		compositeDisposable += scheduler.schedule(after: scheduler.currentDate.addingTimeInterval(interval),
-		                                          interval: interval,
-		                                          leeway: leeway,
-		                                          action: { observer.send(value: scheduler.currentDate) })
+		return SignalProducer { observer, compositeDisposable in
+			compositeDisposable += scheduler.schedule(after: scheduler.currentDate.addingTimeInterval(interval),
+													  interval: interval,
+													  leeway: leeway,
+													  action: { observer.send(value: scheduler.currentDate) })
+		}
 	}
 }

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -839,7 +839,7 @@ class SignalProducerSpec: QuickSpec {
 		describe("timer") {
 			it("should send the current date at the given interval") {
 				let scheduler = TestScheduler()
-				let producer = timer(interval: .seconds(1), on: scheduler, leeway: .seconds(0))
+				let producer = SignalProducer.timer(interval: .seconds(1), on: scheduler, leeway: .seconds(0))
 
 				let startDate = scheduler.currentDate
 				let tick1 = startDate.addingTimeInterval(1)
@@ -873,7 +873,7 @@ class SignalProducerSpec: QuickSpec {
 					scheduler = QueueScheduler(queue: DispatchQueue(label: "\(#file):\(#line)"))
 				}
 
-				let producer = timer(interval: .seconds(3), on: scheduler)
+				let producer = SignalProducer.timer(interval: .seconds(3), on: scheduler)
 				producer
 					.start()
 					.dispose()
@@ -881,7 +881,7 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should release the signal when disposed") {
 				let scheduler = TestScheduler()
-				let producer = timer(interval: .seconds(1), on: scheduler, leeway: .seconds(0))
+				let producer = SignalProducer.timer(interval: .seconds(1), on: scheduler, leeway: .seconds(0))
 				var interrupted = false
 
 				weak var weakSignal: Signal<Date, NoError>?
@@ -1040,7 +1040,7 @@ class SignalProducerSpec: QuickSpec {
 				let startScheduler = TestScheduler()
 				let testScheduler = TestScheduler()
 
-				let producer = timer(interval: .seconds(2), on: testScheduler, leeway: .seconds(0))
+				let producer = SignalProducer.timer(interval: .seconds(2), on: testScheduler, leeway: .seconds(0))
 
 				var value: Date?
 				producer.start(on: startScheduler).startWithValues { value = $0 }


### PR DESCRIPTION
The very last two free functions of ReactiveSwift find their new home. Renaming fix-its work properly despite `self` being the second argument.