### PR TITLE
Rename `SignalProducer.Type.attempt` to `init(_:)`.

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -3,6 +3,16 @@ import Dispatch
 import Result
 
 // MARK: Unavailable methods in ReactiveSwift 2.0.
+extension SignalProducerProtocol {
+	@available(*, unavailable, renamed:"init(_:)")
+	public static func attempt(_ operation: @escaping () -> Result<Value, Error>) -> SignalProducer<Value, Error> { fatalError() }
+}
+
+extension SignalProducerProtocol where Error == AnyError {
+	@available(*, unavailable, renamed:"init(_:)")
+	public static func attempt(_ operation: @escaping () throws -> Value) -> SignalProducer<Value, Error> { fatalError() }
+}
+
 extension PropertyProtocol {
 	@available(*, unavailable, renamed:"flatMap(_:_:)")
 	public func flatMap<P: PropertyProtocol>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> P) -> Property<P.Value> { fatalError() }


### PR DESCRIPTION
Follow-up to #304.

The original signatures are ambiguous, but they somehow work as protocol extensions in Swift 3. Moving them to the concrete type reveals the ambiguity.
```swift
extension SignalProducer {
	public static func attempt(_ operation: @escaping () -> Result<Value, Error>) -> SignalProducer<Value, Error>
}

extension SignalProducer where Error == AnyError {
	public static func attempt(_ operation: @escaping () throws -> Value) -> SignalProducer<Value, Error>
}
```

Consider `.attempt { () -> Result<Int, NoError> in .success(1) }`, the closure can satisfy both methods and produce:
1. `SignalProducer<Int, NoError>`; or
1. `SignalProducer<Result<Int, NoError>, AnyError>` since non-throwing closures are covariant of their throwing version.

### Solution
Renaming `SignalProducer.Type.attempt` to `init(_:)` mitigated the ambiguity.  How this happens is uncertain, given that Swift has no documentation on the overload selection rules at the moment.

Edit: It is suspected that these as static functions require the compiler to consider two additional generic parameters in the return type. Being `init(_:)`, however, binds the return type to be `Self`, and reduce the overload selection factors to the arguments.