### PR TITLE
Overload map() to support key paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. In Swift 3.2 or later, you can use `map()` with the new Smart Key Paths. (#435, kudos to @sharplet)
+
 1. When composing `Signal` and `SignalProducer` of inhabitable types, e.g. `Never` or `NoError`, ReactiveSwift now warns about operators that are illogical to use, and traps at runtime when such operators attempt to instantiate an instance. (#429, kudos to @andersio)
 
 1. N-ary `SignalProducer` operators are now generic and accept any type that can be expressed as `SignalProducer`. (#410, kudos to @andersio)

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -102,6 +102,19 @@ extension PropertyProtocol {
 		return lift { $0.map(transform) }
 	}
 
+#if swift(>=3.2)
+	/// Maps the current value and all subsequent values to a new property
+	/// by applying a key path.
+	///
+	/// - parameters:
+	///   - keyPath: A key path relative to the property's `Value` type.
+	///
+	/// - returns: A property that holds a mapped value from `self`.
+	public func map<U>(_ keyPath: KeyPath<Value, U>) -> Property<U> {
+		return lift { $0.map(keyPath) }
+	}
+#endif
+
 	/// Combines the current value and the subsequent values of two `Property`s in
 	/// the manner described by `Signal.combineLatest(with:)`.
 	///

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -646,6 +646,18 @@ extension Signal {
 		}
 	}
 
+#if swift(>=3.2)
+	/// Map each value in the signal to a new value by applying a key path.
+	///
+	/// - parameters:
+	///   - keyPath: A key path relative to the signal's `Value` type.
+	///
+	/// - returns: A signal that will send new values.
+	public func map<U>(_ keyPath: KeyPath<Value, U>) -> Signal<U, Error> {
+		return map { $0[keyPath: keyPath] }
+	}
+#endif
+
 	/// Map errors in the signal to a new error.
 	///
 	/// - parameters:

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -621,6 +621,18 @@ extension SignalProducer {
 		return lift { $0.map(transform) }
 	}
 
+#if swift(>=3.2)
+	/// Map each value in the producer to a new value by applying a key path.
+	///
+	/// - parameters:
+	///   - keyPath: A key path relative to the producer's `Value` type.
+	///
+	/// - returns: A producer that will send new values.
+	public func map<U>(_ keyPath: KeyPath<Value, U>) -> SignalProducer<U, Error> {
+		return lift { $0.map(keyPath) }
+	}
+#endif
+
 	/// Map errors in the producer to a new error.
 	///
 	/// - parameters:

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -732,6 +732,17 @@ class PropertySpec: QuickSpec {
 					property.value = 2
 					expect(mappedProperty.value) == 3
 				}
+
+#if swift(>=3.2)
+				it("should work with key paths") {
+					let property = MutableProperty("foo")
+					let mappedProperty = property.map(\.count)
+					expect(mappedProperty.value) == 3
+
+					property.value = "foobar"
+					expect(mappedProperty.value) == 6
+				}
+#endif
 			}
 
 			describe("combineLatest") {

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -525,6 +525,26 @@ class SignalSpec: QuickSpec {
 				observer.send(value: 1)
 				expect(lastValue) == "2"
 			}
+
+#if swift(>=3.2)
+			it("should support key paths") {
+				let (signal, observer) = Signal<String, NoError>.pipe()
+				let mappedSignal = signal.map(\String.count)
+
+				var lastValue: Int?
+				mappedSignal.observeValues {
+					lastValue = $0
+				}
+
+				expect(lastValue).to(beNil())
+
+				observer.send(value: "foo")
+				expect(lastValue) == 3
+
+				observer.send(value: "foobar")
+				expect(lastValue) == 6
+			}
+#endif
 		}
 		
 		


### PR DESCRIPTION
We should be able to use key paths with `flatMap()` too, but this is a start.

- [x] Updated CHANGELOG.md.