### PR TITLE
Use `WritableKeyPath` instead of `ReferenceWritableKeyPath`.

### DIFF
--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -158,7 +158,7 @@ public struct BindingTarget<Value>: BindingTargetProvider {
 	///   - lifetime: The expected lifetime of any bindings towards `self`.
 	///   - object: The object to consume values.
 	///   - keyPath: The key path of the object that consumes values.
-	public init<Object: AnyObject>(on scheduler: Scheduler = ImmediateScheduler(), lifetime: Lifetime, object: Object, keyPath: ReferenceWritableKeyPath<Object, Value>) {
+	public init<Object: AnyObject>(on scheduler: Scheduler = ImmediateScheduler(), lifetime: Lifetime, object: Object, keyPath: WritableKeyPath<Object, Value>) {
 		self.init(on: scheduler, lifetime: lifetime) { [weak object] in object?[keyPath: keyPath] = $0 }
 	}
 	#endif


### PR DESCRIPTION
`WritableKeyPath` supports leaves with value semantics, and is the superclass of `ReferenceWritableKeyPath`.

#### Checklist
- ~~Updated CHANGELOG.md.~~
