### PR TITLE
Enforce exclusivity of access in `PropertyBox`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # master
 *Please add new entries at the top.*
 
+1. `MutableProperty` now enforces exclusivity of access. (#419, kudos to @andersio)
+
+   In other words, nested modification in `MutableProperty.modify` is now prohibited. Generally speaking, it should have extremely limited impact as in most cases the `MutableProperty` would have been deadlocked already.
+
 1. `promoteError` can now infer the new error type from the context. (#413, kudos to @andersio)
 
 # 2.0.0-alpha.1

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -559,7 +559,7 @@ public final class Property<Value>: PropertyProtocol {
 		signal = relay
 
 		producer = SignalProducer { [box, signal = relay!] observer, lifetime in
-			box.modify { value in
+			box.withValue { value in
 				observer.send(value: value!)
 				if let d = signal.observe(Signal.Observer(mappingInterruptedToCompleted: observer)) {
 					lifetime.observeEnded(d.dispose)
@@ -605,7 +605,7 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 	/// Setting this to a new value will notify all observers of `signal`, or
 	/// signals created using `producer`.
 	public var value: Value {
-		get { return box.modify { $0 } }
+		get { return box.value }
 		set { modify { $0 = newValue } }
 	}
 
@@ -621,7 +621,7 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 	/// deinitialized.
 	public var producer: SignalProducer<Value, NoError> {
 		return SignalProducer { [box, signal] observer, lifetime in
-			box.modify { value in
+			box.withValue { value in
 				observer.send(value: value)
 				if let d = signal.observe(Signal.Observer(mappingInterruptedToCompleted: observer)) {
 					lifetime.observeEnded(d.dispose)
@@ -682,7 +682,7 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 	/// - returns: the result of the action.
 	@discardableResult
 	public func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result {
-		return try box.modify { try action($0) }
+		return try box.withValue { try action($0) }
 	}
 
 	deinit {
@@ -697,6 +697,8 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 private final class PropertyBox<Value> {
 	private let lock: Lock.PthreadLock
 	private var _value: Value
+	private var isModifying = false
+
 	var value: Value { return modify { $0 } }
 
 	init(_ value: Value) {
@@ -704,9 +706,17 @@ private final class PropertyBox<Value> {
 		lock = Lock.PthreadLock(recursive: true)
 	}
 
+	func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result {
+		lock.lock()
+		defer { lock.unlock() }
+		return try action(_value)
+	}
+
 	func modify<Result>(didSet: (Value) -> Void = { _ in }, _ action: (inout Value) throws -> Result) rethrows -> Result {
 		lock.lock()
-		defer { didSet(_value); lock.unlock() }
+		guard !isModifying else { fatalError("Nested modifications violate exclusivity of access.") }
+		isModifying = true
+		defer { isModifying = false; didSet(_value); lock.unlock() }
 		return try action(&_value)
 	}
 }


### PR DESCRIPTION
As a compensation, we could make `modify(didSet:_:)` a public API, but this can be considered separately.

#### Checklist
- [x] Updated CHANGELOG.md.
