### PR TITLE
Rename `promoteErrors` to `promoteError`.

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -3,6 +3,16 @@ import Dispatch
 import Result
 
 // MARK: Unavailable methods in ReactiveSwift 2.0.
+extension Signal {
+	@available(*, unavailable, renamed:"promoteError")
+	public func promoteErrors<F: Swift.Error>(_: F.Type) -> Signal<Value, F> { fatalError() }
+}
+
+extension SignalProducer {
+	@available(*, unavailable, renamed:"promoteError")
+	public func promoteErrors<F: Swift.Error>(_: F.Type) -> SignalProducer<Value, F> { fatalError() }
+}
+
 extension Lifetime {
 	@available(*, unavailable, renamed:"hasEnded")
 	public var isDisposed: Bool { fatalError() }

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -109,7 +109,7 @@ extension Signal where Value: SignalProducerProtocol, Error == NoError {
 	///	  - strategy: Strategy used when flattening signals.
 	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Value, Value.Error> {
 		return self
-			.promoteErrors(Value.Error.self)
+			.promoteError(Value.Error.self)
 			.flatten(strategy)
 	}
 }
@@ -150,7 +150,7 @@ extension Signal where Value: SignalProducerProtocol, Value.Error == NoError {
 	/// - parameters:
 	///   - strategy: Strategy used when flattening signals.
 	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Value, Error> {
-		return self.flatMap(strategy) { $0.producer.promoteErrors(Error.self) }
+		return self.flatMap(strategy) { $0.producer.promoteError(Error.self) }
 	}
 }
 
@@ -194,7 +194,7 @@ extension SignalProducer where Value: SignalProducerProtocol, Error == NoError {
 	///   - strategy: Strategy used when flattening signals.
 	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Value, Value.Error> {
 		return self
-			.promoteErrors(Value.Error.self)
+			.promoteError(Value.Error.self)
 			.flatten(strategy)
 	}
 }
@@ -235,7 +235,7 @@ extension SignalProducer where Value: SignalProducerProtocol, Value.Error == NoE
 	/// - parameters:
 	///   - strategy: Strategy used when flattening signals.
 	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Value, Error> {
-		return self.flatMap(strategy) { $0.producer.promoteErrors(Error.self) }
+		return self.flatMap(strategy) { $0.producer.promoteError(Error.self) }
 	}
 }
 
@@ -272,7 +272,7 @@ extension Signal where Value: SignalProtocol, Error == NoError {
 	///   - strategy: Strategy used when flattening signals.
 	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Value, Value.Error> {
 		return self
-			.promoteErrors(Value.Error.self)
+			.promoteError(Value.Error.self)
 			.flatten(strategy)
 	}
 }
@@ -306,7 +306,7 @@ extension Signal where Value: SignalProtocol, Value.Error == NoError {
 	/// - parameters:
 	///   - strategy: Strategy used when flattening signals.
 	public func flatten(_ strategy: FlattenStrategy) -> Signal<Value.Value, Error> {
-		return self.flatMap(strategy) { $0.signal.promoteErrors(Error.self) }
+		return self.flatMap(strategy) { $0.signal.promoteError(Error.self) }
 	}
 }
 
@@ -350,7 +350,7 @@ extension SignalProducer where Value: SignalProtocol, Error == NoError {
 	///   - strategy: Strategy used when flattening signals.
 	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Value, Value.Error> {
 		return self
-			.promoteErrors(Value.Error.self)
+			.promoteError(Value.Error.self)
 			.flatten(strategy)
 	}
 }
@@ -384,7 +384,7 @@ extension SignalProducer where Value: SignalProtocol, Value.Error == NoError {
 	/// - parameters:
 	///   - strategy: Strategy used when flattening signals.
 	public func flatten(_ strategy: FlattenStrategy) -> SignalProducer<Value.Value, Error> {
-		return self.flatMap(strategy) { $0.signal.promoteErrors(Error.self) }
+		return self.flatMap(strategy) { $0.signal.promoteError(Error.self) }
 	}
 }
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -2405,7 +2405,7 @@ extension Signal where Error == NoError {
 	///   - _ An `ErrorType`.
 	///
 	/// - returns: A signal that has an instantiatable `ErrorType`.
-	public func promoteErrors<F: Swift.Error>(_: F.Type) -> Signal<Value, F> {
+	public func promoteError<F: Swift.Error>(_: F.Type) -> Signal<Value, F> {
 		return Signal<Value, F> { observer in
 			return self.observe { event in
 				switch event {
@@ -2444,7 +2444,7 @@ extension Signal where Error == NoError {
 		on scheduler: DateScheduler
 	) -> Signal<Value, NewError> {
 		return self
-			.promoteErrors(NewError.self)
+			.promoteError(NewError.self)
 			.timeout(after: interval, raising: error, on: scheduler)
 	}
 }
@@ -2539,7 +2539,7 @@ extension Signal where Error == NoError {
 	/// - returns: A signal which forwards the successful values of the given action.
 	public func attempt(_ action: @escaping (Value) throws -> Void) -> Signal<Value, AnyError> {
 		return self
-			.promoteErrors(AnyError.self)
+			.promoteError(AnyError.self)
 			.attempt(action)
 	}
 
@@ -2553,7 +2553,7 @@ extension Signal where Error == NoError {
 	/// - returns: A signal which forwards the successfully transformed values.
 	public func attemptMap<U>(_ transform: @escaping (Value) throws -> U) -> Signal<U, AnyError> {
 		return self
-			.promoteErrors(AnyError.self)
+			.promoteError(AnyError.self)
 			.attemptMap(transform)
 	}
 }

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1397,8 +1397,8 @@ extension SignalProducer where Error == NoError {
 	///   - _ An `ErrorType`.
 	///
 	/// - returns: A producer that has an instantiatable `ErrorType`.
-	public func promoteErrors<F: Swift.Error>(_: F.Type) -> SignalProducer<Value, F> {
-		return lift { $0.promoteErrors(F.self) }
+	public func promoteError<F: Swift.Error>(_: F.Type) -> SignalProducer<Value, F> {
+		return lift { $0.promoteError(F.self) }
 	}
 
 	/// Forward events from `self` until `interval`. Then if producer isn't
@@ -1871,7 +1871,7 @@ extension SignalProducer {
 	/// - returns: A producer that sends events from `self` and then from
 	///            `replacement` when `self` completes.
 	public func then<U>(_ replacement: SignalProducer<U, NoError>) -> SignalProducer<U, Error> {
-		return _then(replacement.promoteErrors(Error.self))
+		return _then(replacement.promoteError(Error.self))
 	}
 
 	/// Wait for completion of `self`, *then* forward all events from
@@ -1948,7 +1948,7 @@ extension SignalProducer where Error == NoError {
 	/// - returns: A producer that sends events from `self` and then from
 	///            `replacement` when `self` completes.
 	public func then<U, NewError: Swift.Error>(_ replacement: SignalProducer<U, NewError>) -> SignalProducer<U, NewError> {
-		return promoteErrors(NewError.self)._then(replacement)
+		return promoteError(NewError.self)._then(replacement)
 	}
 
 	// NOTE: The overload below is added to disambiguate compile-time selection of


### PR DESCRIPTION
Every `Signal` has only one error. Should it be `promote(_:)` though?