### PR TITLE
Remove the label from `MutableProperty.withValue(_:)`.

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -3,6 +3,11 @@ import Dispatch
 import enum Result.NoError
 
 // MARK: Unavailable methods in ReactiveSwift 2.0.
+extension ComposableMutablePropertyProtocol {
+	@available(*, unavailable, renamed:"withValue(_:)")
+	public func withValue<Result>(action: (Value) throws -> Result) rethrows -> Result { fatalError() }
+}
+
 @available(*, unavailable, renamed:"SignalProducer.timer")
 public func timer(interval: DispatchTimeInterval, on scheduler: DateScheduler) -> SignalProducer<Date, NoError> { fatalError() }
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -69,7 +69,7 @@ public protocol ComposableMutablePropertyProtocol: MutablePropertyProtocol {
 	///   - action: A closure that accepts current property value.
 	///
 	/// - returns: the result of the action.
-	func withValue<Result>(action: (Value) throws -> Result) rethrows -> Result
+	func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result
 
 	/// Atomically modifies the variable.
 	///
@@ -701,7 +701,7 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 	///
 	/// - returns: the result of the action.
 	@discardableResult
-	public func withValue<Result>(action: (Value) throws -> Result) rethrows -> Result {
+	public func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result {
 		return try atomic.withValue(action)
 	}
 


### PR DESCRIPTION
... and also `ComposableMutablePropertyProtocol.withValue(_:)`.

It breaks the conformances, but the impact should not be large given its recent introduction in ReactiveSwift 1.1. Call sites are migrated.