### PR TITLE
Fixed a deadlock upon disposal in AggregateBuilder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. Fixed a deadlock upon disposal when combining operators, i.e. `zip` and `combineLatest`, are used. (#471, kudos to @stevebrambilla for catching the bug)
+
 # 2.0.0-rc.1
 1. If the input observer of a `Signal` deinitializes while the `Signal` has not yet terminated, an `interrupted` event would now be automatically sent. (#463, kudos to @andersio)
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -2132,11 +2132,7 @@ extension Signal {
 				disposables += action(index, strategy) { observer.action($0.map { _ in fatalError() }) }
 			}
 
-			return AnyDisposable {
-				strategy.modify { _ in
-					disposables.dispose()
-				}
-			}
+			return disposables
 		}
 	}
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -2791,6 +2791,96 @@ class SignalSpec: QuickSpec {
 				aObserver.send(value: ())
 				bObserver.send(value: ())
 			}
+
+			it("should not deadlock upon recursive completion of the sources") {
+				let (a, aObserver) = Signal<(), NoError>.pipe()
+				let (b, bObserver) = Signal<(), NoError>.pipe()
+
+				Signal.zip(a, b)
+					.observeValues { _ in
+						aObserver.sendCompleted()
+					}
+
+				aObserver.send(value: ())
+				bObserver.send(value: ())
+			}
+
+			it("should not deadlock upon recursive interruption of the sources") {
+				let (a, aObserver) = Signal<(), NoError>.pipe()
+				let (b, bObserver) = Signal<(), NoError>.pipe()
+
+				Signal.zip(a, b)
+					.observeResult { _ in
+						aObserver.sendInterrupted()
+					}
+
+				aObserver.send(value: ())
+				bObserver.send(value: ())
+			}
+
+			it("should not deadlock upon recursive failure of the sources") {
+				let (a, aObserver) = Signal<(), TestError>.pipe()
+				let (b, bObserver) = Signal<(), TestError>.pipe()
+
+				Signal.zip(a, b)
+					.observeResult { _ in
+						aObserver.send(error: .default)
+					}
+
+				aObserver.send(value: ())
+				bObserver.send(value: ())
+			}
+
+			it("should not deadlock upon disposal") {
+				let (a, aObserver) = Signal<(), NoError>.pipe()
+				let (b, bObserver) = Signal<(), NoError>.pipe()
+
+				Signal.combineLatest(a, b)
+					.take(first: 1)
+					.observeValues { _ in }
+
+				aObserver.send(value: ())
+				bObserver.send(value: ())
+			}
+
+			it("should not deadlock upon recursive completion of the sources") {
+				let (a, aObserver) = Signal<(), NoError>.pipe()
+				let (b, bObserver) = Signal<(), NoError>.pipe()
+
+				Signal.combineLatest(a, b)
+					.observeValues { _ in
+						aObserver.sendCompleted()
+				}
+
+				aObserver.send(value: ())
+				bObserver.send(value: ())
+			}
+
+			it("should not deadlock upon recursive interruption of the sources") {
+				let (a, aObserver) = Signal<(), NoError>.pipe()
+				let (b, bObserver) = Signal<(), NoError>.pipe()
+
+				Signal.combineLatest(a, b)
+					.observeResult { _ in
+						aObserver.sendInterrupted()
+				}
+
+				aObserver.send(value: ())
+				bObserver.send(value: ())
+			}
+
+			it("should not deadlock upon recursive failure of the sources") {
+				let (a, aObserver) = Signal<(), TestError>.pipe()
+				let (b, bObserver) = Signal<(), TestError>.pipe()
+
+				Signal.combineLatest(a, b)
+					.observeResult { _ in
+						aObserver.send(error: .default)
+				}
+
+				aObserver.send(value: ())
+				bObserver.send(value: ())
+			}
 		}
 
 		describe("combineLatest") {

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -14,27 +14,8 @@ import Nimble
 import Quick
 @testable import ReactiveSwift
 
-private class StateA<U, V> {}
-private class StateB<U, V> {}
-private enum SignalState<U, V> {
-	case alive(StateA<U, V>)
-	case terminating(StateB<U, V>)
-	case terminated
-}
-
 class SignalSpec: QuickSpec {
 	override func spec() {
-		describe("thread safety") {
-			it("should have the same memory layout as a native pointer") {
-				let enumLayout = MemoryLayout<SignalState<Int, Error>>.self
-				let pointerLayout = MemoryLayout<UnsafeMutableRawPointer>.self
-
-				expect(enumLayout.alignment) == pointerLayout.alignment
-				expect(enumLayout.size) == pointerLayout.size
-				expect(enumLayout.stride) == pointerLayout.stride
-			}
-		}
-
 		describe("init") {
 			var testScheduler: TestScheduler!
 			
@@ -2795,6 +2776,20 @@ class SignalSpec: QuickSpec {
 				observer.send(value: 2)
 				expect(latestValues?.0) == 1
 				expect(latestValues?.1) == 2
+			}
+		}
+
+		describe("AggregateBuilder") {
+			it("should not deadlock upon disposal") {
+				let (a, aObserver) = Signal<(), NoError>.pipe()
+				let (b, bObserver) = Signal<(), NoError>.pipe()
+
+				Signal.zip(a, b)
+					.take(first: 1)
+					.observeValues { _ in }
+
+				aObserver.send(value: ())
+				bObserver.send(value: ())
 			}
 		}
 


### PR DESCRIPTION
Fixes #470.
Removed also a stale test case.

The deadlock happens when a `value` event of a combined signal triggers termination of one of its source signals (except for the one that indirectly yields the `value` event).

Example: https://github.com/ReactiveCocoa/ReactiveSwift/pull/471/files#diff-8c46f2726f3ee5a6dbf7ad24b29dbd57R2795

The value from `B` yields a new `(A, B)` tuple, leading to termination of `A` and eventually informing the strategy with the completion of `A`. Since the delivery of the tuple is in progress, the strategy's internal lock is still acquired, resulting in the deadlock.

Threading of the signal aggregate strategies now mirrors that of `Signal.Core` to allow recursive termial event sent by a `value` event.

#### Checklist
- [x] Updated CHANGELOG.md.
