### PR TITLE
Remove `CompositeDisposable.DisposableHandle`.

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -8,6 +8,16 @@ extension ComposableMutablePropertyProtocol {
 	public func withValue<Result>(action: (Value) throws -> Result) rethrows -> Result { fatalError() }
 }
 
+extension CompositeDisposable {
+	@available(*, deprecated, message:"Use `Disposable?` instead. The typealias would be removed in a future release.")
+	public typealias DisposableHandle = Disposable?
+}
+
+extension Optional where Wrapped == Disposable {
+	@available(*, unavailable, renamed:"dispose")
+	public func remove() { fatalError() }
+}
+
 @available(*, unavailable, renamed:"SignalProducer.timer")
 public func timer(interval: DispatchTimeInterval, on scheduler: DateScheduler) -> SignalProducer<Date, NoError> { fatalError() }
 
@@ -239,7 +249,7 @@ extension Bag {
 
 extension CompositeDisposable {
 	@available(*, unavailable, renamed:"add(_:)")
-	public func addDisposable(_ d: Disposable) -> DisposableHandle { fatalError() }
+	public func addDisposable(_ d: Disposable) -> Disposable? { fatalError() }
 }
 
 extension Observer {

--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -170,18 +170,18 @@ public final class CompositeDisposable: Disposable {
 	///            `disposable` is `nil`.
 	@discardableResult
 	public func add(_ disposable: Disposable?) -> Disposable? {
-		if isDisposed {
+		guard let d = disposable, !d.isDisposed, !isDisposed else {
 			disposable?.dispose()
 			return nil
 		}
 
-		return disposable.flatMap { disposable in
-			return disposables.modify { disposables in
-				let token = disposables!.insert(disposable)
-				return ActionDisposable { [weak self] in
-					self?.disposables.modify {
-						$0?.remove(using: token)
-					}
+		return disposables.modify { disposables in
+			guard disposables != nil else { return nil }
+
+			let token = disposables!.insert(d)
+			return ActionDisposable { [weak self] in
+				self?.disposables.modify {
+					$0?.remove(using: token)
 				}
 			}
 		}

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -452,7 +452,7 @@ extension Signal where Value: SignalProducerProtocol, Error == Value.Error {
 					signal.observe { event in
 						switch event {
 						case .completed, .interrupted:
-							handle.remove()
+							handle?.dispose()
 
 							let shouldComplete: Bool = state.modify { state in
 								state.activeCount -= 1
@@ -839,7 +839,7 @@ extension Signal where Value: SignalProducerProtocol, Error == Value.Error {
 
 						// Dispose all running innerSignals except winning one.
 						if !relayDisposable.isDisposed {
-							disposableHandle.remove()
+							disposableHandle?.dispose()
 							relayDisposable.dispose()
 						}
 

--- a/Tests/ReactiveSwiftTests/DisposableSpec.swift
+++ b/Tests/ReactiveSwiftTests/DisposableSpec.swift
@@ -74,8 +74,8 @@ class DisposableSpec: QuickSpec {
 				let handle = disposable += simpleDisposable
 
 				// We should be allowed to call this any number of times.
-				handle.remove()
-				handle.remove()
+				handle?.dispose()
+				handle?.dispose()
 				expect(simpleDisposable.isDisposed) == false
 
 				disposable.dispose()


### PR DESCRIPTION
Cherry-picked from #334.

Use `ActionDisposable` instead, akin to `Signal.observe`.