### PR TITLE
Fix method signature errors in BasicOperators.md

### DIFF
--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -497,14 +497,14 @@ observer.send(error: NSError(domain: "com.example.foo", code: 42, userInfo: nil)
 
 ### Promote
 
-The `promoteErrors` operator promotes an event stream that does not generate failures into one that can. 
+The `promoteError` operator promotes an event stream that does not generate failures into one that can.
 
 ```Swift
 let (numbersSignal, numbersObserver) = Signal<Int, NoError>.pipe()
 let (lettersSignal, lettersObserver) = Signal<String, NSError>.pipe()
 
 numbersSignal
-    .promoteErrors(NSError.self)
+    .promoteError(NSError.self)
     .combineLatest(with: lettersSignal)
 ```
 

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -387,7 +387,7 @@ The `flatMapError` operator catches any failure that may occur on the input even
 
 ```Swift
 let (signal, observer) = Signal<String, NSError>.pipe()
-let producer = SignalProducer(signal: signal)
+let producer = SignalProducer(signal)
 
 let error = NSError(domain: "domain", code: 0, userInfo: nil)
 


### PR DESCRIPTION
Hi, it's me again 👋

I found a couple of method signature errors in BasicOperators.md when I was trying the code snippet out in Sandbox.playground. Thanks!