### PR TITLE
Rename closure parameter names of operators, and update documentations.

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Dispatch
-import enum Result.NoError
+import Result
 
 // MARK: Unavailable methods in ReactiveSwift 2.0.
 extension PropertyProtocol {
@@ -73,6 +73,11 @@ extension SignalProducer where Error == NoError {
 extension ComposableMutablePropertyProtocol {
 	@available(*, unavailable, renamed:"withValue(_:)")
 	public func withValue<Result>(action: (Value) throws -> Result) rethrows -> Result { fatalError() }
+}
+
+extension SignalProducer {
+	@available(*, unavailable, renamed:"attempt(_:)")
+	public func attempt(action: @escaping (Value) -> Result<(), Error>) -> SignalProducer<Value, Error> { fatalError() }
 }
 
 @available(*, unavailable, renamed:"SignalProducer.timer")

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -137,25 +137,26 @@ extension PropertyProtocol {
 		return lift { $0.combinePrevious(initial) }
 	}
 
-	/// Forward only those values from `self` which do not pass `isRepeat` with
-	/// respect to the previous value.
+	/// Forward only values from `self` that are not considered equivalent to its
+	/// consecutive predecessor.
+	///
+	/// - note: The first value is always forwarded.
 	///
 	/// - parameters:
-	///   - isRepeat: A predicate to determine if the two given values are equal.
+	///   - isEquivalent: A closure to determine whether two values are equivalent.
 	///
-	/// - returns: A property that does not emit events for two equal values
-	///            sequentially.
-	public func skipRepeats(_ isRepeat: @escaping (Value, Value) -> Bool) -> Property<Value> {
-		return lift { $0.skipRepeats(isRepeat) }
+	/// - returns: A property which conditionally forwards values from `self`.
+	public func skipRepeats(_ isEquivalent: @escaping (Value, Value) -> Bool) -> Property<Value> {
+		return lift { $0.skipRepeats(isEquivalent) }
 	}
 }
 
 extension PropertyProtocol where Value: Equatable {
-	/// Forward only those values from `self` which do not pass `isRepeat` with
-	/// respect to the previous value.
+	/// Forward only values from `self` that are not equal to its consecutive predecessor.
 	///
-	/// - returns: A property that does not emit events for two equal values
-	///            sequentially.
+	/// - note: The first value is always forwarded.
+	///
+	/// - returns: A property which conditionally forwards values from `self`.
 	public func skipRepeats() -> Property<Value> {
 		return lift { $0.skipRepeats() }
 	}


### PR DESCRIPTION
1. Follow the Swift API Guidelines and the Standard Library in naming closure parameters according to their assertions or roles, instead of generic names like `predicate`. e.g.
    ```
    -	public func filter(_ predicate: @escaping (Value) -> Bool) -> Signal<Value, Error> {
    +	public func filter(_ isIncluded: @escaping (Value) -> Bool) -> Signal<Value, Error> {
    ```

1. Remove the label of a `SignalProducer.attempt` overload, which is supposed to be a parameter name.

1. Condense a few pieces of documentations by taking advantage of the new parameter names, while keeping another few consistent among the `Signal` and the lifted versions.