### PR TITLE
Fix typo and link in documentation

### DIFF
--- a/Documentation/APIContracts.md
+++ b/Documentation/APIContracts.md
@@ -314,7 +314,7 @@ everything added to the [`CompositeDisposable`][CompositeDisposable] in
 Note that disposing of one produced `Signal` will not affect other signals created
 by the same `SignalProducer`.
 
-## The Property contract.
+## The Property contract
 
 A property is essentially a `Signal` which guarantees it has an initial value, and its latest value is always available for being read out.
 

--- a/Documentation/ReactivePrimitives.md
+++ b/Documentation/ReactivePrimitives.md
@@ -25,7 +25,7 @@ A `Signal` may have any arbitrary number of events carrying a value, following b
 
 It is like a frame in a one-time live feed — seas of data frames carry the visual and audio data, but the feed would eventually be terminated with a special frame to indicate "end of stream".
 
-*See also: [The `Event` overview](FrameworkOverview.md#events), [The `Event` contract](APIContracts.md#the-event-contract), [The `Event` API reference](http://reactivecocoa.io/reactiveswift/docs/latest/Enums/Event.html)*
+*See also: [The `Event` overview](FrameworkOverview.md#events), [The `Event` contract](APIContracts.md#the-event-contract), [The `Event` API reference](http://reactivecocoa.io/reactiveswift/docs/latest/Classes/Signal/Event.html)*
 
 #### `SignalProducer`: deferred work that creates a stream of values.
 `SignalProducer` defers work — of which the output is represented as a stream of values — until it is started. For every invocation to start the `SignalProducer`, a new `Signal` is created and the deferred work is subsequently invoked.

--- a/Documentation/ReactivePrimitives.md
+++ b/Documentation/ReactivePrimitives.md
@@ -25,7 +25,7 @@ A `Signal` may have any arbitrary number of events carrying a value, following b
 
 It is like a frame in a one-time live feed — seas of data frames carry the visual and audio data, but the feed would eventually be terminated with a special frame to indicate "end of stream".
 
-*See also: [The `Event` overview](FrameworkOverview.md#events), [The `Signal` contract](APIContracts.md#the-event-contract), [The `Event` API reference](http://reactivecocoa.io/reactiveswift/docs/latest/Enums/Event.html)*
+*See also: [The `Event` overview](FrameworkOverview.md#events), [The `Event` contract](APIContracts.md#the-event-contract), [The `Event` API reference](http://reactivecocoa.io/reactiveswift/docs/latest/Enums/Event.html)*
 
 #### `SignalProducer`: deferred work that creates a stream of values.
 `SignalProducer` defers work — of which the output is represented as a stream of values — until it is started. For every invocation to start the `SignalProducer`, a new `Signal` is created and the deferred work is subsequently invoked.


### PR DESCRIPTION
Hi ReactiveSwift team,

This PR fixes 2 typos and a link. Please check it out. Thanks!