### PR TITLE
`promoteError` type inference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 *Please add new entries at the top.*
+1. `promoteError` can now infer the new error type from the context. (#xxx, kudos to @andersio)
+
 1. `promoteErrors(_:)` has been renamed to `promoteError(_:)`. (#408, kudos to @andersio)
 
 # 1.1.3

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -2405,7 +2405,7 @@ extension Signal where Error == NoError {
 	///   - _ An `ErrorType`.
 	///
 	/// - returns: A signal that has an instantiatable `ErrorType`.
-	public func promoteError<F: Swift.Error>(_: F.Type) -> Signal<Value, F> {
+	public func promoteError<F: Swift.Error>(_: F.Type = F.self) -> Signal<Value, F> {
 		return Signal<Value, F> { observer in
 			return self.observe { event in
 				switch event {
@@ -2420,6 +2420,21 @@ extension Signal where Error == NoError {
 				}
 			}
 		}
+	}
+
+	/// Promote a signal that does not generate failures into one that can.
+	///
+	/// - note: This does not actually cause failures to be generated for the
+	///         given signal, but makes it easier to combine with other signals
+	///         that may fail; for example, with operators like
+	///         `combineLatestWith`, `zipWith`, `flatten`, etc.
+	///
+	/// - parameters:
+	///   - _ An `ErrorType`.
+	///
+	/// - returns: A signal that has an instantiatable `ErrorType`.
+	public func promoteError(_: Error.Type = Error.self) -> Signal<Value, Error> {
+		return self
 	}
 
 	/// Forward events from `self` until `interval`. Then if signal isn't

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1397,8 +1397,23 @@ extension SignalProducer where Error == NoError {
 	///   - _ An `ErrorType`.
 	///
 	/// - returns: A producer that has an instantiatable `ErrorType`.
-	public func promoteError<F: Swift.Error>(_: F.Type) -> SignalProducer<Value, F> {
+	public func promoteError<F: Swift.Error>(_: F.Type = F.self) -> SignalProducer<Value, F> {
 		return lift { $0.promoteError(F.self) }
+	}
+
+	/// Promote a producer that does not generate failures into one that can.
+	///
+	/// - note: This does not actually cause failers to be generated for the
+	///         given producer, but makes it easier to combine with other
+	///         producers that may fail; for example, with operators like
+	///         `combineLatestWith`, `zipWith`, `flatten`, etc.
+	///
+	/// - parameters:
+	///   - _ An `ErrorType`.
+	///
+	/// - returns: A producer that has an instantiatable `ErrorType`.
+	public func promoteError(_: Error.Type = Error.self) -> SignalProducer<Value, Error> {
+		return self
 	}
 
 	/// Forward events from `self` until `interval`. Then if producer isn't

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -2739,6 +2739,18 @@ class SignalProducerSpec: QuickSpec {
 				observer2.sendCompleted()
 			}
 		}
+
+		describe("promoteError") {
+			it("should infer the error type from the context") {
+				let combined: Any = SignalProducer
+					.combineLatest(SignalProducer<Int, NoError>.never.promoteError(),
+					               SignalProducer<Double, TestError>.never,
+					               SignalProducer<Float, NoError>.never.promoteError(),
+					               SignalProducer<UInt, POSIXError>.never.flatMapError { _ in .empty })
+
+				expect(combined is SignalProducer<(Int, Double, Float, UInt), TestError>) == true
+			}
+		}
 	}
 }
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -3093,6 +3093,18 @@ class SignalSpec: QuickSpec {
 				observer2.sendCompleted()
 			}
 		}
+
+		describe("promoteError") {
+			it("should infer the error type from the context") {
+				let combined: Any = Signal
+					.combineLatest(Signal<Int, NoError>.never.promoteError(),
+					               Signal<Double, TestError>.never,
+					               Signal<Float, NoError>.never.promoteError(),
+					               Signal<UInt, POSIXError>.never.flatMapError { _ in .empty })
+
+				expect(combined is Signal<(Int, Double, Float, UInt), TestError>) == true
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Preceded by #408.

This is useful when combining multiple signals with `NoError` in the mix, reducing the verbosity.

```swift
let (signal, _) = Signal<(), NoError>.pipe()

print(type(of: signal.promoteError(CocoaError.self)))
print(type(of: signal.promoteError()))
print(type(of: signal.promoteError() as Signal<(), CocoaError>))

// The promotion of the second operand is inferred.
print(type(of: Signal.zip(signal.promoteError(CocoaError.self), signal.promoteError())))
```
