### PR TITLE
A variant of `combinePrevious` that doesn't need an initial value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. `combinePrevious` for `Signal` and `SignalProducer` no longer requires an initial value. The first tuple would be emitted as soon as the second value is received by the operator if no initial value is given. (#445, kudos to @andersio)
+
 1. In Swift 3.2 or later, you may create `BindingTarget` for a key path of a specific object. (#440, kudos to @andersio)
 
 # 2.0.0-alpha.2

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1444,21 +1444,38 @@ extension Signal {
 
 	/// Forward events from `self` with history: values of the returned signal
 	/// are a tuples whose first member is the previous value and whose second member
-	/// is the current value. `initial` is supplied as the first member when `self`
-	/// sends its first value.
+	/// is the current value.
+	///
+	/// If an initial value is given, the returned `Signal` would emit tuples as soon as
+	/// the first value is received. If `initial` is nil, the returned `Signal` would not
+	/// emit any tuple until it has received at least two values.
 	///
 	/// - parameters:
-	///   - initial: A value that will be combined with the first value sent by
-	///              `self`.
+	///   - initial: An optional initial value.
 	///
 	/// - returns: A signal that sends tuples that contain previous and current
 	///            sent values of `self`.
-	public func combinePrevious(_ initial: Value) -> Signal<(Value, Value), Error> {
-		return scan((initial, initial)) { previousCombinedValues, newValue in
-			return (previousCombinedValues.1, newValue)
+	public func combinePrevious(_ initial: Value? = nil) -> Signal<(Value, Value), Error> {
+		return Signal<(Value, Value), Error> { observer in
+			var previous = initial
+
+			return self.observe { event in
+				switch event {
+				case let .value(value):
+					if let previous = previous {
+						observer.send(value: (previous, value))
+					}
+					previous = value
+				case .completed:
+					observer.sendCompleted()
+				case let .failed(error):
+					observer.send(error: error)
+				case .interrupted:
+					observer.sendInterrupted()
+				}
+			}
 		}
 	}
-
 
 	/// Combine all values from `self`, and forward only the final accumuated result.
 	///

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1444,18 +1444,37 @@ extension Signal {
 
 	/// Forward events from `self` with history: values of the returned signal
 	/// are a tuples whose first member is the previous value and whose second member
-	/// is the current value.
-	///
-	/// If an initial value is given, the returned `Signal` would emit tuples as soon as
-	/// the first value is received. If `initial` is nil, the returned `Signal` would not
-	/// emit any tuple until it has received at least two values.
+	/// is the current value. `initial` is supplied as the first member when `self`
+	/// sends its first value.
 	///
 	/// - parameters:
-	///   - initial: An optional initial value.
+	///   - initial: A value that will be combined with the first value sent by
+	///              `self`.
 	///
 	/// - returns: A signal that sends tuples that contain previous and current
 	///            sent values of `self`.
-	public func combinePrevious(_ initial: Value? = nil) -> Signal<(Value, Value), Error> {
+	public func combinePrevious(_ initial: Value) -> Signal<(Value, Value), Error> {
+		return combinePrevious(initial: initial)
+	}
+
+	/// Forward events from `self` with history: values of the returned signal
+	/// are a tuples whose first member is the previous value and whose second member
+	/// is the current value.
+	///
+	/// The returned `Signal` would not emit any tuple until it has received at least two
+	/// values.
+	///
+	/// - returns: A signal that sends tuples that contain previous and current
+	///            sent values of `self`.
+	public func combinePrevious() -> Signal<(Value, Value), Error> {
+		return combinePrevious(initial: nil)
+	}
+
+	/// Implementation detail of `combinePrevious`. A default argument of a `nil` initial
+	/// is deliberately avoided, since in the case of `Value` being an optional, the
+	/// `nil` literal would be materialized as `Optional<Value>.none` instead of `Value`,
+	/// thus changing the semantic.
+	private func combinePrevious(initial: Value?) -> Signal<(Value, Value), Error> {
 		return Signal<(Value, Value), Error> { observer in
 			var previous = initial
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -978,21 +978,32 @@ extension SignalProducer {
 		return liftRight(Signal.skip(until:))(trigger.producer)
 	}
 
+	/// Forward events from `self` with history: values of the returned signal
+	/// are a tuples whose first member is the previous value and whose second member
+	/// is the current value. `initial` is supplied as the first member when `self`
+	/// sends its first value.
+	///
+	/// - parameters:
+	///   - initial: A value that will be combined with the first value sent by
+	///              `self`.
+	///
+	/// - returns: A signal that sends tuples that contain previous and current
+	///            sent values of `self`.
+	public func combinePrevious(_ initial: Value) -> SignalProducer<(Value, Value), Error> {
+		return lift { $0.combinePrevious(initial) }
+	}
+
 	/// Forward events from `self` with history: values of the produced signal
 	/// are a tuples whose first member is the previous value and whose second member
 	/// is the current value.
 	///
-	/// If an initial value is given, the produced `Signal` would emit tuples as soon as
-	/// the first value is received. If `initial` is nil, the produced `Signal` would not
-	/// emit any tuple until it has received at least two values.
-	///
-	/// - parameters:
-	///   - initial: An optional initial value.
+	/// The produced `Signal` would not emit any tuple until it has received at least two
+	/// values.
 	///
 	/// - returns: A producer that sends tuples that contain previous and current
 	///            sent values of `self`.
-	public func combinePrevious(_ initial: Value? = nil) -> SignalProducer<(Value, Value), Error> {
-		return lift { $0.combinePrevious(initial) }
+	public func combinePrevious() -> SignalProducer<(Value, Value), Error> {
+		return lift { $0.combinePrevious() }
 	}
 
 	/// Combine all values from `self`, and forward the final result.

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -978,18 +978,20 @@ extension SignalProducer {
 		return liftRight(Signal.skip(until:))(trigger.producer)
 	}
 
-	/// Forward events from `self` with history: values of the returned producer
-	/// are a tuple whose first member is the previous value and whose second
-	/// member is the current value. `initial` is supplied as the first member
-	/// when `self` sends its first value.
+	/// Forward events from `self` with history: values of the produced signal
+	/// are a tuples whose first member is the previous value and whose second member
+	/// is the current value.
+	///
+	/// If an initial value is given, the produced `Signal` would emit tuples as soon as
+	/// the first value is received. If `initial` is nil, the produced `Signal` would not
+	/// emit any tuple until it has received at least two values.
 	///
 	/// - parameters:
-	///   - initial: A value that will be combined with the first value sent by
-	///              `self`.
+	///   - initial: An optional initial value.
 	///
-	/// - returns: A producer that sends tuples that contain previous and
-	///            current sent values of `self`.
-	public func combinePrevious(_ initial: Value) -> SignalProducer<(Value, Value), Error> {
+	/// - returns: A producer that sends tuples that contain previous and current
+	///            sent values of `self`.
+	public func combinePrevious(_ initial: Value? = nil) -> SignalProducer<(Value, Value), Error> {
 		return lift { $0.combinePrevious(initial) }
 	}
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -2768,7 +2768,7 @@ class SignalSpec: QuickSpec {
 				(signal, observer) = (baseSignal, baseObserver)
 			}
 			
-			it("should forward the latest value with previous value with the given initial value") {
+			it("should forward the latest value with previous value with an initial value") {
 				signal.combinePrevious(initialValue).observeValues { latestValues = $0 }
 
 				expect(latestValues).to(beNil())

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -2756,6 +2756,7 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("combinePrevious") {
+			var signal: Signal<Int, NoError>!
 			var observer: Signal<Int, NoError>.Observer!
 			let initialValue: Int = 0
 			var latestValues: (Int, Int)?
@@ -2763,18 +2764,32 @@ class SignalSpec: QuickSpec {
 			beforeEach {
 				latestValues = nil
 				
-				let (signal, baseObserver) = Signal<Int, NoError>.pipe()
-				observer = baseObserver
-				signal.combinePrevious(initialValue).observeValues { latestValues = $0 }
+				let (baseSignal, baseObserver) = Signal<Int, NoError>.pipe()
+				(signal, observer) = (baseSignal, baseObserver)
 			}
 			
-			it("should forward the latest value with previous value") {
+			it("should forward the latest value with previous value with the given initial value") {
+				signal.combinePrevious(initialValue).observeValues { latestValues = $0 }
+
 				expect(latestValues).to(beNil())
 				
 				observer.send(value: 1)
 				expect(latestValues?.0) == initialValue
 				expect(latestValues?.1) == 1
 				
+				observer.send(value: 2)
+				expect(latestValues?.0) == 1
+				expect(latestValues?.1) == 2
+			}
+
+			it("should forward the latest value with previous value without any initial value") {
+				signal.combinePrevious().observeValues { latestValues = $0 }
+
+				expect(latestValues).to(beNil())
+
+				observer.send(value: 1)
+				expect(latestValues).to(beNil())
+
 				observer.send(value: 2)
 				expect(latestValues?.0) == 1
 				expect(latestValues?.1) == 2


### PR DESCRIPTION
Note that `combinePrevious()` is not implemented using default arguments and optionals, so that existing use cases as concerned by @NachoSoto would not break.

In other words, `combinePrevious(nil)` and `combinePrevious()` are not equivalent, given the constraint `<U> Value == Optional<U>`.

#### Checklist
- [x] Updated CHANGELOG.md.
