### PR TITLE
Inlined lock storage in `Lock`.

### DIFF
--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -732,7 +732,7 @@ private final class PropertyBox<Value> {
 
 	init(_ value: Value) {
 		_value = value
-		lock = Lock.PthreadLock(recursive: true)
+		lock = Lock.PthreadLock.make(recursive: true)
 	}
 
 	func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result {


### PR DESCRIPTION
Initialise `PthreadLock` and `UnfairLock` using `ManagedBufferPointer`, having the lock as the tail allocated header.

Unlike using `&` on a stored property, the location is guaranteed to be the same. :)

#### Checklist
- ~~Updated CHANGELOG.md.~~