### PR TITLE
Documentation: Add note about observe() side effects in SignalProducer

### DIFF
--- a/Documentation/FrameworkOverview.md
+++ b/Documentation/FrameworkOverview.md
@@ -79,7 +79,7 @@ A **signal producer**, represented by the [`SignalProducer`][SignalProducer] typ
 [signals](#signals) and performs side effects.
 
 They can be used to represent operations or tasks, like network
-requests, where each invocation of `start()` will create a new underlying
+requests, where each invocation of `start()` or `observe()` will create a new underlying
 operation, and allow the caller to observe the result(s). The
 `startWithSignal()` variant gives access to the produced signal, allowing it to
 be observed multiple times if desired.
@@ -88,7 +88,9 @@ Because of the behavior of `start()`, each signal created from the same
 producer may see a different ordering or version of events, or the stream might
 even be completely different! Unlike a plain signal, no work is started (and
 thus no events are generated) until an observer is attached, and the work is
-restarted anew for each additional observer.
+restarted anew for each additional observer. (This means that, unlike for `Signal`,
+calling `observe(_:during:)` may generate side effects, since the underlying
+operation is created and run immediately.)
 
 Starting a signal producer returns a [disposable](#disposables) that can be used to
 interrupt/cancel the work associated with the produced signal.


### PR DESCRIPTION
This tripped me up (as a reactive newbie), leading to a rather confused debugging session: I hadn't realised that `observe()` on a SignalProducer triggers the underlying operation (with all side effects).

I see renaming `observe()` has been discussed in #204 and #178 so I presume that's not an option. If it were, my vote would be to rename `SignalProducer.observe()` to something like `SignalProducer.start(with:during:)` to emphasise the side-effecty similarity with plain `start()`. But without a rename, I think it's at least useful to make this a little more prominent in the docs.