### PR TITLE
Fixed an impedance mismatch between Signal.Core RCU and Bag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. Fixed an impedance mismatch in the `Signal` internals that caused heap corruptions. (#449, kudos to @gparker42)
+
 1. In Swift 3.2 or later, you may create `BindingTarget` for a key path of a specific object. (#440, kudos to @andersio)
 
 # 2.0.0-alpha.2


### PR DESCRIPTION
Related: https://bugs.swift.org/browse/SR-5190 with the kind help from @gparker42.

The changes we made to `AliveState` in #355 clash with #354, causing heap corruptions when `Signal` is under concurrent stress tests in ReactiveCocoa.

I have re-run the concerned RAC stress tests with fairly large number of iterations, and the issue is patched by this fix.

#### Checklist
- [x] Updated CHANGELOG.md.