### PR TITLE
Signal resource management with `Lifetime`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,23 @@
 # master
 *Please add new entries at the top.*
 
-1. `SignalProducer.startWithSignal` now returns the value of the setup closure.
+1. `Signal` now uses `Lifetime` for resource management. (#404, kudos to @andersio)
+
+   The `Signal` initialzer now accepts a generator closure that is passed with the input `Observer` and the `Lifetime` as its arguments. The original variant accepting a single-argument generator closure is now obselete. This is a source breaking change.
+   
+   ```swift
+   // New: Add `Disposable`s to the `Lifetime`.
+   let candies = Signal<U, E> { (observer: Signal<U, E>.Observer, lifetime: Lifetime) in
+      lifetime += trickOrTreat.observe(observer)
+   }
+   
+   // Obsolete: Returning a `Disposable`.
+   let candies = Signal { (observer: Signal<U, E>.Observer) -> Disposable? in
+      return trickOrTreat.observe(observer)
+   }
+   ```
+
+1. `SignalProducer.startWithSignal` now returns the value of the setup closure. (#533, kudos to @Burgestrand)
 
 # 2.1.0-alpha.2
 1. Disabled code coverage data to allow app submissions with Xcode 9.0 (see https://github.com/Carthage/Carthage/issues/2056, kudos to @NachoSoto)

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -11,6 +11,9 @@ extension AnyDisposable {
 extension Signal {
 	@available(*, unavailable, renamed:"promoteError")
 	public func promoteErrors<F>(_: F.Type) -> Signal<Value, F> { fatalError() }
+
+	@available(*, unavailable, message:"Use the `Signal.init` that accepts a two-argument generator.")
+	public convenience init(_ generator: (Observer) -> Disposable?) { fatalError() }
 }
 
 extension SignalProducer {

--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -30,12 +30,12 @@ extension Reactive where Base: NotificationCenter {
 	/// - note: The signal does not terminate naturally. Observers must be
 	///         explicitly disposed to avoid leaks.
 	public func notifications(forName name: Notification.Name?, object: AnyObject? = nil) -> Signal<Notification, NoError> {
-		return Signal { [base = self.base] observer in
+		return Signal { [base = self.base] observer, lifetime in
 			let notificationObserver = base.addObserver(forName: name, object: object, queue: nil) { notification in
 				observer.send(value: notification)
 			}
 
-			return AnyDisposable {
+			lifetime.observeEnded {
 				base.removeObserver(notificationObserver)
 			}
 		}

--- a/Sources/Lifetime.swift
+++ b/Sources/Lifetime.swift
@@ -11,8 +11,9 @@ public final class Lifetime {
 	/// - note: Consider using `Lifetime.observeEnded` if only a closure observer
 	///         is to be attached.
 	public var ended: Signal<Never, NoError> {
-		return Signal { observer in
-			return disposables += observer.sendCompleted
+		return Signal { observer, lifetime in
+			let disposable = (disposables += observer.sendCompleted)
+			_ = (disposable?.dispose).map(lifetime.observeEnded)
 		}
 	}
 

--- a/Sources/Lifetime.swift
+++ b/Sources/Lifetime.swift
@@ -12,8 +12,7 @@ public final class Lifetime {
 	///         is to be attached.
 	public var ended: Signal<Never, NoError> {
 		return Signal { observer, lifetime in
-			let disposable = (disposables += observer.sendCompleted)
-			_ = (disposable?.dispose).map(lifetime.observeEnded)
+			lifetime += (disposables += observer.sendCompleted)
 		}
 	}
 
@@ -64,7 +63,8 @@ public final class Lifetime {
 	///            if `lifetime` has already ended.
 	@discardableResult
 	public static func += (lifetime: Lifetime, disposable: Disposable?) -> Disposable? {
-		return (disposable?.dispose).flatMap(lifetime.observeEnded)
+		guard let dispose = disposable?.dispose else { return nil }
+		return lifetime.observeEnded(dispose)
 	}
 }
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -543,6 +543,7 @@ public final class Property<Value>: PropertyProtocol {
 			// A composed property tracks its active consumers through its relay signal, and
 			// interrupts `unsafeProducer` if the relay signal terminates.
 			let (signal, _observer) = Signal<Value, NoError>.pipe(disposable: interruptHandle)
+
 			let observer = transform?(_observer) ?? _observer
 			relay = signal
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -339,8 +339,8 @@ private final class TransformerCore<Value, Error: Swift.Error, SourceValue, Sour
 
 	internal override func makeInstance() -> Instance {
 		let product = source.makeInstance()
-		let signal = Signal<Value, Error> { observer in
-			return product.signal.observe(Signal.Observer(observer, transform))
+		let signal = Signal<Value, Error> { observer, lifetime in
+			lifetime += product.signal.observe(Signal.Observer(observer, transform))
 		}
 
 		return Instance(signal: signal,

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -1629,6 +1629,10 @@ class PropertySpec: QuickSpec {
 					var isDisposed = false
 
 					var outerObserver: Signal<String, NoError>.Observer!
+
+					// Mitigate the "was written to, but never read" warning.
+					_ = outerObserver
+
 					var signal: Signal<String, NoError>? = {
 						let (signal, observer) = Signal<String, NoError>.pipe()
 						outerObserver = observer

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -1433,6 +1433,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var samplerObserver: Signal<(), NoError>.Observer!
 				var observer: Signal<Payload, NoError>.Observer!
 
+				// Mitigate the "was written to, but never read" warning.
+				_ = samplerObserver
+
 				beforeEach {
 					let (producer, incomingObserver) = SignalProducer<Payload, NoError>.pipe()
 					let (sampler, _samplerObserver) = Signal<(), NoError>.pipe()


### PR DESCRIPTION
Follow-up to #334.

This is not as trivially migratable as #334, since `Signal` had a different design choice in the signal generator closure than the `SignalProducer`. Let alone the fact that [SE-0110](https://github.com/apple/swift-evolution/blob/master/proposals/0110-distingish-single-tuple-arg.md) is not implemented in Swift 3, adding obstacles to automatic migration.

1. Change the `Signal` generator signature to `(Observer, Lifetime) -> Void`, so that it matches the style of `SignalProducer.init`.
   ```swift
   let signal = Signal { observer, lifetime in
      let disposable = self.observe { ... }
      _ = (disposable?.dispose).map(lifetime.observeEnded)
   }

   let producer = SignalProducer { observer, lifetime in
      let disposable = producer.start { ... }
      lifetime.observeEnded(disposable.dispose)
   }
   ```
