### PR TITLE
Include the unavailable reason in `ActionError.disabled`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. `ActionError.disabled` now includes the reason why the `Action` refused the execution attempt. (#479, kudos to @andersio)
+
 # 2.0.0-rc.2
 1. Fixed a deadlock upon disposal when combining operators, i.e. `zip` and `combineLatest`, are used. (#471, kudos to @stevebrambilla for catching the bug)
 


### PR DESCRIPTION
This frees retrying logic with `Action`s from the need of composing `isExecuting` and `isEnabled`. More importantly, it allows the observer to differentiate between temporary and potentially permanent unavailability. `isEnabled` does not convey such information.

### Impact
[The breaking bit affects only those who instantiates `ActionError.disabled`, presumably in unit tests](https://github.com/ReactiveCocoa/ReactiveSwift/pull/479/files#diff-cb74afb7f7cae7399eddbb00da5ae227L102). Usage in patterns is not affected.

#### Checklist
- [x] Updated CHANGELOG.md.