### PR TITLE
Tweak unidirectional binding protocols.

### DIFF
--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -30,19 +30,6 @@ public protocol PropertyProtocol: class, BindingSource {
 	var signal: Signal<Value, NoError> { get }
 }
 
-extension PropertyProtocol {
-	/// Observe the property by sending all of future value changes to the
-	/// given `observer` during the given `lifetime`.
-	///
-	/// - parameters:
-	///   - observer: An observer to send the events to.
-	///   - lifetime: A lifetime of the observing object.
-	@discardableResult
-	public func observe(_ observer: Observer<Value, NoError>, during lifetime: Lifetime) -> Disposable? {
-		return producer.observe(observer, during: lifetime)
-	}
-}
-
 /// Represents an observable property that can be mutated directly.
 public protocol MutablePropertyProtocol: PropertyProtocol, BindingTargetProvider {
 	/// The current value of the property.


### PR DESCRIPTION
1. Replace the `observe(_:during:)` requirement in the `BindingSource` protocol with a `SignalProducer` representation.

   If #351 is accepted, `BindingSource` would adopt arbitrary constraint on associated types and conditional conformances in Swift 4:
    ```swift
    public protocol BindingSource: SignalProducerRepresentable where Error == NoError {}
    extension SignalProducer: BindingSource where Error == NoError {}
    // ... etc.
    ```

   While this is breaking, `observe(_:during:)` is not expected to be publicly used.

1. Move `<~` into `BindingTargetProvider`.

   The `SignalProducer` representation and the `BindingTarget` are sufficient points of customisation, and apparently there would not be an alternative semantic of `<~` to override for in the context of these two protocols.