### PR TITLE
Send `interrupted` when an input observer deinitializes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. If the input observer of a `Signal` deinitializes while the `Signal` has not yet terminated, an `interrupted` event would now be automatically sent. (#463, kudos to @andersio)
+
 1. Mitigated a race condition related to ARC in the `Signal` internal. (#456, kudos to @andersio)
 
 1. Added new convenience initialisers to `Action` that make creating actions with state input properties easier. When creating an `Action` that is conditionally enabled based on an optional property, use the renamed `Action.init(unwrapping:execute:)` initialisers. (#455, kudos to @sharplet)

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -15,6 +15,21 @@ extension Signal {
 		/// An action that will be performed upon arrival of the event.
 		public let action: Action
 
+		/// Whether the observer should send an `interrupted` event as it deinitializes.
+		private let interruptsOnDeinit: Bool
+
+		/// An initializer that accepts a closure accepting an event for the
+		/// observer.
+		///
+		/// - parameters:
+		///   - action: A closure to lift over received event.
+		///   - interruptsOnDeinit: `true` if the observer should send an `interrupted`
+		///                         event as it deinitializes. `false` otherwise.
+		internal init(action: @escaping Action, interruptsOnDeinit: Bool) {
+			self.action = action
+			self.interruptsOnDeinit = interruptsOnDeinit
+		}
+
 		/// An initializer that accepts a closure accepting an event for the 
 		/// observer.
 		///
@@ -22,6 +37,7 @@ extension Signal {
 		///   - action: A closure to lift over received event.
 		public init(_ action: @escaping Action) {
 			self.action = action
+			self.interruptsOnDeinit = false
 		}
 
 		/// An initializer that accepts closures for different event types.
@@ -65,6 +81,15 @@ extension Signal {
 				case .interrupted:
 					observer.sendCompleted()
 				}
+			}
+		}
+
+		deinit {
+			if interruptsOnDeinit {
+				// Since `Signal` would ensure that only one terminal event would ever be
+				// sent for any given `Signal`, we do not need to assert any condition
+				// here.
+				action(.interrupted)
 			}
 		}
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -70,7 +70,7 @@ public final class Signal<Value, Error: Swift.Error> {
 			disposable = SerialDisposable()
 
 			// The generator observer retains the `Signal` core.
-			disposable.inner = generator(Observer(self.send))
+			disposable.inner = generator(Observer(action: self.send, interruptsOnDeinit: true))
 		}
 
 		private func send(_ event: Event) {
@@ -376,7 +376,11 @@ public final class Signal<Value, Error: Swift.Error> {
 extension Signal {
 	/// A Signal that never sends any events to its observers.
 	public static var never: Signal {
-		return self.init { _ in nil }
+		return self.init { observer in
+			// If `observer` deinitializes, the `Signal` would interrupt which is
+			// undesirable for `Signal.never`.
+			return AnyDisposable { _ = observer }
+		}
 	}
 
 	/// A Signal that completes immediately without emitting any value.

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -1680,17 +1680,19 @@ class PropertySpec: QuickSpec {
 				}
 
 				it("should tear down the binding when the property deallocates") {
-					let (signal, _) = Signal<String, NoError>.pipe()
+					let (signal, observer) = Signal<String, NoError>.pipe()
 					let signalProducer = SignalProducer(signal)
 
 					var mutableProperty: MutableProperty<String>? = MutableProperty(initialPropertyValue)
 
-					var isDisposed = false
-					mutableProperty! <~ signalProducer.on(disposed: { isDisposed = true })
-					expect(isDisposed) == false
+					withExtendedLifetime(observer) {
+						var isDisposed = false
+						mutableProperty! <~ signalProducer.on(disposed: { isDisposed = true })
+						expect(isDisposed) == false
 
-					mutableProperty = nil
-					expect(isDisposed) == true
+						mutableProperty = nil
+						expect(isDisposed) == true
+					}
 				}
 			}
 

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -1430,12 +1430,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				var sampledProducer: SignalProducer<Payload, NoError>!
+				var samplerObserver: Signal<(), NoError>.Observer!
 				var observer: Signal<Payload, NoError>.Observer!
 
 				beforeEach {
 					let (producer, incomingObserver) = SignalProducer<Payload, NoError>.pipe()
-					let (sampler, _) = Signal<(), NoError>.pipe()
+					let (sampler, _samplerObserver) = Signal<(), NoError>.pipe()
 					sampledProducer = producer.sample(on: sampler)
+					samplerObserver = _samplerObserver
 					observer = incomingObserver
 				}
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -260,7 +260,7 @@ class SignalSpec: QuickSpec {
 
 			context("memory") {
 				it("should not crash allocating memory with a few observers") {
-					let (signal, _) = Signal<Int, NoError>.pipe()
+					let (signal, observer) = Signal<Int, NoError>.pipe()
 
 					#if os(Linux)
 						func autoreleasepool(invoking code: () -> Void) {
@@ -268,11 +268,13 @@ class SignalSpec: QuickSpec {
 						}
 					#endif
 
-					for _ in 0..<50 {
-						autoreleasepool {
-							let disposable = signal.observe { _ in }
+					withExtendedLifetime(observer) {
+						for _ in 0..<50 {
+							autoreleasepool {
+								let disposable = signal.observe { _ in }
 
-							disposable!.dispose()
+								disposable!.dispose()
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Implements #461.

#### Checklist
- [x] Updated CHANGELOG.md.
