### PR TITLE
Xcode 9 beta 3 Support

### DIFF
--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -96,7 +96,7 @@ extension DispatchTimeInterval {
 			case let .milliseconds(ms):
 				return TimeInterval(TimeInterval(ms) / 1000.0)
 			case let .microseconds(us):
-				return TimeInterval( UInt64(us) * NSEC_PER_USEC ) / TimeInterval(NSEC_PER_SEC)
+				return TimeInterval(Int64(us) * Int64(NSEC_PER_USEC)) / TimeInterval(NSEC_PER_SEC)
 			case let .nanoseconds(ns):
 				return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
 			case .never:
@@ -109,7 +109,7 @@ extension DispatchTimeInterval {
 			case let .milliseconds(ms):
 				return TimeInterval(TimeInterval(ms) / 1000.0)
 			case let .microseconds(us):
-				return TimeInterval( UInt64(us) * NSEC_PER_USEC ) / TimeInterval(NSEC_PER_SEC)
+				return TimeInterval(Int64(us) * Int64(NSEC_PER_USEC)) / TimeInterval(NSEC_PER_SEC)
 			case let .nanoseconds(ns):
 				return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
 			}

--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -89,31 +89,61 @@ extension Date {
 
 extension DispatchTimeInterval {
 	internal var timeInterval: TimeInterval {
-		switch self {
-		case let .seconds(s):
-			return TimeInterval(s)
-		case let .milliseconds(ms):
-			return TimeInterval(TimeInterval(ms) / 1000.0)
-		case let .microseconds(us):
-			return TimeInterval( UInt64(us) * NSEC_PER_USEC ) / TimeInterval(NSEC_PER_SEC)
-		case let .nanoseconds(ns):
-			return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
-		}
+		#if swift(>=3.2)
+			switch self {
+			case let .seconds(s):
+				return TimeInterval(s)
+			case let .milliseconds(ms):
+				return TimeInterval(TimeInterval(ms) / 1000.0)
+			case let .microseconds(us):
+				return TimeInterval( UInt64(us) * NSEC_PER_USEC ) / TimeInterval(NSEC_PER_SEC)
+			case let .nanoseconds(ns):
+				return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
+			case .never:
+				return .infinity
+			}
+		#else
+			switch self {
+			case let .seconds(s):
+				return TimeInterval(s)
+			case let .milliseconds(ms):
+				return TimeInterval(TimeInterval(ms) / 1000.0)
+			case let .microseconds(us):
+				return TimeInterval( UInt64(us) * NSEC_PER_USEC ) / TimeInterval(NSEC_PER_SEC)
+			case let .nanoseconds(ns):
+				return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
+			}
+		#endif
 	}
 
 	// This was added purely so that our test scheduler to "go backwards" in
 	// time. See `TestScheduler.rewind(by interval: DispatchTimeInterval)`.
 	internal static prefix func -(lhs: DispatchTimeInterval) -> DispatchTimeInterval {
-		switch lhs {
-		case let .seconds(s):
-			return .seconds(-s)
-		case let .milliseconds(ms):
-			return .milliseconds(-ms)
-		case let .microseconds(us):
-			return .microseconds(-us)
-		case let .nanoseconds(ns):
-			return .nanoseconds(-ns)
-		}
+		#if swift(>=3.2)
+			switch lhs {
+			case let .seconds(s):
+				return .seconds(-s)
+			case let .milliseconds(ms):
+				return .milliseconds(-ms)
+			case let .microseconds(us):
+				return .microseconds(-us)
+			case let .nanoseconds(ns):
+				return .nanoseconds(-ns)
+			case .never:
+				return .never
+			}
+		#else
+			switch lhs {
+			case let .seconds(s):
+				return .seconds(-s)
+			case let .milliseconds(ms):
+				return .milliseconds(-ms)
+			case let .microseconds(us):
+				return .microseconds(-us)
+			case let .nanoseconds(ns):
+				return .nanoseconds(-ns)
+			}
+		#endif
 	}
 
 	/// Scales a time interval by the given scalar specified in `rhs`.

--- a/Tests/ReactiveSwiftTests/FoundationExtensionsSpec.swift
+++ b/Tests/ReactiveSwiftTests/FoundationExtensionsSpec.swift
@@ -103,13 +103,19 @@ class FoundationExtensionsSpec: QuickSpec {
 
 				expect(DispatchTimeInterval.milliseconds(500).timeInterval).to(beCloseTo(0.5))
 				expect(DispatchTimeInterval.milliseconds(250).timeInterval).to(beCloseTo(0.25))
+				#if swift(>=3.2)
+					expect(DispatchTimeInterval.never.timeInterval) == Double.infinity
+				#endif
 			}
 
 			it("should negate as you'd hope") {
-				expect(-DispatchTimeInterval.seconds(1).timeInterval).to(beCloseTo(-1.0))
-				expect(-DispatchTimeInterval.milliseconds(1).timeInterval).to(beCloseTo(-0.001))
-				expect(-DispatchTimeInterval.microseconds(1).timeInterval).to(beCloseTo(-0.000001, within: 0.0000001))
-				expect(-DispatchTimeInterval.nanoseconds(1).timeInterval).to(beCloseTo(-0.000000001, within: 0.0000000001))
+				expect((-DispatchTimeInterval.seconds(1)).timeInterval).to(beCloseTo(-1.0))
+				expect((-DispatchTimeInterval.milliseconds(1)).timeInterval).to(beCloseTo(-0.001))
+				expect((-DispatchTimeInterval.microseconds(1)).timeInterval).to(beCloseTo(-0.000001, within: 0.0000001))
+				expect((-DispatchTimeInterval.nanoseconds(1)).timeInterval).to(beCloseTo(-0.000000001, within: 0.0000000001))
+				#if swift(>=3.2)
+					expect((-DispatchTimeInterval.never).timeInterval) == Double.infinity
+				#endif
 			}
 		}
 	}


### PR DESCRIPTION
In Swift 3.2, `Dispatch.DispatchTimeInterval` has a new case, `.never`, that needs to be switched on.

Fixes https://github.com/ReactiveCocoa/ReactiveSwift/issues/483.

#### Checklist
- [ ] Updated CHANGELOG.md.
