### PR TITLE
Generic n-ary producer operators for n > 1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 *Please add new entries at the top.*
+1. N-ary `SignalProducer` operators are now generic and accept any type that can be expressed as `SignalProducer`. (#410, kudos to @andersio)
+   Types may conform to `SignalProducerConvertible` to be an eligible operand.
 
 1. `promoteError` can now infer the new error type from the context. (#413, kudos to @andersio)
 

--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -416,17 +416,10 @@
 			name = Signals;
 			sourceTree = "<group>";
 		};
-		D03B4A3A19F4C26D009E02AC /* Internal Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				4AC73ECA1DF273570004EC4F /* ResultExtensions.swift */,
-			);
-			name = "Internal Utilities";
-			sourceTree = "<group>";
-		};
 		D03B4A3B19F4C281009E02AC /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				4AC73ECA1DF273570004EC4F /* ResultExtensions.swift */,
 				D03B4A3C19F4C39A009E02AC /* FoundationExtensions.swift */,
 			);
 			name = Extensions;
@@ -471,7 +464,6 @@
 				D0C312C819EF2A5800984962 /* Scheduler.swift */,
 				C79B647B1CD52E23003F2376 /* EventLogger.swift */,
 				D03B4A3919F4C25F009E02AC /* Signals */,
-				D03B4A3A19F4C26D009E02AC /* Internal Utilities */,
 				D03B4A3B19F4C281009E02AC /* Extensions */,
 				9ABCB1841D2A5B5A00BCA243 /* Deprecations+Removals.swift */,
 				D04725ED19E49ED7006002AA /* Supporting Files */,

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -43,12 +43,12 @@ extension Lifetime {
 	}
 }
 
-extension SignalProducerProtocol {
+extension SignalProducer {
 	@available(*, unavailable, renamed:"init(_:)")
 	public static func attempt(_ operation: @escaping () -> Result<Value, Error>) -> SignalProducer<Value, Error> { fatalError() }
 }
 
-extension SignalProducerProtocol where Error == AnyError {
+extension SignalProducer where Error == AnyError {
 	@available(*, unavailable, renamed:"init(_:)")
 	public static func attempt(_ operation: @escaping () throws -> Value) -> SignalProducer<Value, Error> { fatalError() }
 }
@@ -60,64 +60,34 @@ extension PropertyProtocol {
 
 extension Signal {
 	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> { fatalError() }
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Error> where Error == Inner.Error { fatalError() }
 
 	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, NoError>) -> Signal<U, Error> { fatalError() }
-
-	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, Error>) -> Signal<U, Error> { fatalError() }
-
-	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, NoError>) -> Signal<U, Error> { fatalError() }
-
-	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<P: PropertyProtocol>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> P) -> Signal<P.Value, Error> { fatalError() }
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Error> where Inner.Error == NoError { fatalError() }
 }
 
 extension Signal where Error == NoError {
 	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, E>) -> Signal<U, E> { fatalError() }
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Inner.Error> where Error == Inner.Error { fatalError() }
 
 	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, NoError>) -> Signal<U, NoError> { fatalError() }
-
-	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, E>) -> Signal<U, E> { fatalError() }
-
-	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, NoError>) -> Signal<U, NoError> { fatalError() }
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Inner.Error> { fatalError() }
 }
 
 extension SignalProducer {
 	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> { fatalError() }
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Error> where Error == Inner.Error { fatalError() }
 
 	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, NoError>) -> SignalProducer<U, Error> { fatalError() }
-
-	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> { fatalError() }
-
-	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, NoError>) -> SignalProducer<U, Error> { fatalError() }
-
-	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<P: PropertyProtocol>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> P) -> SignalProducer<P.Value, Error> { fatalError() }
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Error> where Inner.Error == NoError { fatalError() }
 }
 
 extension SignalProducer where Error == NoError {
 	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, E>) -> SignalProducer<U, E> { fatalError() }
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Inner.Error> where Error == Inner.Error { fatalError() }
 
 	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, NoError>) -> SignalProducer<U, NoError> { fatalError() }
-
-	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, E>) -> SignalProducer<U, E> { fatalError() }
-
-	@available(*, unavailable, renamed:"flatMap(_:_:)")
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, NoError>) -> SignalProducer<U, NoError> { fatalError() }
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Inner.Error> { fatalError() }
 }
 
 extension ComposableMutablePropertyProtocol {
@@ -152,6 +122,12 @@ public typealias SimpleDisposable = AnyDisposable
 
 @available(*, unavailable, renamed:"AnyDisposable")
 public typealias ActionDisposable = AnyDisposable
+
+@available(*, unavailable, message: "`SignalProtocol` has been removed. Constrain `Signal` directly instead.")
+public protocol SignalProtocol {}
+
+@available(*, unavailable, message: "`SignalProducerProtocol` has been removed. Constrain `SignalProducer` directly instead.")
+public protocol SignalProducerProtocol {}
 
 @available(*, unavailable, renamed:"Signal.Event")
 public typealias Event<Value, Error: Swift.Error> = Signal<Value, Error>.Event

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -123,12 +123,6 @@ public typealias SimpleDisposable = AnyDisposable
 @available(*, unavailable, renamed:"AnyDisposable")
 public typealias ActionDisposable = AnyDisposable
 
-@available(*, unavailable, message: "`SignalProtocol` has been removed. Constrain `Signal` directly instead.")
-public protocol SignalProtocol {}
-
-@available(*, unavailable, message: "`SignalProducerProtocol` has been removed. Constrain `SignalProducer` directly instead.")
-public protocol SignalProducerProtocol {}
-
 @available(*, unavailable, renamed:"Signal.Event")
 public typealias Event<Value, Error: Swift.Error> = Signal<Value, Error>.Event
 

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -69,7 +69,7 @@ public enum FlattenStrategy: Equatable {
 	}
 }
 
-extension Signal where Value: SignalProducerProtocol, Error == Value.Error {
+extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	/// Flattens the inner producers sent upon `signal` (into a single signal of
 	/// values), according to the semantics of the given strategy.
 	///
@@ -95,7 +95,7 @@ extension Signal where Value: SignalProducerProtocol, Error == Value.Error {
 	}
 }
 
