### PR TITLE
Fix bad productName values

### DIFF
--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -654,7 +654,7 @@
 			dependencies = (
 			);
 			name = "ReactiveSwift-tvOS";
-			productName = ReactiveCocoa;
+			productName = "ReactiveSwift-tvOS";
 			productReference = 57A4D2411BA13D7A00F7D4B1 /* ReactiveSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
@@ -673,7 +673,7 @@
 				7DFBED0A1CDB8C9500EE435B /* PBXTargetDependency */,
 			);
 			name = "ReactiveSwift-tvOSTests";
-			productName = "ReactiveCocoa-tvOSTests";
+			productName = "ReactiveSwift-tvOSTests";
 			productReference = 7DFBED031CDB8C9500EE435B /* ReactiveSwiftTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
@@ -691,7 +691,7 @@
 			dependencies = (
 			);
 			name = "ReactiveSwift-watchOS";
-			productName = ReactiveCocoa;
+			productName = "ReactiveSwift-watchOS";
 			productReference = A9B315541B3940610001CB9C /* ReactiveSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
@@ -709,7 +709,7 @@
 			dependencies = (
 			);
 			name = "ReactiveSwift-macOS";
-			productName = ReactiveCocoa;
+			productName = "ReactiveSwift-macOS";
 			productReference = D04725EA19E49ED7006002AA /* ReactiveSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
@@ -727,7 +727,7 @@
 				D04725F819E49ED7006002AA /* PBXTargetDependency */,
 			);
 			name = "ReactiveSwift-macOSTests";
-			productName = ReactiveCocoaTests;
+			productName = "ReactiveSwift-macOSTests";
 			productReference = D04725F519E49ED7006002AA /* ReactiveSwiftTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
@@ -745,7 +745,7 @@
 			dependencies = (
 			);
 			name = "ReactiveSwift-iOS";
-			productName = ReactiveCocoa;
+			productName = "ReactiveSwift-iOS";
 			productReference = D047260C19E49F82006002AA /* ReactiveSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
@@ -764,7 +764,7 @@
 				D047261919E49F82006002AA /* PBXTargetDependency */,
 			);
 			name = "ReactiveSwift-iOSTests";
-			productName = ReactiveCocoaTests;
+			productName = "ReactiveSwift-iOSTests";
 			productReference = D047261619E49F82006002AA /* ReactiveSwiftTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};


### PR DESCRIPTION
This (should be) a very minimally invasive PR. 

**The background:**

In general, Xcode appears to behave very badly when using workspaces and its "Find Implicit Dependencies" feature in the scheme editor. Many folks throw up their hands and resort to manual dependency specifications.

Well I think that its terrible behavior can be attributed to a bug in Xcode that causes it to not update the `productName` value in the `.pbxproj` file when a target is renamed. This happens very commonly when creating a framework project, then duplicating the framework targets with suffixes for other platforms.

For some folks, this patch may improve their build experience in Xcode quite a bit—especially for follks like me with very large workspaces that involve a lot of subprojects.

Sorry it took so long to write this one up after making the branch—I hadn't verified that the fix actually worked until I hit the issue again today, and fixing the `productName` value resolved my dependency issue. I'll try and cook up a Radar for this now that I know the steps.