### PR TITLE
Precautionary `SignalProducer.never` fix.

### DIFF
--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -174,7 +174,9 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 
 	/// A producer for a Signal that never sends any events to its observers.
 	public static var never: SignalProducer {
-		return self.init { _ in return }
+		return self.init { observer, lifetime in
+			lifetime.observeEnded { _ = observer }
+		}
 	}
 
 	/// Create a `Signal` from `self`, pass it into the given closure, and start the


### PR DESCRIPTION
A "bug" that would materialise only with #140.

As the signal semantic of 2.0 requires the generator/input observer to be retained, the lifetime of `SignalProducer.never` should have retained its input observer.

#### Checklist
- ~~Updated CHANGELOG.md.~~