-extension Signal where Value: SignalProducerProtocol, Error == NoError {
+extension Signal where Value: SignalProducerConvertible, Error == NoError {
 	/// Flattens the inner producers sent upon `signal` (into a single signal of
 	/// values), according to the semantics of the given strategy.
 	///
@@ -114,7 +114,7 @@ extension Signal where Value: SignalProducerProtocol, Error == NoError {
 	}
 }
 
-extension Signal where Value: SignalProducerProtocol, Error == NoError, Value.Error == NoError {
+extension Signal where Value: SignalProducerConvertible, Error == NoError, Value.Error == NoError {
 	/// Flattens the inner producers sent upon `signal` (into a single signal of
 	/// values), according to the semantics of the given strategy.
 	///
@@ -137,7 +137,7 @@ extension Signal where Value: SignalProducerProtocol, Error == NoError, Value.Er
 	}
 }
 
-extension Signal where Value: SignalProducerProtocol, Value.Error == NoError {
+extension Signal where Value: SignalProducerConvertible, Value.Error == NoError {
 	/// Flattens the inner producers sent upon `signal` (into a single signal of
 	/// values), according to the semantics of the given strategy.
 	///
@@ -154,7 +154,7 @@ extension Signal where Value: SignalProducerProtocol, Value.Error == NoError {
 	}
 }
 
-extension SignalProducer where Value: SignalProducerProtocol, Error == Value.Error {
+extension SignalProducer where Value: SignalProducerConvertible, Error == Value.Error {
 	/// Flattens the inner producers sent upon `producer` (into a single
 	/// producer of values), according to the semantics of the given strategy.
 	///
@@ -180,7 +180,7 @@ extension SignalProducer where Value: SignalProducerProtocol, Error == Value.Err
 	}
 }
 
-extension SignalProducer where Value: SignalProducerProtocol, Error == NoError {
+extension SignalProducer where Value: SignalProducerConvertible, Error == NoError {
 	/// Flattens the inner producers sent upon `producer` (into a single
 	/// producer of values), according to the semantics of the given strategy.
 	///
@@ -199,7 +199,7 @@ extension SignalProducer where Value: SignalProducerProtocol, Error == NoError {
 	}
 }
 
-extension SignalProducer where Value: SignalProducerProtocol, Error == NoError, Value.Error == NoError {
+extension SignalProducer where Value: SignalProducerConvertible, Error == NoError, Value.Error == NoError {
 	/// Flattens the inner producers sent upon `producer` (into a single
 	/// producer of values), according to the semantics of the given strategy.
 	///
@@ -222,7 +222,7 @@ extension SignalProducer where Value: SignalProducerProtocol, Error == NoError, 
 	}
 }
 
-extension SignalProducer where Value: SignalProducerProtocol, Value.Error == NoError {
+extension SignalProducer where Value: SignalProducerConvertible, Value.Error == NoError {
 	/// Flattens the inner producers sent upon `signal` (into a single signal of
 	/// values), according to the semantics of the given strategy.
 	///
@@ -239,152 +239,10 @@ extension SignalProducer where Value: SignalProducerProtocol, Value.Error == NoE
 	}
 }
 
-extension Signal where Value: SignalProtocol, Error == Value.Error {
-	/// Flattens the inner signals sent upon `signal` (into a single signal of
-	/// values), according to the semantics of the given strategy.
-	///
-	/// - note: If `signal` or an active inner signal emits an error, the
-	///         returned signal will forward that error immediately.
-	///
-	/// - warning: `interrupted` events on inner signals will be treated like
-	///            `completed` events on inner signals.
-	///
-	/// - parameters:
-	///   - strategy: Strategy used when flattening signals.
-	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Value, Error> {
-		return self
-			.map { SignalProducer<Value.Value, Error>($0.signal) }
-			.flatten(strategy)
-	}
-}
-
-extension Signal where Value: SignalProtocol, Error == NoError {
-	/// Flattens the inner signals sent upon `signal` (into a single signal of
-	/// values), according to the semantics of the given strategy.
-	///
-	/// - note: If an active inner signal emits an error, the returned signal
-	///         will forward that error immediately.
-	///
-	/// - warning: `interrupted` events on inner signals will be treated like
-	///            `completed` events on inner signals.
-	///
-	/// - parameters:
-	///   - strategy: Strategy used when flattening signals.
-	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Value, Value.Error> {
-		return self
-			.promoteError(Value.Error.self)
-			.flatten(strategy)
-	}
-}
-
-extension Signal where Value: SignalProtocol, Error == NoError, Value.Error == NoError {
-	/// Flattens the inner signals sent upon `signal` (into a single signal of
-	/// values), according to the semantics of the given strategy.
-	///
-	/// - warning: `interrupted` events on inner signals will be treated like
-	///            `completed` events on inner signals.
-	///
-	/// - parameters:
-	///   - strategy: Strategy used when flattening signals.
-	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Value, Value.Error> {
-		return self
-			.map { SignalProducer<Value.Value, NoError>($0.signal) }
-			.flatten(strategy)
-	}
-}
-
-extension Signal where Value: SignalProtocol, Value.Error == NoError {
-	/// Flattens the inner signals sent upon `signal` (into a single signal of
-	/// values), according to the semantics of the given strategy.
-	///
-	/// - note: If `signal` emits an error, the returned signal will forward
-	///         that error immediately.
-	///
-	/// - warning: `interrupted` events on inner signals will be treated like
-	///            `completed` events on inner signals.
-	///
-	/// - parameters:
-	///   - strategy: Strategy used when flattening signals.
-	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Value, Error> {
-		return self.flatMap(strategy) { $0.signal.promoteError(Error.self) }
-	}
-}
-
 extension Signal where Value: Sequence {
 	/// Flattens the `sequence` value sent by `signal`.
 	public func flatten() -> Signal<Value.Iterator.Element, Error> {
 		return self.flatMap(.merge, SignalProducer.init)
-	}
-}
-
-extension SignalProducer where Value: SignalProtocol, Error == Value.Error {
-	/// Flattens the inner signals sent upon `producer` (into a single producer
-	/// of values), according to the semantics of the given strategy.
-	///
-	/// - note: If `producer` or an active inner signal emits an error, the
-	///         returned producer will forward that error immediately.
-	///
-	/// - warning: `interrupted` events on inner signals will be treated like
-	///            `completed` events on inner signals.
-	///
-	/// - parameters:
-	///   - strategy: Strategy used when flattening signals.
-	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Value, Error> {
-		return self
-			.map { SignalProducer<Value.Value, Value.Error>($0.signal) }
-			.flatten(strategy)
-	}
-}
-
-extension SignalProducer where Value: SignalProtocol, Error == NoError {
-	/// Flattens the inner signals sent upon `producer` (into a single producer
-	/// of values), according to the semantics of the given strategy.
-	///
-	/// - note: If an active inner signal emits an error, the returned producer
-	///         will forward that error immediately.
-	///
-	/// - warning: `interrupted` events on inner signals will be treated like
-	///            `completed` events on inner signals.
-	///
-	/// - parameters:
-	///   - strategy: Strategy used when flattening signals.
-	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Value, Value.Error> {
-		return self
-			.promoteError(Value.Error.self)
-			.flatten(strategy)
-	}
-}
-
-extension SignalProducer where Value: SignalProtocol, Error == NoError, Value.Error == NoError {
-	/// Flattens the inner signals sent upon `producer` (into a single producer
-	/// of values), according to the semantics of the given strategy.
-	///
-	/// - warning: `interrupted` events on inner signals will be treated like
-	///            `completed` events on inner signals.
-	///
-	/// - parameters:
-	///   - strategy: Strategy used when flattening signals.
-	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Value, Value.Error> {
-		return self
-			.map { SignalProducer<Value.Value, NoError>($0.signal) }
-			.flatten(strategy)
-	}
-}
-
-extension SignalProducer where Value: SignalProtocol, Value.Error == NoError {
-	/// Flattens the inner signals sent upon `producer` (into a single producer
-	/// of values), according to the semantics of the given strategy.
-	///
-	/// - note: If `producer` emits an error, the returned producer will forward
-	///         that error immediately.
-	///
-	/// - warning: `interrupted` events on inner signals will be treated like
-	///            `completed` events on inner signals.
-	///
-	/// - parameters:
-	///   - strategy: Strategy used when flattening signals.
-	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Value, Error> {
-		return self.flatMap(strategy) { $0.signal.promoteError(Error.self) }
 	}
 }
 
@@ -395,35 +253,7 @@ extension SignalProducer where Value: Sequence {
 	}
 }
 
-extension Signal where Value: PropertyProtocol {
-	/// Flattens the inner properties sent upon `signal` (into a single signal of
-	/// values), according to the semantics of the given strategy.
-	///
-	/// - note: If `signal` fails, the returned signal will forward that failure
-	///         immediately.
-	///
-	/// - parameters:
-	///   - strategy: Strategy used when flattening signals.
-	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Value, Error> {
-		return self.flatMap(strategy) { $0.producer }
-	}
-}
-
-extension SignalProducer where Value: PropertyProtocol {
-	/// Flattens the inner properties sent upon `signal` (into a single signal of
-	/// values), according to the semantics of the given strategy.
-	///
-	/// - note: If `signal` fails, the returned signal will forward that failure
-	///         immediately.
-	///
-	/// - parameters:
-	///   - strategy: Strategy used when flattening signals.
-	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Value, Error> {
-		return self.flatMap(strategy) { $0.producer }
-	}
-}
-
-extension Signal where Value: SignalProducerProtocol, Error == Value.Error {
+extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	fileprivate func concurrent(limit: UInt) -> Signal<Value.Value, Error> {
 		precondition(limit > 0, "The concurrent limit must be greater than zero.")
 
@@ -505,7 +335,7 @@ extension Signal where Value: SignalProducerProtocol, Error == Value.Error {
 	}
 }
 
-extension SignalProducer where Value: SignalProducerProtocol, Error == Value.Error {
+extension SignalProducer where Value: SignalProducerConvertible, Error == Value.Error {
 	fileprivate func concurrent(limit: UInt) -> SignalProducer<Value.Value, Error> {
 		precondition(limit > 0, "The concurrent limit must be greater than zero.")
 
@@ -622,10 +452,9 @@ extension Signal {
 	///
 	/// - parameters:
 	///   - signals: A sequence of signals to merge.
-	public static func merge<Seq: Sequence, S: SignalProtocol>(_ signals: Seq) -> Signal<Value, Error>
-		where S.Value == Value, S.Error == Error, Seq.Iterator.Element == S
+	public static func merge<Seq: Sequence>(_ signals: Seq) -> Signal<Value, Error> where Seq.Iterator.Element == Signal<Value, Error>
 	{
-		return SignalProducer<S, Error>(signals)
+		return SignalProducer<Signal<Value, Error>, Error>(signals)
 			.flatten(.merge)
 			.startAndRetrieveSignal()
 	}
@@ -635,9 +464,7 @@ extension Signal {
 	///
 	/// - parameters:
     ///   - signals: A list of signals to merge.
-	public static func merge<S: SignalProtocol>(_ signals: S...) -> Signal<Value, Error>
-		where S.Value == Value, S.Error == Error
-	{
+	public static func merge(_ signals: Signal<Value, Error>...) -> Signal<Value, Error> {
 		return Signal.merge(signals)
 	}
 }
@@ -665,7 +492,7 @@ extension SignalProducer {
 	}
 }
 
-extension Signal where Value: SignalProducerProtocol, Error == Value.Error {
+extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	/// Returns a signal that forwards values from the latest signal sent on
 	/// `signal`, ignoring values sent on previous inner signal.
 	///
@@ -759,7 +586,7 @@ extension Signal where Value: SignalProducerProtocol, Error == Value.Error {
 	}
 }
 
-extension SignalProducer where Value: SignalProducerProtocol, Error == Value.Error {
+extension SignalProducer where Value: SignalProducerConvertible, Error == Value.Error {
 	/// - warning: An error sent on `signal` or the latest inner signal will be
 	///            sent on the returned signal.
 	///
@@ -791,7 +618,7 @@ private struct LatestState<Value, Error: Swift.Error> {
 	var replacingInnerSignal: Bool = false
 }
 
-extension Signal where Value: SignalProducerProtocol, Error == Value.Error {
+extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	/// Returns a signal that forwards values from the "first input signal to send an event"
 	/// (winning signal) that is sent on `self`, ignoring values sent from other inner signals.
 	///
@@ -887,7 +714,7 @@ extension Signal where Value: SignalProducerProtocol, Error == Value.Error {
 	}
 }
 
-extension SignalProducer where Value: SignalProducerProtocol, Error == Value.Error {
+extension SignalProducer where Value: SignalProducerConvertible, Error == Value.Error {
 	/// Returns a producer that forwards values from the "first input producer to send an event"
 	/// (winning producer) that is sent on `self`, ignoring values sent from other inner producers.
 	///
@@ -929,7 +756,7 @@ extension Signal {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> {
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Error> where Inner.Error == Error {
 		return map(transform).flatten(strategy)
 	}
 	
@@ -944,52 +771,7 @@ extension Signal {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, NoError>) -> Signal<U, Error> {
-		return map(transform).flatten(strategy)
-	}
-
-	/// Maps each event from `signal` to a new signal, then flattens the
-	/// resulting signals (into a signal of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// - warning: If `signal` or any of the created signals emit an error, the
-	///            returned signal will forward that error immediately.
-	///
-	/// - parameters:
-	///	  - strategy: Strategy used when flattening signals.
-	///   - transform: A closure that takes a value emitted by `self` and
-	///                returns a signal with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Signal<U, Error>) -> Signal<U, Error> {
-		return map(transform).flatten(strategy)
-	}
-
-	/// Maps each event from `signal` to a new signal, then flattens the
-	/// resulting signals (into a signal of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// - warning: If `signal` emits an error, the returned signal will forward
-	///            that error immediately.
-	///
-	/// - parameters:
-	///	  - strategy: Strategy used when flattening signals.
-	///   - transform: A closure that takes a value emitted by `self` and
-	///                returns a signal with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Signal<U, NoError>) -> Signal<U, Error> {
-		return map(transform).flatten(strategy)
-	}
-
-	/// Maps each event from `signal` to a new property, then flattens the
-	/// resulting properties (into a signal of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// - warning: If `signal` emits an error, the returned signal will forward
-	///            that error immediately.
-	///
-	/// - parameters:
-	///	  - strategy: Strategy used when flattening signals.
-	///   - transform: A closure that takes a value emitted by `self` and
-	///                returns a property with transformed value.
-	public func flatMap<P: PropertyProtocol>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> P) -> Signal<P.Value, Error> {
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Error> where Inner.Error == NoError {
 		return map(transform).flatten(strategy)
 	}
 }
@@ -1006,7 +788,7 @@ extension Signal where Error == NoError {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, E>) -> Signal<U, E> {
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Inner.Error> {
 		return map(transform).flatten(strategy)
 	}
 	
@@ -1018,34 +800,7 @@ extension Signal where Error == NoError {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, NoError>) -> Signal<U, NoError> {
-		return map(transform).flatten(strategy)
-	}
-	
-	/// Maps each event from `signal` to a new signal, then flattens the
-	/// resulting signals (into a signal of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// - warning: If any of the created signals emit an error, the returned
-	///            signal will forward that error immediately.
-	///
-	/// - parameters:
-	///	  - strategy: Strategy used when flattening signals.
-	///   - transform: A closure that takes a value emitted by `self` and
-	///                returns a signal with transformed value.
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Signal<U, E>) -> Signal<U, E> {
-		return map(transform).flatten(strategy)
-	}
-
-	/// Maps each event from `signal` to a new signal, then flattens the
-	/// resulting signals (into a signal of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// - parameters:
-	///	  - strategy: Strategy used when flattening signals.
-	///   - transform: A closure that takes a value emitted by `self` and
-	///                returns a signal with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Signal<U, NoError>) -> Signal<U, NoError> {
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, NoError> where Inner.Error == NoError {
 		return map(transform).flatten(strategy)
 	}
 }
@@ -1062,7 +817,7 @@ extension SignalProducer {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Error> where Inner.Error == Error {
 		return map(transform).flatten(strategy)
 	}
 	
@@ -1077,57 +832,24 @@ extension SignalProducer {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, NoError>) -> SignalProducer<U, Error> {
-		return map(transform).flatten(strategy)
-	}
-
-	/// Maps each event from `self` to a new producer, then flattens the
-	/// resulting signals (into a producer of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// - warning: If `self` or any of the created signals emit an error, the
-	///            returned producer will forward that error immediately.
-	///
-	/// - parameters:
-	///	  - strategy: Strategy used when flattening signals.
-	///   - transform: A closure that takes a value emitted by `self` and
-	///                returns a signal with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> {
-		return map(transform).flatten(strategy)
-	}
-
-	/// Maps each event from `self` to a new producer, then flattens the
-	/// resulting signals (into a producer of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// - warning: If `self` emits an error, the returned producer will forward
-	///            that error immediately.
-	///
-	/// - parameters:
-	///	  - strategy: Strategy used when flattening signals.
-	///   - transform: A closure that takes a value emitted by `self` and
-	///                returns a signal with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Signal<U, NoError>) -> SignalProducer<U, Error> {
-		return map(transform).flatten(strategy)
-	}
-
-	/// Maps each event from `self` to a new property, then flattens the
-	/// resulting properties (into a producer of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// - warning: If `self` emits an error, the returned producer will forward
-	///            that error immediately.
-	///
-	/// - parameters:
-	///	  - strategy: Strategy used when flattening signals.
-	///   - transform: A closure that takes a value emitted by `self` and
-	///                returns a property with transformed value.
-	public func flatMap<P: PropertyProtocol>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> P) -> SignalProducer<P.Value, Error> {
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Error> where Inner.Error == NoError {
 		return map(transform).flatten(strategy)
 	}
 }
 
 extension SignalProducer where Error == NoError {
+	/// Maps each event from `self` to a new producer, then flattens the
+	/// resulting producers (into a producer of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// - parameters:
+	///	  - strategy: Strategy used when flattening signals.
+	///   - transform: A closure that takes a value emitted by `self` and
+	///                returns a signal producer with transformed value.
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Error> where Inner.Error == Error {
+		return map(transform).flatten(strategy)
+	}
+	
 	/// Maps each event from `self` to a new producer, then flattens the
 	/// resulting producers (into a producer of values), according to the
 	/// semantics of the given strategy.
@@ -1139,46 +861,7 @@ extension SignalProducer where Error == NoError {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, E>) -> SignalProducer<U, E> {
-		return map(transform).flatten(strategy)
-	}
-	
-	/// Maps each event from `self` to a new producer, then flattens the
-	/// resulting producers (into a producer of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// - parameters:
-	///	  - strategy: Strategy used when flattening signals.
-	///   - transform: A closure that takes a value emitted by `self` and
-	///                returns a signal producer with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, NoError>) -> SignalProducer<U, NoError> {
-		return map(transform).flatten(strategy)
-	}
-
-	/// Maps each event from `self` to a new producer, then flattens the
-	/// resulting signals (into a producer of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// - warning: If any of the created signals emit an error, the returned
-	///            producer will forward that error immediately.
-	///
-	/// - parameters:
-	///	  - strategy: Strategy used when flattening signals.
-	///   - transform: A closure that takes a value emitted by `self` and
-	///                returns a signal with transformed value.
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Signal<U, E>) -> SignalProducer<U, E> {
-		return map(transform).flatten(strategy)
-	}
-
-	/// Maps each event from `self` to a new producer, then flattens the
-	/// resulting signals (into a producer of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// - parameters:
-	///	  - strategy: Strategy used when flattening signals.
-	///   - transform: A closure that takes a value emitted by `self` and
-	///                returns a signal with transformed value.
-	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Signal<U, NoError>) -> SignalProducer<U, NoError> {
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Inner.Error> {
 		return map(transform).flatten(strategy)
 	}
 }

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -519,22 +519,9 @@ extension Signal {
 	}
 }
 
-/// A protocol used to constraint `Signal` operators.
-public protocol SignalProtocol {
-	/// The type of values being sent on the signal.
-	associatedtype Value
-
-	/// The type of error that can occur on the signal. If errors aren't
-	/// possible then `NoError` can be used.
-	associatedtype Error: Swift.Error
-
-	/// Extracts a signal from the receiver.
-	var signal: Signal<Value, Error> { get }
-}
-
-extension Signal: SignalProtocol {
-	public var signal: Signal {
-		return self
+extension Signal: SignalProducerConvertible {
+	public var producer: SignalProducer<Value, Error> {
+		return SignalProducer(self)
 	}
 }
 
@@ -1052,7 +1039,7 @@ extension Signal {
 		precondition(count >= 0)
 
 		if count == 0 {
-			return signal
+			return self
 		}
 
 		return Signal { observer in
@@ -1154,7 +1141,7 @@ extension Signal {
 
 			_ = disposed.map(disposable.add)
 
-			disposable += signal.observe { receivedEvent in
+			disposable += self.observe { receivedEvent in
 				event?(receivedEvent)
 
 				switch receivedEvent {

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -519,6 +519,23 @@ extension Signal {
 	}
 }
 
+public protocol SignalProtocol: class {
+	/// The type of values being sent by `self`.
+	associatedtype Value
+
+	/// The type of error that can occur on `self`.
+	associatedtype Error: Swift.Error
+
+	/// The materialized `self`.
+	var signal: Signal<Value, Error> { get }
+}
+
+extension Signal: SignalProtocol {
+	public var signal: Signal<Value, Error> {
+		return self
+	}
+}
+
 extension Signal: SignalProducerConvertible {
 	public var producer: SignalProducer<Value, Error> {
 		return SignalProducer(self)

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -234,7 +234,7 @@ extension SignalProducer where Error == AnyError {
 	}
 }
 
-/// Represents reactive primitives that can be represented by `Signalproducer`.
+/// Represents reactive primitives that can be represented by `SignalProducer`.
 public protocol SignalProducerConvertible {
 	/// The type of values being sent by `self`.
 	associatedtype Value
@@ -246,7 +246,19 @@ public protocol SignalProducerConvertible {
 	var producer: SignalProducer<Value, Error> { get }
 }
 
-extension SignalProducer: SignalProducerConvertible {
+/// A protocol for constraining associated types to `SignalProducer`.
+public protocol SignalProducerProtocol {
+	/// The type of values being sent by `self`.
+	associatedtype Value
+
+	/// The type of error that can occur on `self`.
+	associatedtype Error: Swift.Error
+
+	/// The materialized `self`.
+	var producer: SignalProducer<Value, Error> { get }
+}
+
+extension SignalProducer: SignalProducerConvertible, SignalProducerProtocol {
 	public var producer: SignalProducer {
 		return self
 	}

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -21,6 +21,14 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 
 	private let startHandler: (Signal<Value, Error>.Observer, Lifetime) -> Void
 
+	/// Convert an entity into its equivalent representation as `SignalProducer`.
+	///
+	/// - parameters:
+	///   - base: The entity to convert from.
+	public init<T: SignalProducerConvertible>(_ base: T) where T.Value == Value, T.Error == Error {
+		self = base.producer
+	}
+
 	/// Initializes a `SignalProducer` that will emit the same events as the
 	/// given signal.
 	///
@@ -226,19 +234,19 @@ extension SignalProducer where Error == AnyError {
 	}
 }
 
-/// A protocol used to constraint `SignalProducer` operators.
-public protocol SignalProducerProtocol {
-	/// The type of values being sent on the producer
+/// Represents reactive primitives that can be represented by `Signalproducer`.
+public protocol SignalProducerConvertible {
+	/// The type of values being sent by `self`.
 	associatedtype Value
-	/// The type of error that can occur on the producer. If errors aren't possible
-	/// then `NoError` can be used.
+
+	/// The type of error that can occur on `self`.
 	associatedtype Error: Swift.Error
 
-	/// Extracts a signal producer from the receiver.
+	/// The `SignalProducer` representation of `self`.
 	var producer: SignalProducer<Value, Error> { get }
 }
 
-extension SignalProducer: SignalProducerProtocol {
+extension SignalProducer: SignalProducerConvertible {
 	public var producer: SignalProducer {
 		return self
 	}
@@ -448,25 +456,6 @@ extension SignalProducer {
 					}
 				}
 			}
-		}
-	}
-
-	/// Lift a binary Signal operator to operate upon a Signal and a
-	/// SignalProducer instead.
-	///
-	/// In other words, this will create a new `SignalProducer` which will apply
-	/// the given `Signal` operator to _every_ `Signal` created from the two
-	/// producers, just as if the operator had been applied to each `Signal`
-	/// yielded from `start()`.
-	///
-	/// - parameters:
-	///   - transform: A binary operator to lift.
-	///
-	/// - returns: A binary operator that works on `Signal` and returns
-	///            `SignalProducer`.
-	public func lift<U, F, V, G>(_ transform: @escaping (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (Signal<U, F>) -> SignalProducer<V, G> {
-		return { otherSignal in
-			return self.liftRight(transform)(SignalProducer<U, F>(otherSignal))
 		}
 	}
 }
@@ -797,29 +786,8 @@ extension SignalProducer {
 	///
 	/// - returns: A producer that, when started, will yield a tuple containing
 	///            values of `self` and given producer.
-	public func combineLatest<U>(with other: SignalProducer<U, Error>) -> SignalProducer<(Value, U), Error> {
+	public func combineLatest<Other: SignalProducerConvertible>(with other: Other) -> SignalProducer<(Value, Other.Value), Error> where Other.Error == Error {
 		return SignalProducer.combineLatest(self, other)
-	}
-
-	/// Combine the latest value of the receiver with the latest value from
-	/// the given signal.
-	///
-	/// - note: The returned producer will not send a value until both inputs
-	///         have sent at least one value each. 
-	///
-	/// - note: If either input is interrupted, the returned producer will also
-	///         be interrupted.
-	///
-	/// - note: The returned producer will not complete until both inputs
-	///         complete.
-	///
-	/// - parameters:
-	///   - other: A signal to combine `self`'s value with.
-	///
-	/// - returns: A producer that, when started, will yield a tuple containing
-	///            values of `self` and given signal.
-	public func combineLatest<U>(with other: Signal<U, Error>) -> SignalProducer<(Value, U), Error> {
-		return SignalProducer.combineLatest(self, SignalProducer<U, Error>(other))
 	}
 
 	/// Delay `value` and `completed` events by the given interval, forwarding
@@ -878,27 +846,8 @@ extension SignalProducer {
 	///            sampled (possibly multiple times) by `sampler`, then complete
 	///            once both input producers have completed, or interrupt if
 	///            either input producer is interrupted.
-	public func sample<T>(with sampler: SignalProducer<T, NoError>) -> SignalProducer<(Value, T), Error> {
-		return liftLeft(Signal.sample(with:))(sampler)
-	}
-	
-	/// Forward the latest value from `self` with the value from `sampler` as a
-	/// tuple, only when `sampler` sends a `value` event.
-	///
-	/// - note: If `sampler` fires before a value has been observed on `self`,
-	///         nothing happens.
-	///
-	/// - parameters:
-	///   - sampler: A signal that will trigger the delivery of `value` event
-	///              from `self`.
-	///
-	/// - returns: A producer that, when started, will send values from `self`
-	///            and `sampler`, sampled (possibly multiple times) by
-	///            `sampler`, then complete once both input producers have
-	///            completed, or interrupt if either input producer is
-	///            interrupted.
-	public func sample<T>(with sampler: Signal<T, NoError>) -> SignalProducer<(Value, T), Error> {
-		return lift(Signal.sample(with:))(sampler)
+	public func sample<Sampler: SignalProducerConvertible>(with sampler: Sampler) -> SignalProducer<(Value, Sampler.Value), Error> where Sampler.Error == NoError {
+		return liftLeft(Signal.sample(with:))(sampler.producer)
 	}
 
 	/// Forward the latest value from `self` whenever `sampler` sends a `value`
@@ -915,26 +864,8 @@ extension SignalProducer {
 	///            sampled (possibly multiple times) by `sampler`, then complete
 	///            once both input producers have completed, or interrupt if
 	///            either input producer is interrupted.
-	public func sample(on sampler: SignalProducer<(), NoError>) -> SignalProducer<Value, Error> {
-		return liftLeft(Signal.sample(on:))(sampler)
-	}
-
-	/// Forward the latest value from `self` whenever `sampler` sends a `value`
-	/// event.
-	///
-	/// - note: If `sampler` fires before a value has been observed on `self`,
-	///         nothing happens.
-	///
-	/// - parameters:
-	///   - trigger: A signal whose `value` or `completed` events will start the
-	///              deliver of events on `self`.
-	///
-	/// - returns: A producer that will send values from `self`, sampled
-	///            (possibly multiple times) by `sampler`, then complete once 
-	///            both inputs have completed, or interrupt if either input is
-	///            interrupted.
-	public func sample(on sampler: Signal<(), NoError>) -> SignalProducer<Value, Error> {
-		return lift(Signal.sample(on:))(sampler)
+	public func sample<Sampler: SignalProducerConvertible>(on sampler: Sampler) -> SignalProducer<Value, Error> where Sampler.Value == (), Sampler.Error == NoError {
+		return liftLeft(Signal.sample(on:))(sampler.producer)
 	}
 
 	/// Forward the latest value from `samplee` with the value from `self` as a
@@ -952,27 +883,8 @@ extension SignalProducer {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func withLatest<U>(from samplee: SignalProducer<U, NoError>) -> SignalProducer<(Value, U), Error> {
-		return liftRight(Signal.withLatest)(samplee)
-	}
-
-	/// Forward the latest value from `samplee` with the value from `self` as a
-	/// tuple, only when `self` sends a `value` event.
-	/// This is like a flipped version of `sample(with:)`, but `samplee`'s
-	/// terminal events are completely ignored.
-	///
-	/// - note: If `self` fires before a value has been observed on `samplee`,
-	///         nothing happens.
-	///
-	/// - parameters:
-	///   - samplee: A signal whose latest value is sampled by `self`.
-	///
-	/// - returns: A signal that will send values from `self` and `samplee`,
-	///            sampled (possibly multiple times) by `self`, then terminate
-	///            once `self` has terminated. **`samplee`'s terminated events
-	///            are ignored**.
-	public func withLatest<U>(from samplee: Signal<U, NoError>) -> SignalProducer<(Value, U), Error> {
-		return lift(Signal.withLatest)(samplee)
+	public func withLatest<Samplee: SignalProducerConvertible>(from samplee: Samplee) -> SignalProducer<(Value, Samplee.Value), Error> where Samplee.Error == NoError {
+		return liftRight(Signal.withLatest)(samplee.producer)
 	}
 
 	/// Forwards events from `self` until `lifetime` ends, at which point the
@@ -996,21 +908,8 @@ extension SignalProducer {
 	///
 	/// - returns: A producer that will deliver events until `trigger` sends
 	///            `value` or `completed` events.
-	public func take(until trigger: SignalProducer<(), NoError>) -> SignalProducer<Value, Error> {
-		return liftRight(Signal.take(until:))(trigger)
-	}
-
-	/// Forward events from `self` until `trigger` sends a `value` or
-	/// `completed` event, at which point the returned producer will complete.
-	///
-	/// - parameters:
-	///   - trigger: A signal whose `value` or `completed` events will stop the
-	///              delivery of `value` events from `self`.
-	///
-	/// - returns: A producer that will deliver events until `trigger` sends
-	///            `value` or `completed` events.
-	public func take(until trigger: Signal<(), NoError>) -> SignalProducer<Value, Error> {
-		return lift(Signal.take(until:))(trigger)
+	public func take<Trigger: SignalProducerConvertible>(until trigger: Trigger) -> SignalProducer<Value, Error> where Trigger.Value == (), Trigger.Error == NoError {
+		return liftRight(Signal.take(until:))(trigger.producer)
 	}
 
 	/// Do not forward any values from `self` until `trigger` sends a `value`
@@ -1023,24 +922,10 @@ extension SignalProducer {
 	///
 	/// - returns: A producer that will deliver events once the `trigger` sends
 	///            `value` or `completed` events.
-	public func skip(until trigger: SignalProducer<(), NoError>) -> SignalProducer<Value, Error> {
-		return liftRight(Signal.skip(until:))(trigger)
+	public func skip<Trigger: SignalProducerConvertible>(until trigger: Trigger) -> SignalProducer<Value, Error> where Trigger.Value == (), Trigger.Error == NoError {
+		return liftRight(Signal.skip(until:))(trigger.producer)
 	}
-	
-	/// Do not forward any values from `self` until `trigger` sends a `value`
-	/// or `completed`, at which point the returned signal behaves exactly like
-	/// `signal`.
-	///
-	/// - parameters:
-	///   - trigger: A signal whose `value` or `completed` events will start the
-	///              deliver of events on `self`.
-	///
-	/// - returns: A producer that will deliver events once the `trigger` sends
-	///            `value` or `completed` events.
-	public func skip(until trigger: Signal<(), NoError>) -> SignalProducer<Value, Error> {
-		return lift(Signal.skip(until:))(trigger)
-	}
-	
+
 	/// Forward events from `self` with history: values of the returned producer
 	/// are a tuple whose first member is the previous value and whose second
 	/// member is the current value. `initial` is supplied as the first member
@@ -1151,26 +1036,10 @@ extension SignalProducer {
 		return lift { $0.skip(while: shouldContinue) }
 	}
 
-	/// Forward events from `self` until `replacement` begins sending events.
-	///
-	/// - parameters:
-	///   - replacement: A producer to wait to wait for values from and start
-	///                  sending them as a replacement to `self`'s values.
-	///
-	/// - returns: A producer which passes through `value`, `failed`, and
-	///            `interrupted` events from `self` until `replacement` sends an 
-	///            event, at which point the returned producer will send that
-	///            event and switch to passing through events from `replacement` 
-	///            instead, regardless of whether `self` has sent events
-	///            already.
-	public func take(untilReplacement signal: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
-		return liftRight(Signal.take(untilReplacement:))(signal)
-	}
-
 	/// Forwards events from `self` until `replacement` begins sending events.
 	///
 	/// - parameters:
-	///   - replacement: A signal to wait to wait for values from and start
+	///   - replacement: A producer to wait to wait for values from and start
 	///                  sending them as a replacement to `self`'s values.
 	///
 	/// - returns: A producer which passes through `value`, `failed`, and
@@ -1179,8 +1048,8 @@ extension SignalProducer {
 	///            event and switch to passing through events from `replacement`
 	///            instead, regardless of whether `self` has sent events
 	///            already.
-	public func take(untilReplacement signal: Signal<Value, Error>) -> SignalProducer<Value, Error> {
-		return lift(Signal.take(untilReplacement:))(signal)
+	public func take<Replacement: SignalProducerConvertible>(untilReplacement replacement: Replacement) -> SignalProducer<Value, Error> where Replacement.Value == Value, Replacement.Error == Error {
+		return liftRight(Signal.take(untilReplacement:))(replacement.producer)
 	}
 
 	/// Wait until `self` completes and then forward the final `count` values
@@ -1214,19 +1083,8 @@ extension SignalProducer {
 	///   - other: A producer to zip values with.
 	///
 	/// - returns: A producer that sends tuples of `self` and `otherProducer`.
-	public func zip<U>(with other: SignalProducer<U, Error>) -> SignalProducer<(Value, U), Error> {
+	public func zip<Other: SignalProducerConvertible>(with other: Other) -> SignalProducer<(Value, Other.Value), Error> where Other.Error == Error {
 		return SignalProducer.zip(self, other)
-	}
-
-	/// Zip elements of this producer and a signal into pairs. The elements of
-	/// any Nth pair are the Nth elements of the two.
-	///
-	/// - parameters:
-	///   - other: A signal to zip values with.
-	///
-	/// - returns: A producer that sends tuples of `self` and `otherSignal`.
-	public func zip<U>(with other: Signal<U, Error>) -> SignalProducer<(Value, U), Error> {
-		return SignalProducer.zip(self, SignalProducer<U, Error>(other))
 	}
 
 	/// Apply an action to every value from `self`, and forward the value if the action
@@ -1619,161 +1477,161 @@ extension SignalProducer {
 extension SignalProducer {
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<B>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>) -> SignalProducer<(Value, B), Error> {
-		return SignalProducer<(Value, B), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b) { Signal.combineLatest($0, $1).observe(observer) }
+	public static func combineLatest<A: SignalProducerConvertible, B: SignalProducerConvertible>(_ a: A, _ b: B) -> SignalProducer<(Value, B.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer) { Signal.combineLatest($0, $1).observe(observer) }
 		}
 	}
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<B, C>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>) -> SignalProducer<(Value, B, C), Error> {
-		return SignalProducer<(Value, B, C), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c) { Signal.combineLatest($0, $1, $2).observe(observer) }
+	public static func combineLatest<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C) -> SignalProducer<(Value, B.Value, C.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer) { Signal.combineLatest($0, $1, $2).observe(observer) }
 		}
 	}
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<B, C, D>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>) -> SignalProducer<(Value, B, C, D), Error> {
-		return SignalProducer<(Value, B, C, D), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d) { Signal.combineLatest($0, $1, $2, $3).observe(observer) }
+	public static func combineLatest<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D) -> SignalProducer<(Value, B.Value, C.Value, D.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer) { Signal.combineLatest($0, $1, $2, $3).observe(observer) }
 		}
 	}
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<B, C, D, E>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>) -> SignalProducer<(Value, B, C, D, E), Error> {
-		return SignalProducer<(Value, B, C, D, E), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e) { Signal.combineLatest($0, $1, $2, $3, $4).observe(observer) }
+	public static func combineLatest<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value), Error> where A.Value == Value, A.Error == Error , B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer) { Signal.combineLatest($0, $1, $2, $3, $4).observe(observer) }
 		}
 	}
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<B, C, D, E, F>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>) -> SignalProducer<(Value, B, C, D, E, F), Error> {
-		return SignalProducer<(Value, B, C, D, E, F), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e, f) { Signal.combineLatest($0, $1, $2, $3, $4, $5).observe(observer) }
+	public static func combineLatest<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value, F.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error, F.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer, f.producer) { Signal.combineLatest($0, $1, $2, $3, $4, $5).observe(observer) }
 		}
 	}
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<B, C, D, E, F, G>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>) -> SignalProducer<(Value, B, C, D, E, F, G), Error> {
-		return SignalProducer<(Value, B, C, D, E, F, G), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e, f, g) { Signal.combineLatest($0, $1, $2, $3, $4, $5, $6).observe(observer) }
+	public static func combineLatest<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error, F.Error == Error, G.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer) { Signal.combineLatest($0, $1, $2, $3, $4, $5, $6).observe(observer) }
 		}
 	}
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<B, C, D, E, F, G, H>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>) -> SignalProducer<(Value, B, C, D, E, F, G, H), Error> {
-		return SignalProducer<(Value, B, C, D, E, F, G, H), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e, f, g, h) { Signal.combineLatest($0, $1, $2, $3, $4, $5, $6, $7).observe(observer) }
+	public static func combineLatest<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible, H: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error, F.Error == Error, G.Error == Error, H.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer, h.producer) { Signal.combineLatest($0, $1, $2, $3, $4, $5, $6, $7).observe(observer) }
 		}
 	}
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<B, C, D, E, F, G, H, I>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>, _ i: SignalProducer<I, Error>) -> SignalProducer<(Value, B, C, D, E, F, G, H, I), Error> {
-		return SignalProducer<(Value, B, C, D, E, F, G, H, I), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e, f, g, h, i) { Signal.combineLatest($0, $1, $2, $3, $4, $5, $6, $7, $8).observe(observer) }
+	public static func combineLatest<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible, H: SignalProducerConvertible, I: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error, F.Error == Error, G.Error == Error, H.Error == Error, I.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer, h.producer, i.producer) { Signal.combineLatest($0, $1, $2, $3, $4, $5, $6, $7, $8).observe(observer) }
 		}
 	}
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<B, C, D, E, F, G, H, I, J>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>, _ i: SignalProducer<I, Error>, _ j: SignalProducer<J, Error>) -> SignalProducer<(Value, B, C, D, E, F, G, H, I, J), Error> {
-		return SignalProducer<(Value, B, C, D, E, F, G, H, I, J), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e, f, g, h, i, j) { Signal.combineLatest($0, $1, $2, $3, $4, $5, $6, $7, $8, $9).observe(observer) }
+	public static func combineLatest<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible, H: SignalProducerConvertible, I: SignalProducerConvertible, J: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value, J.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error, F.Error == Error, G.Error == Error, H.Error == Error, I.Error == Error, J.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer, h.producer, i.producer, j.producer) { Signal.combineLatest($0, $1, $2, $3, $4, $5, $6, $7, $8, $9).observe(observer) }
 		}
 	}
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`. Will return an empty `SignalProducer` if the sequence is empty.
-	public static func combineLatest<S: Sequence>(_ producers: S) -> SignalProducer<[Value], Error> where S.Iterator.Element == SignalProducer<Value, Error> {
+	public static func combineLatest<S: Sequence>(_ producers: S) -> SignalProducer<[Value], Error> where S.Iterator.Element: SignalProducerConvertible, S.Iterator.Element.Value == Value, S.Iterator.Element.Error == Error {
 		return start(producers, Signal.combineLatest)
 	}
 
 	/// Zips the values of all the given producers, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<B>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>) -> SignalProducer<(Value, B), Error> {
-		return SignalProducer<(Value, B), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b) { Signal.zip($0, $1).observe(observer) }
+	public static func zip<A: SignalProducerConvertible, B: SignalProducerConvertible>(_ a: A, _ b: B) -> SignalProducer<(Value, B.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer) { Signal.zip($0, $1).observe(observer) }
 		}
 	}
 
 	/// Zips the values of all the given producers, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<B, C>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>) -> SignalProducer<(Value, B, C), Error> {
-		return SignalProducer<(Value, B, C), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c) { Signal.zip($0, $1, $2).observe(observer) }
+	public static func zip<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C) -> SignalProducer<(Value, B.Value, C.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer) { Signal.zip($0, $1, $2).observe(observer) }
 		}
 	}
 
 	/// Zips the values of all the given producers, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<B, C, D>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>) -> SignalProducer<(Value, B, C, D), Error> {
-		return SignalProducer<(Value, B, C, D), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d) { Signal.zip($0, $1, $2, $3).observe(observer) }
+	public static func zip<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D) -> SignalProducer<(Value, B.Value, C.Value, D.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer) { Signal.zip($0, $1, $2, $3).observe(observer) }
 		}
 	}
 
 	/// Zips the values of all the given producers, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<B, C, D, E>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>) -> SignalProducer<(Value, B, C, D, E), Error> {
-		return SignalProducer<(Value, B, C, D, E), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e) { Signal.zip($0, $1, $2, $3, $4).observe(observer) }
+	public static func zip<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer) { Signal.zip($0, $1, $2, $3, $4).observe(observer) }
 		}
 	}
 
 	/// Zips the values of all the given producers, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<B, C, D, E, F>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>) -> SignalProducer<(Value, B, C, D, E, F), Error> {
-		return SignalProducer<(Value, B, C, D, E, F), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e, f) { Signal.zip($0, $1, $2, $3, $4, $5).observe(observer) }
+	public static func zip<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value, F.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error, F.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer, f.producer) { Signal.zip($0, $1, $2, $3, $4, $5).observe(observer) }
 		}
 	}
 
 	/// Zips the values of all the given producers, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<B, C, D, E, F, G>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>) -> SignalProducer<(Value, B, C, D, E, F, G), Error> {
-		return SignalProducer<(Value, B, C, D, E, F, G), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e, f, g) { Signal.zip($0, $1, $2, $3, $4, $5, $6).observe(observer) }
+	public static func zip<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error, F.Error == Error, G.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer) { Signal.zip($0, $1, $2, $3, $4, $5, $6).observe(observer) }
 		}
 	}
 
 	/// Zips the values of all the given producers, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<B, C, D, E, F, G, H>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>) -> SignalProducer<(Value, B, C, D, E, F, G, H), Error> {
-		return SignalProducer<(Value, B, C, D, E, F, G, H), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e, f, g, h) { Signal.zip($0, $1, $2, $3, $4, $5, $6, $7).observe(observer) }
+	public static func zip<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible, H: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error, F.Error == Error, G.Error == Error, H.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer, h.producer) { Signal.zip($0, $1, $2, $3, $4, $5, $6, $7).observe(observer) }
 		}
 	}
 
 	/// Zips the values of all the given producers, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<B, C, D, E, F, G, H, I>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>, _ i: SignalProducer<I, Error>) -> SignalProducer<(Value, B, C, D, E, F, G, H, I), Error> {
-		return SignalProducer<(Value, B, C, D, E, F, G, H, I), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e, f, g, h, i) { Signal.zip($0, $1, $2, $3, $4, $5, $6, $7, $8).observe(observer) }
+	public static func zip<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible, H: SignalProducerConvertible, I: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error, F.Error == Error, G.Error == Error, H.Error == Error, I.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer, h.producer, i.producer) { Signal.zip($0, $1, $2, $3, $4, $5, $6, $7, $8).observe(observer) }
 		}
 	}
 
 	/// Zips the values of all the given producers, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<B, C, D, E, F, G, H, I, J>(_ a: SignalProducer<Value, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>, _ i: SignalProducer<I, Error>, _ j: SignalProducer<J, Error>) -> SignalProducer<(Value, B, C, D, E, F, G, H, I, J), Error> {
-		return SignalProducer<(Value, B, C, D, E, F, G, H, I, J), Error> { observer, lifetime in
-			flattenStart(lifetime, a, b, c, d, e, f, g, h, i, j) { Signal.zip($0, $1, $2, $3, $4, $5, $6, $7, $8, $9).observe(observer) }
+	public static func zip<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible, H: SignalProducerConvertible, I: SignalProducerConvertible, J: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> SignalProducer<(Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value, J.Value), Error> where A.Value == Value, A.Error == Error, B.Error == Error, C.Error == Error, D.Error == Error, E.Error == Error, F.Error == Error, G.Error == Error, H.Error == Error, I.Error == Error, J.Error == Error {
+		return .init { observer, lifetime in
+			flattenStart(lifetime, a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer, h.producer, i.producer, j.producer) { Signal.zip($0, $1, $2, $3, $4, $5, $6, $7, $8, $9).observe(observer) }
 		}
 	}
 
 	/// Zips the values of all the given producers, in the manner described by
 	/// `zipWith`. Will return an empty `SignalProducer` if the sequence is empty.
-	public static func zip<S: Sequence>(_ producers: S) -> SignalProducer<[Value], Error> where S.Iterator.Element == SignalProducer<Value, Error> {
+	public static func zip<S: Sequence>(_ producers: S) -> SignalProducer<[Value], Error> where S.Iterator.Element: SignalProducerConvertible, S.Iterator.Element.Value == Value, S.Iterator.Element.Error == Error {
 		return start(producers, Signal.zip)
 	}
 
-	private static func start<S: Sequence>(_ producers: S, _ transform: @escaping (ReversedRandomAccessCollection<[Signal<Value, Error>]>) -> Signal<[Value], Error>) -> SignalProducer<[Value], Error> where S.Iterator.Element == SignalProducer<Value, Error> {
+	private static func start<S: Sequence>(_ producers: S, _ transform: @escaping (ReversedRandomAccessCollection<[Signal<Value, Error>]>) -> Signal<[Value], Error>) -> SignalProducer<[Value], Error> where S.Iterator.Element: SignalProducerConvertible, S.Iterator.Element.Value == Value, S.Iterator.Element.Error == Error {
 		return SignalProducer<[Value], Error> { observer, lifetime in
 			var producers = Array(producers)
 			var signals: [Signal<Value, Error>] = []
@@ -1789,7 +1647,7 @@ extension SignalProducer {
 					return
 				}
 
-				producers.removeLast().startWithSignal { signal, interruptHandle in
+				producers.removeLast().producer.startWithSignal { signal, interruptHandle in
 					lifetime.observeEnded(interruptHandle.dispose)
 					signals.append(signal)
 
@@ -2156,44 +2014,22 @@ extension SignalProducer where Value == Bool {
 	/// and `producer`.
 	///
 	/// - parameters:
-	///   - producer: Producer to be combined with `self`.
+	///   - booleans: A producer of booleans to be combined with `self`.
 	///
 	/// - returns: A producer that emits the logical AND results.
-	public func and(_ producer: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
-		return self.liftLeft(Signal.and)(producer)
+	public func and<Booleans: SignalProducerConvertible>(_ booleans: Booleans) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error {
+		return self.liftLeft(Signal.and)(booleans.producer)
 	}
-	
-	/// Create a producer that computes a logical AND between the latest values of `self`
-	/// and `signal`.
-	///
-	/// - parameters:
-	///   - signal: Signal to be combined with `self`.
-	///
-	/// - returns: A producer that emits the logical AND results.
-	public func and(_ signal: Signal<Value, Error>) -> SignalProducer<Value, Error> {
-		return self.lift(Signal.and)(signal)
-	}
-	
+
 	/// Create a producer that computes a logical OR between the latest values of `self`
 	/// and `producer`.
 	///
 	/// - parameters:
-	///   - producer: Producer to be combined with `self`.
+	///   - booleans: A producer of booleans to be combined with `self`.
 	///
 	/// - returns: A producer that emits the logical OR results.
-	public func or(_ producer: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
-		return self.liftLeft(Signal.or)(producer)
-	}
-	
-	/// Create a producer that computes a logical OR between the latest values of `self`
-	/// and `signal`.
-	///
-	/// - parameters:
-	///   - signal: Signal to be combined with `self`.
-	///
-	/// - returns: A producer that emits the logical OR results.
-	public func or(_ signal: Signal<Value, Error>) -> SignalProducer<Value, Error> {
-		return self.lift(Signal.or)(signal)
+	public func or<Booleans: SignalProducerConvertible>(_ booleans: Booleans) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error {
+		return self.liftLeft(Signal.or)(booleans.producer)
 	}
 }
 

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -11,20 +11,13 @@ precedencegroup BindingPrecedence {
 
 infix operator <~ : BindingPrecedence
 
+// FIXME: Swift 4 - associated type arbitrary requirements
+// public protocol BindingSource: SignalProducerConvertible where Error == NoError {}
+
 /// Describes a source which can be bound.
-public protocol BindingSource {
-	associatedtype Value
-	associatedtype Error: Swift.Error
+public protocol BindingSource: SignalProducerConvertible {}
 
-	var producer: SignalProducer<Value, Error> { get }
-}
-
-extension Signal: BindingSource {
-	public var producer: SignalProducer<Value, Error> {
-		return SignalProducer(self)
-	}
-}
-
+extension Signal: BindingSource {}
 extension SignalProducer: BindingSource {}
 
 /// Describes an entity which be bond towards.

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -12,7 +12,7 @@ import Quick
 import ReactiveSwift
 import Dispatch
 
-private extension SignalProtocol {
+private extension Signal {
 	typealias Pipe = (output: Signal<Value, Error>, input: Signal<Value, Error>.Observer)
 }
 

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -753,7 +753,7 @@ class SignalProducerSpec: QuickSpec {
 						}
 					}
 
-					let producer = baseProducer.lift(transform)(otherSignal)
+					let producer = baseProducer.lift(transform)(SignalProducer(otherSignal))
 					expect(counter) == 0
 
 					producer.start()
@@ -775,7 +775,7 @@ class SignalProducerSpec: QuickSpec {
 						}
 					}
 
-					let producer = baseProducer.lift(transform)(otherSignal)
+					let producer = baseProducer.lift(transform)(SignalProducer(otherSignal))
 					var result: [Int] = []
 					var completed: Bool = false
 


### PR DESCRIPTION
Implements #349.

Introduce `SignalProducerConvertible` so that n-ary producer operators may take any entity which is declared to be expressible by a `SignalProducer`.