### PR TITLE
Address redundant conformance constraint warnings for Swift 4 compiler (Xcode 9)

### DIFF
--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -10,12 +10,12 @@ extension AnyDisposable {
 
 extension Signal {
 	@available(*, unavailable, renamed:"promoteError")
-	public func promoteErrors<F: Swift.Error>(_: F.Type) -> Signal<Value, F> { fatalError() }
+	public func promoteErrors<F>(_: F.Type) -> Signal<Value, F> { fatalError() }
 }
 
 extension SignalProducer {
 	@available(*, unavailable, renamed:"promoteError")
-	public func promoteErrors<F: Swift.Error>(_: F.Type) -> SignalProducer<Value, F> { fatalError() }
+	public func promoteErrors<F>(_: F.Type) -> SignalProducer<Value, F> { fatalError() }
 }
 
 extension Lifetime {

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -2414,7 +2414,7 @@ extension Signal where Error == NoError {
 	///   - _ An `ErrorType`.
 	///
 	/// - returns: A signal that has an instantiatable `ErrorType`.
-	public func promoteError<F: Swift.Error>(_: F.Type = F.self) -> Signal<Value, F> {
+	public func promoteError<F>(_: F.Type = F.self) -> Signal<Value, F> {
 		return Signal<Value, F> { observer in
 			return self.observe { event in
 				switch event {
@@ -2462,7 +2462,7 @@ extension Signal where Error == NoError {
 	/// - returns: A signal that sends events for at most `interval` seconds,
 	///            then, if not `completed` - sends `error` with `failed` event
 	///            on `scheduler`.
-	public func timeout<NewError: Swift.Error>(
+	public func timeout<NewError>(
 		after interval: TimeInterval,
 		raising error: NewError,
 		on scheduler: DateScheduler

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1297,7 +1297,7 @@ extension SignalProducer where Error == NoError {
 	///   - _ An `ErrorType`.
 	///
 	/// - returns: A producer that has an instantiatable `ErrorType`.
-	public func promoteError<F: Swift.Error>(_: F.Type = F.self) -> SignalProducer<Value, F> {
+	public func promoteError<F>(_: F.Type = F.self) -> SignalProducer<Value, F> {
 		return lift { $0.promoteError(F.self) }
 	}
 
@@ -1332,7 +1332,7 @@ extension SignalProducer where Error == NoError {
 	/// - returns: A producer that sends events for at most `interval` seconds,
 	///            then, if not `completed` - sends `error` with `failed` event
 	///            on `scheduler`.
-	public func timeout<NewError: Swift.Error>(
+	public func timeout<NewError>(
 		after interval: TimeInterval,
 		raising error: NewError,
 		on scheduler: DateScheduler
@@ -1857,7 +1857,7 @@ extension SignalProducer where Error == NoError {
 	///
 	/// - returns: A producer that sends events from `self` and then from
 	///            `replacement` when `self` completes.
-	public func then<U, NewError: Swift.Error>(_ replacement: SignalProducer<U, NewError>) -> SignalProducer<U, NewError> {
+	public func then<U, NewError>(_ replacement: SignalProducer<U, NewError>) -> SignalProducer<U, NewError> {
 		return promoteError(NewError.self)._then(replacement)
 	}
 

--- a/Sources/ValidatingProperty.swift
+++ b/Sources/ValidatingProperty.swift
@@ -190,7 +190,7 @@ public final class ValidatingProperty<Value, ValidationError: Swift.Error>: Muta
 	///   - inner: The inner property which validated values are committed to.
 	///   - other: The property that `validator` depends on.
 	///   - validator: The closure to invoke for any proposed value to `self`.
-	public convenience init<U, E: Swift.Error>(
+	public convenience init<U, E>(
 		_ inner: MutableProperty<Value>,
 		with other: ValidatingProperty<U, E>,
 		_ validator: @escaping (Value, U) -> ValidatorOutput<Value, ValidationError>
@@ -209,7 +209,7 @@ public final class ValidatingProperty<Value, ValidationError: Swift.Error>: Muta
 	///              pass the validation as specified by `validator`.
 	///   - other: The property that `validator` depends on.
 	///   - validator: The closure to invoke for any proposed value to `self`.
-	public convenience init<U, E: Swift.Error>(
+	public convenience init<U, E>(
 		_ initial: Value,
 		with other: ValidatingProperty<U, E>,
 		_ validator: @escaping (Value, U) -> ValidatorOutput<Value, ValidationError>


### PR DESCRIPTION
The changes should be compatible with Swift 3.1.