### PR TITLE
Add more general timeout() operator to send any event

### DIFF
--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1365,6 +1365,31 @@ extension SignalProducer {
 	public func timeout(after interval: TimeInterval, raising error: Error, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
 		return lift { $0.timeout(after: interval, raising: error, on: scheduler) }
 	}
+
+	/// Forward events from `self` until `interval`. Then if producer isn't
+	/// completed yet, sends `event` and terminates.
+	///
+	/// - note: If `event` is a value, the returned producer will automatically
+	///         complete after sending it.
+	///
+	/// - note: If the interval is 0, the timeout will be scheduled immediately.
+	///         The signal must complete synchronously (or on a faster
+	///         scheduler) to avoid the timeout.
+	///
+	/// - precondition: `interval` must be non-negative number.
+	///
+	/// - parameters:
+	///   - event: An event to terminate with if `self` is not completed
+	///            when `interval` passes.
+	///   - interval: Number of seconds to wait for `self` to complete.
+	///   - scheduler: A scheduler to deliver error on.
+	///
+	/// - returns: A signal that sends events for at most `interval` seconds,
+	///            then, if not `completed` - sends `error` with failed event
+	///            on `scheduler`.
+	public func timeout(after interval: TimeInterval, sending event: ProducedSignal.Event, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
+		return lift { $0.timeout(after: interval, sending: event, on: scheduler) }
+	}
 }
 
 extension SignalProducer where Value: OptionalProtocol {
@@ -1414,7 +1439,7 @@ extension SignalProducer where Error == NoError {
 	///   - interval: Number of seconds to wait for `self` to complete.
 	///   - error: Error to send with `failed` event if `self` is not completed
 	///            when `interval` passes.
-	///   - scheudler: A scheduler to deliver error on.
+	///   - scheduler: A scheduler to deliver error on.
 	///
 	/// - returns: A producer that sends events for at most `interval` seconds,
 	///            then, if not `completed` - sends `error` with `failed` event
@@ -1425,6 +1450,35 @@ extension SignalProducer where Error == NoError {
 		on scheduler: DateScheduler
 	) -> SignalProducer<Value, NewError> {
 		return lift { $0.timeout(after: interval, raising: error, on: scheduler) }
+	}
+
+	/// Forward events from `self` until `interval`. Then if producer isn't
+	/// completed yet, sends `event` and terminates.
+	///
+	/// - note: If `event` is a value, the returned producer will automatically
+	///         complete after sending it.
+	///
+	/// - note: If the interval is 0, the timeout will be scheduled immediately.
+	///         The signal must complete synchronously (or on a faster
+	///         scheduler) to avoid the timeout.
+	///
+	/// - precondition: `interval` must be non-negative number.
+	///
+	/// - parameters:
+	///   - event: An event to terminate with if `self` is not completed
+	///            when `interval` passes.
+	///   - interval: Number of seconds to wait for `self` to complete.
+	///   - scheduler: A scheduler to deliver error on.
+	///
+	/// - returns: A signal that sends events for at most `interval` seconds,
+	///            then, if not `completed` - sends `error` with failed event
+	///            on `scheduler`.
+	public func timeout<NewError: Swift.Error>(
+		after interval: TimeInterval,
+		sending event: SignalProducer<Value, NewError>.ProducedSignal.Event,
+		on scheduler: DateScheduler
+	) -> SignalProducer<Value, NewError> {
+		return lift { $0.timeout(after: interval, sending: event, on: scheduler) }
 	}
 
 	/// Apply a throwable action to every value from `self`, and forward the values

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -18,6 +18,7 @@ import Result
 /// different!
 public struct SignalProducer<Value, Error: Swift.Error> {
 	public typealias ProducedSignal = Signal<Value, Error>
+	public typealias Event = ProducedSignal.Event
 
 	private let startHandler: (Signal<Value, Error>.Observer, Lifetime) -> Void
 
@@ -860,7 +861,7 @@ extension SignalProducer {
 	///         send the `Event` itself and then interrupt.
 	///
 	/// - returns: A producer that sends events as its values.
-	public func materialize() -> SignalProducer<ProducedSignal.Event, NoError> {
+	public func materialize() -> SignalProducer<Event, NoError> {
 		return lift { $0.materialize() }
 	}
 
@@ -1387,7 +1388,7 @@ extension SignalProducer {
 	/// - returns: A signal that sends events for at most `interval` seconds,
 	///            then, if not `completed` - sends `error` with failed event
 	///            on `scheduler`.
-	public func timeout(after interval: TimeInterval, sending event: ProducedSignal.Event, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
+	public func timeout(after interval: TimeInterval, sending event: Event, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
 		return lift { $0.timeout(after: interval, sending: event, on: scheduler) }
 	}
 }
@@ -1475,7 +1476,7 @@ extension SignalProducer where Error == NoError {
 	///            on `scheduler`.
 	public func timeout<NewError: Swift.Error>(
 		after interval: TimeInterval,
-		sending event: SignalProducer<Value, NewError>.ProducedSignal.Event,
+		sending event: SignalProducer<Value, NewError>.Event,
 		on scheduler: DateScheduler
 	) -> SignalProducer<Value, NewError> {
 		return lift { $0.timeout(after: interval, sending: event, on: scheduler) }
@@ -1599,7 +1600,7 @@ extension SignalProducer {
 	public func on(
 		starting: (() -> Void)? = nil,
 		started: (() -> Void)? = nil,
-		event: ((ProducedSignal.Event) -> Void)? = nil,
+		event: ((Event) -> Void)? = nil,
 		failed: ((Error) -> Void)? = nil,
 		completed: (() -> Void)? = nil,
 		interrupted: (() -> Void)? = nil,


### PR DESCRIPTION
This came out of a discussion in Slack, and seemed like a useful addition.

This more general implementation of `timeout()` allows any kind of event to be sent, not just errors. For backwards compatibility, the existing `timeout(after:raising:on:)` operator now calls through to the new implementation.