### PR TITLE
Enable `Action` executing state feedback to the state property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 *Please add new entries at the top.*
+1. Feedbacks from `isExecuting` to the state of the same `Action`, including all `enabledIf` convenience initializers, no longer deadlocks. (#400, kudos to @andersio)
 
 # 1.1.3
 ## Deprecation

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -18,11 +18,21 @@ import Result
 ///
 /// `Action` enforces serial execution, and disables the `Action` during the execution.
 public final class Action<Input, Output, Error: Swift.Error> {
-	private let deinitToken: Lifetime.Token
+	private struct ActionState<Value> {
+		var isEnabled: Bool {
+			return isUserEnabled && !isExecuting
+		}
 
-	private let executeClosure: (_ state: Any, _ input: Input) -> SignalProducer<Output, Error>
+		var isUserEnabled: Bool
+		var isExecuting: Bool
+		var value: Value
+	}
+
+	private let execute: (Action<Input, Output, Error>, Input) -> SignalProducer<Output, ActionError<Error>>
 	private let eventsObserver: Signal<Signal<Output, Error>.Event, NoError>.Observer
 	private let disabledErrorsObserver: Signal<(), NoError>.Observer
+
+	private let deinitToken: Lifetime.Token
 
 	/// The lifetime of the `Action`.
 	public let lifetime: Lifetime
@@ -60,8 +70,6 @@ public final class Action<Input, Output, Error: Swift.Error> {
 	/// Whether the action is currently enabled.
 	public let isEnabled: Property<Bool>
 
-	private let state: MutableProperty<ActionState>
-
 	/// Initializes an `Action` that would be conditionally enabled depending on its
 	/// state.
 	///
@@ -80,39 +88,78 @@ public final class Action<Input, Output, Error: Swift.Error> {
 	///
 	/// - parameters:
 	///   - state: A property to be the state of the `Action`.
-	///   - enabledIf: A predicate which determines the availability of the `Action`,
+	///   - isEnabled: A predicate which determines the availability of the `Action`,
 	///                given the latest `Action` state.
 	///   - execute: A closure that produces a unit of work, as `SignalProducer`, to be
 	///              executed by the `Action`.
-	public init<State: PropertyProtocol>(state property: State, enabledIf isEnabled: @escaping (State.Value) -> Bool, execute: @escaping (State.Value, Input) -> SignalProducer<Output, Error>) {
+	public init<State: PropertyProtocol>(state: State, enabledIf isEnabled: @escaping (State.Value) -> Bool, execute: @escaping (State.Value, Input) -> SignalProducer<Output, Error>) {
+		let isUserEnabled = isEnabled
+
 		deinitToken = Lifetime.Token()
 		lifetime = Lifetime(deinitToken)
-		
-		// Retain the `property` for the created `Action`.
-		lifetime.observeEnded { _ = property }
 
-		executeClosure = { state, input in execute(state as! State.Value, input) }
+		// `isExecuting` has its own `Signal`, so that legitimate feedbacks would
+		// not deadlock.
+		let actionState = MutableProperty(ActionState<State.Value>(isUserEnabled: true, isExecuting: false, value: state.value))
+		self.isEnabled = actionState.map { $0.isEnabled }
+
+		let isExecuting = MutableProperty(false)
+		self.isExecuting = Property(capturing: isExecuting)
+
+		// Associate the state property with the created `Action`.
+		lifetime.observeEnded { _ = state }
 
 		(events, eventsObserver) = Signal<Signal<Output, Error>.Event, NoError>.pipe()
 		(disabledErrors, disabledErrorsObserver) = Signal<(), NoError>.pipe()
 
 		values = events.filterMap { $0.value }
 		errors = events.filterMap { $0.error }
-		completed = events.filter { $0.isCompleted }.map { _ in }
+		completed = events.filterMap { $0.isCompleted ? () : nil }
 
-		let initial = ActionState(value: property.value, isEnabled: { isEnabled($0 as! State.Value) })
-		state = MutableProperty(initial)
+		let disposable = state.producer.startWithValues { value in
+			actionState.modify { state in
+				state.value = value
+				state.isUserEnabled = isUserEnabled(value)
+			}
+		}
 
-		property.signal
-			.take(during: state.lifetime)
-			.observeValues { [weak state] newValue in
-				state?.modify {
-					$0.value = newValue
+		lifetime.observeEnded(disposable.dispose)
+
+		self.execute = { action, input in
+			return SignalProducer { observer, lifetime in
+				func tryStart() -> State.Value? {
+					return actionState.modify { state in
+						guard state.isEnabled else {
+							return nil
+						}
+
+						state.isExecuting = true
+						isExecuting.value = true
+						return state.value
+					}
+				}
+
+				guard let state = tryStart() else {
+					observer.send(error: .disabled)
+					action.disabledErrorsObserver.send(value: ())
+					return
+				}
+
+				let interruptHandle = execute(state, input).start { event in
+					observer.action(event.mapError(ActionError.producerFailed))
+					action.eventsObserver.send(value: event)
+				}
+
+				lifetime.observeEnded {
+					interruptHandle.dispose()
+
+					actionState.modify { state in
+						state.isExecuting = false
+						isExecuting.value = false
+					}
 				}
 			}
-
-		self.isEnabled = state.map { $0.isEnabled }.skipRepeats()
-		self.isExecuting = state.map { $0.isExecuting }.skipRepeats()
+		}
 	}
 
 	/// Initializes an `Action` that would be conditionally enabled.
@@ -122,11 +169,11 @@ public final class Action<Input, Output, Error: Swift.Error> {
 	/// `execute` with the input value.
 	///
 	/// - parameters:
-	///   - enabledIf: A property which determines the availability of the `Action`.
+	///   - isEnabled: A property which determines the availability of the `Action`.
 	///   - execute: A closure that produces a unit of work, as `SignalProducer`, to be
 	///              executed by the `Action`.
-	public convenience init<P: PropertyProtocol>(enabledIf property: P, execute: @escaping (Input) -> SignalProducer<Output, Error>) where P.Value == Bool {
-		self.init(state: property, enabledIf: { $0 }) { _, input in
+	public convenience init<P: PropertyProtocol>(enabledIf isEnabled: P, execute: @escaping (Input) -> SignalProducer<Output, Error>) where P.Value == Bool {
+		self.init(state: isEnabled, enabledIf: { $0 }) { _, input in
 			execute(input)
 		}
 	}
@@ -162,62 +209,7 @@ public final class Action<Input, Output, Error: Swift.Error> {
 	/// - returns: A producer that forwards events generated by its started unit of work,
 	///            or emits `ActionError.disabled` if the execution attempt is failed.
 	public func apply(_ input: Input) -> SignalProducer<Output, ActionError<Error>> {
-		return SignalProducer { observer, lifetime in
-			let startingState = self.state.modify { state -> Any? in
-				if state.isEnabled {
-					state.isExecuting = true
-					return state.value
-				} else {
-					return nil
-				}
-			}
-
-			guard let state = startingState else {
-				observer.send(error: .disabled)
-				self.disabledErrorsObserver.send(value: ())
-				return
-			}
-
-			self.executeClosure(state, input).startWithSignal { signal, signalDisposable in
-				lifetime.observeEnded(signalDisposable.dispose)
-
-				signal.observe { event in
-					observer.action(event.mapError(ActionError.producerFailed))
-					self.eventsObserver.send(value: event)
-				}
-			}
-
-			lifetime.observeEnded {
-				self.state.modify {
-					$0.isExecuting = false
-				}
-			}
-		}
-	}
-}
-
-private struct ActionState {
-	var isExecuting: Bool = false
-
-	var value: Any {
-		didSet {
-			userEnabled = userEnabledClosure(value)
-		}
-	}
-
-	private var userEnabled: Bool
-	private let userEnabledClosure: (Any) -> Bool
-
-	init(value: Any, isEnabled: @escaping (Any) -> Bool) {
-		self.value = value
-		self.userEnabled = isEnabled(value)
-		self.userEnabledClosure = isEnabled
-	}
-
-	/// Whether the action should be enabled for the given combination of user
-	/// enabledness and executing status.
-	fileprivate var isEnabled: Bool {
-		return userEnabled && !isExecuting
+		return execute(self, input)
 	}
 }
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -673,6 +673,22 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 		}
 	}
 
+	/// Atomically modifies the variable.
+	///
+	/// - parameters:
+	///   - didSet: A closure that is invoked after `action` returns and the value is
+	///             committed to the storage, but before `modify` releases the lock.
+	///   - action: A closure that accepts old property value and returns a new
+	///             property value.
+	///
+	/// - returns: The result of the action.
+	@discardableResult
+	internal func modify<Result>(didSet: () -> Void, _ action: (inout Value) throws -> Result) rethrows -> Result {
+		return try box.modify(didSet: { self.observer.send(value: $0); didSet() }) { value in
+			return try action(&value)
+		}
+	}
+
 	/// Atomically performs an arbitrary action using the current value of the
 	/// variable.
 	///


### PR DESCRIPTION
Related: #309.

There are legitimate uses of `isExecuting` feedback to the `Action` state property. For example, we may link the availability of multiple actions together, so that all disables when one executes.

This PR refactors the internal of `Action` so that such use cases are permitted. Legitimate infinite feedback loops would still result in deadlocks.

Example:
```swift
let isIdle = MutableProperty(true)

candyCrusher = Action(enabledIf: isIdle) { ... }
fruitCrusher = Action(enabledIf: isIdle) { ... }
carrotCrusher = Action(enabledIf: isIdle) { ... }

isIdle <~ candyCrusher.isExecuting.negate()
isIdle <~ fruitCrusher.isExecuting.negate()
isIdle <~ carrotCrusher.isExecuting.negate()
```

### Alternative/Follow-up
Could we have some kind of "action group"s that determine the availability at a coarser granularity?