### PR TITLE
swiftpm test dependency updates

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,9 @@ import Foundation
 import PackageDescription
 
 var isSwiftPackagerManagerTest: Bool {
-    return ProcessInfo.processInfo.environment["SWIFTPM_TEST_ReactiveSwift"] == "YES"
+    let environment = ProcessInfo.processInfo.environment
+    guard let value = environment["SWIFTPM_TEST_ReactiveSwift"] else { return false }
+    return NSString(string: value).boolValue
 }
 
 let package = Package(


### PR DESCRIPTION
There are two independent changes here:

 1. Use `NSString.boolValue` in `Package.swift` to parse the
    `SWIFTPM_TEST_ReactiveSwift` environment variable for a truthy value. This
    is cross-platform, and handles more truthy values like `true` and `1`, which is
    nice.

 2. Use a more general `SWIFT_PACKAGE_TEST` environment variable. I introduced
    this in https://github.com/sharplet/Regex/pull/53, and like the idea of
    having a more standard variable name that can be used across different
    projects.

I think (1) is a nice improvement, and would love some input on (2) as a potential standard variable name. What do you think?

- N/A: ~Updated CHANGELOG.md.~