### PR TITLE
Revisit Action state-property convenience initialisers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. Added new convenience initialisers to `Action` that make creating actions with state input properties easier. When creating an `Action` that is conditionally enabled based on an optional property, use the renamed `Action.init(unwrapping:execute:)` initialisers. (#455, kudos to @sharplet)
+
 # 2.0.0-alpha.3
 1. `combinePrevious` for `Signal` and `SignalProducer` no longer requires an initial value. The first tuple would be emitted as soon as the second value is received by the operator if no initial value is given. (#445, kudos to @andersio)
 

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -168,6 +168,20 @@ public final class Action<Input, Output, Error: Swift.Error> {
 		}
 	}
 
+	/// Initializes an `Action` that uses a property as its state.
+	///
+	/// When the `Action` is asked to start the execution, a unit of work — represented by
+	/// a `SignalProducer` — would be created by invoking `execute` with the latest value
+	/// of the state.
+	///
+	/// - parameters:
+	///   - state: A property to be the state of the `Action`.
+	///   - execute: A closure that produces a unit of work, as `SignalProducer`, to
+	///              be executed by the `Action`.
+	public convenience init<P: PropertyProtocol>(state: P, execute: @escaping (P.Value, Input) -> SignalProducer<Output, Error>) {
+		self.init(state: state, enabledIf: { _ in true }, execute: execute)
+	}
+
 	/// Initializes an `Action` that would be conditionally enabled.
 	///
 	/// When the `Action` is asked to start the execution with an input value, a unit of
@@ -269,7 +283,9 @@ extension Action where Input == Void {
 	///   - execute: A closure that produces a unit of work, as `SignalProducer`, to
 	///              be executed by the `Action`.
 	public convenience init<P: PropertyProtocol, T>(state: P, execute: @escaping (T) -> SignalProducer<Output, Error>) where P.Value == T {
-		self.init(state: state.map(Optional.some), execute: execute)
+		self.init(state: state) { state, _ in
+			execute(state)
+		}
 	}
 }
 

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -285,7 +285,7 @@ extension Action where Input == Void {
 	///   - state: A property of optional to be the state of the `Action`.
 	///   - execute: A closure that produces a unit of work, as `SignalProducer`, to
 	///              be executed by the `Action`.
-	public convenience init<P: PropertyProtocol, T>(state: P, execute: @escaping (T) -> SignalProducer<Output, Error>) where P.Value == T? {
+	public convenience init<P: PropertyProtocol, T>(unwrapping state: P, execute: @escaping (T) -> SignalProducer<Output, Error>) where P.Value == T? {
 		self.init(unwrapping: state) { state, _ in
 			execute(state)
 		}

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -198,6 +198,25 @@ public final class Action<Input, Output, Error: Swift.Error> {
 		}
 	}
 
+	/// Initializes an `Action` that uses a property of optional as its state.
+	///
+	/// When the `Action` is asked to start executing, a unit of work (represented by
+	/// a `SignalProducer`) is created by invoking `execute` with the latest value
+	/// of the state and the `input` that was passed to `apply()`.
+	///
+	/// If the property holds a `nil`, the `Action` would be disabled until it is not
+	/// `nil`.
+	///
+	/// - parameters:
+	///   - state: A property of optional to be the state of the `Action`.
+	///   - execute: A closure that produces a unit of work, as `SignalProducer`, to
+	///              be executed by the `Action`.
+	public convenience init<P: PropertyProtocol, T>(unwrapping state: P, execute: @escaping (T, Input) -> SignalProducer<Output, Error>) where P.Value == T? {
+		self.init(state: state, enabledIf: { $0 != nil }) { state, input in
+			execute(state!, input)
+		}
+	}
+
 	/// Initializes an `Action` that would always be enabled.
 	///
 	/// When the `Action` is asked to start the execution with an input value, a unit of
@@ -267,8 +286,8 @@ extension Action where Input == Void {
 	///   - execute: A closure that produces a unit of work, as `SignalProducer`, to
 	///              be executed by the `Action`.
 	public convenience init<P: PropertyProtocol, T>(state: P, execute: @escaping (T) -> SignalProducer<Output, Error>) where P.Value == T? {
-		self.init(state: state, enabledIf: { $0 != nil }) { state, _ in
-			execute(state!)
+		self.init(unwrapping: state) { state, _ in
+			execute(state)
 		}
 	}
 

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -141,7 +141,10 @@ extension Action {
 }
 
 extension Action where Input == Void {
-	@available(*, unavailable, renamed:"init(state:execute:)")
+	@available(*, unavailable, renamed:"init(unwrapping:execute:)")
+	public convenience init<P: PropertyProtocol, T>(state: P, _ execute: @escaping (T) -> SignalProducer<Output, Error>) where P.Value == T? { fatalError() }
+
+	@available(*, unavailable, renamed:"init(unwrapping:execute:)")
 	public convenience init<P: PropertyProtocol, T>(input: P, _ execute: @escaping (T) -> SignalProducer<Output, Error>) where P.Value == T? { fatalError() }
 
 	@available(*, unavailable, renamed:"init(state:execute:)")

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -344,7 +344,7 @@ class ActionSpec: QuickSpec {
 
 			it("is disabled if the property is nil") {
 				let input = MutableProperty<Int?>(1)
-				let action = Action(state: input, execute: echo)
+				let action = Action(unwrapping: input, execute: echo)
 
 				expect(action.isEnabled.value) == true
 				input.value = nil

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -350,6 +350,34 @@ class ActionSpec: QuickSpec {
 				input.value = nil
 				expect(action.isEnabled.value) == false
 			}
+
+			it("allows a different input type while unwrapping an optional state property") {
+				let state = MutableProperty<Int?>(nil)
+
+				let add = Action<String, Int?, NoError>(unwrapping: state) { state, input -> SignalProducer<Int?, NoError> in
+					guard let input = Int(input) else { return SignalProducer(value: nil) }
+					return SignalProducer(value: state + input)
+				}
+
+				var values: [Int] = []
+				add.values.observeValues { output in
+					if let output = output {
+						values.append(output)
+					}
+				}
+
+				expect(add.isEnabled.value) == false
+				state.value = 1
+				expect(add.isEnabled.value) == true
+
+				add.apply("2").start()
+				add.apply("3").start()
+
+				state.value = -1
+				add.apply("-10").start()
+
+				expect(values) == [3, 4, -11]
+			}
 		}
 	}
 }

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -323,6 +323,25 @@ class ActionSpec: QuickSpec {
 				expect(values) == [1, 2, 3]
 			}
 
+			it("allows a non-void input type") {
+				let state = MutableProperty(1)
+
+				let add = Action<Int, Int, NoError>(state: state) { state, input in
+					SignalProducer(value: state + input)
+				}
+
+				var values: [Int] = []
+				add.values.observeValues { values.append($0) }
+
+				add.apply(2).start()
+				add.apply(3).start()
+
+				state.value = -1
+				add.apply(-10).start()
+
+				expect(values) == [3, 4, -11]
+			}
+
 			it("is disabled if the property is nil") {
 				let input = MutableProperty<Int?>(1)
 				let action = Action(state: input, execute: echo)


### PR DESCRIPTION
There are currently two options for using some property as state for an `Action`:

- Use the designated initialiser `Action.init(state:enabledIf:executing:)` (the most complicated);
- Use the various convenience initialisers defined for `Void` input types, which are nice but sacrifice the ability to use a custom input type.

This change rounds out the set of convenience initialisers for maximum flexibility:

- You can now use a state-property with a non-`Void` input type, without having to worry about `enabledIf`;
- You can use a conditionally-unwrapped optional state-property in the same way.

In order to unambiguously differentiate between the optional and non-optional variants in all cases, all the optional versions now use `unwrapping` as the parameter label for the state-property:

```swift
let model: MutableProperty<MyModel?>

let share = Action<UIViewController, Never, AnyError>(unwrapping: model) { model, viewController in
  return viewController.share(model)
}

// later...

button.reactive.pressed = CocoaAction(viewModel.share) { [unowned self] _ in self }
```

I'm pretty happy with the `unwrapping` label, as it feels much more self-documenting, and should hopefully make this series of convenience initialisers easier to navigate.

- [x] Updated CHANGELOG.md.