### PR TITLE
Cutting the SignalProducer overhead further.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. The `SignalProducer` internals have undergone a significant refactoring, which bootstraps the effort to reduce the overhead of constant producers and producer compositions. (#487, kudos to @andersio)
+
 1. New method ``retry(upTo:interval:on:)``. This delays retrying on failure by `interval` until hitting the `upTo` limitation.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 1. New method ``retry(upTo:interval:on:)``. This delays retrying on failure by `interval` until hitting the `upTo` limitation.
 
-1. Addressed the exceptionally high build time. (#495)
-
 # 2.0.0
 # 2.0.0-rc.3
 1. `Lifetime.+=` which ties a `Disposable` to a `Lifetime`, is now part of the public API and is no longer deprecated.

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -42,9 +42,7 @@ internal struct UnsafeAtomicState<State: RawRepresentable> where State.RawValue 
 	/// - returns: `true` if the current state matches the expected state.
 	///            `false` otherwise.
 	internal func `is`(_ expected: State) -> Bool {
-		return OSAtomicCompareAndSwap32Barrier(expected.rawValue,
-		                                       expected.rawValue,
-		                                       value)
+		return expected.rawValue == value.pointee
 	}
 
 	/// Try to transition from the expected current state to the specified next
@@ -82,7 +80,7 @@ internal struct UnsafeAtomicState<State: RawRepresentable> where State.RawValue 
 	/// - returns: `true` if the current state matches the expected state.
 	///            `false` otherwise.
 	internal func `is`(_ expected: State) -> Bool {
-		return value.modify { $0 == expected.rawValue }
+		return value.value == expected.rawValue
 	}
 
 	/// Try to transition from the expected current state to the specified next

--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -38,6 +38,13 @@ extension UnsafeAtomicState where State == DisposableState {
 	}
 }
 
+internal final class NopDisposable: Disposable {
+	static let shared = NopDisposable()
+	var isDisposed = false
+	func dispose() {}
+	private init() {}
+}
+
 /// A type-erased disposable that forwards operations to an underlying disposable.
 public final class AnyDisposable: Disposable {
 	private final class ActionDisposable: Disposable {

--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -38,9 +38,27 @@ extension UnsafeAtomicState where State == DisposableState {
 	}
 }
 
+/// A disposable that does not have side effect upon disposal.
+internal final class _SimpleDisposable: Disposable {
+	private let state = UnsafeAtomicState<DisposableState>(.active)
+
+	var isDisposed: Bool {
+		return state.is(.disposed)
+	}
+
+	func dispose() {
+		_ = state.tryDispose()
+	}
+
+	deinit {
+		state.deinitialize()
+	}
+}
+
+/// A disposable that has already been disposed.
 internal final class NopDisposable: Disposable {
 	static let shared = NopDisposable()
-	var isDisposed = false
+	var isDisposed = true
 	func dispose() {}
 	private init() {}
 }

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -103,6 +103,26 @@ extension Signal {
 			}
 		}
 
+		internal func filterMap<U>(_ transform: (Value) -> U?) -> Signal<U, Error>.Event? {
+			switch self {
+			case let .value(value):
+				if let newValue = transform(value) {
+					return .value(newValue)
+				} else {
+					return nil
+				}
+
+			case .completed:
+				return .completed
+
+			case let .failed(error):
+				return .failed(error)
+
+			case .interrupted:
+				return .interrupted
+			}
+		}
+
 		/// Unwrap the contained `value` value.
 		public var value: Value? {
 			if case let .value(value) = self {

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -18,6 +18,24 @@ extension Signal {
 		/// Whether the observer should send an `interrupted` event as it deinitializes.
 		private let interruptsOnDeinit: Bool
 
+		/// The target observer of `self`.
+		private let wrapped: AnyObject?
+
+		/// An initializer that transforms the action of the given observer with the
+		/// given transform.
+		///
+		/// If the given observer would perform side effect on deinitialization, the
+		/// created observer would retain it.
+		///
+		/// - parameters:
+		///   - observer: The observer to transform.
+		///   - transform: The transform.
+		internal init<U, E: Swift.Error>(_ observer: Signal<U, E>.Observer, _ transform: @escaping (@escaping Signal<U, E>.Observer.Action) -> Action) {
+			self.action = transform(observer.action)
+			self.wrapped = observer.interruptsOnDeinit ? observer : nil
+			self.interruptsOnDeinit = false
+		}
+
 		/// An initializer that accepts a closure accepting an event for the
 		/// observer.
 		///
@@ -27,6 +45,7 @@ extension Signal {
 		///                         event as it deinitializes. `false` otherwise.
 		internal init(action: @escaping Action, interruptsOnDeinit: Bool) {
 			self.action = action
+			self.wrapped = nil
 			self.interruptsOnDeinit = interruptsOnDeinit
 		}
 
@@ -37,6 +56,7 @@ extension Signal {
 		///   - action: A closure to lift over received event.
 		public init(_ action: @escaping Action) {
 			self.action = action
+			self.wrapped = nil
 			self.interruptsOnDeinit = false
 		}
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -637,6 +637,16 @@ extension Signal {
 			}
 		}
 	}
+
+	internal func flatMapEvent<Events: Sequence>(_ transform: @escaping (Signal<Value, Error>.Event) -> Events) -> Signal<Events.Iterator.Element.Value, Events.Iterator.Element.Error> where Events.Iterator.Element: EventProtocol {
+		return Signal<Events.Iterator.Element.Value, Events.Iterator.Element.Error> { observer in
+			return self.observe { event in
+				for e in transform(event) {
+					observer.action(e.event)
+				}
+			}
+		}
+	}
 }
 
 extension Signal where Value: OptionalProtocol {

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -534,12 +534,21 @@ extension Signal {
 	///                returns a new value.
 	///
 	/// - returns: A signal that will send new values.
-	public func map<U>(_ transform: @escaping (Value) -> U) -> Signal<U, Error> {
-		return Signal<U, Error> { observer in
-			return self.observe { event in
-				observer.action(event.map(transform))
-			}
+	public func flatMapEvent<U, E>(_ transform: @escaping (@escaping Signal<U, E>.Observer.Action) -> (Event) -> Void) -> Signal<U, E> {
+		return Signal<U, E> { observer in
+			return self.observe(.init(observer, transform))
 		}
+	}
+
+	/// Map each value in the signal to a new value.
+	///
+	/// - parameters:
+	///   - transform: A closure that accepts a value from the `value` event and
+	///                returns a new value.
+	///
+	/// - returns: A signal that will send new values.
+	public func map<U>(_ transform: @escaping (Value) -> U) -> Signal<U, Error> {
+		return flatMapEvent(Signal.Event.map(transform))
 	}
 
 #if swift(>=3.2)
@@ -562,11 +571,7 @@ extension Signal {
 	///
 	/// - returns: A signal that will send new type of errors.
 	public func mapError<F>(_ transform: @escaping (Error) -> F) -> Signal<Value, F> {
-		return Signal<Value, F> { observer in
-			return self.observe { event in
-				observer.action(event.mapError(transform))
-			}
-		}
+		return flatMapEvent(Signal.Event.mapError(transform))
 	}
 
 	/// Maps each value in the signal to a new value, lazily evaluating the
@@ -599,18 +604,7 @@ extension Signal {
 	///
 	/// - returns: A signal that forwards the values passing the given closure.
 	public func filter(_ isIncluded: @escaping (Value) -> Bool) -> Signal<Value, Error> {
-		return Signal { observer in
-			return self.observe { (event: Event) -> Void in
-				guard let value = event.value else {
-					observer.action(event)
-					return
-				}
-
-				if isIncluded(value) {
-					observer.send(value: value)
-				}
-			}
-		}
+		return flatMapEvent(Signal.Event.filter(isIncluded))
 	}
 	
 	/// Applies `transform` to values from `signal` and forwards values with non `nil` results unwrapped.
@@ -620,32 +614,7 @@ extension Signal {
 	///
 	/// - returns: A signal that will send new values, that are non `nil` after the transformation.
 	public func filterMap<U>(_ transform: @escaping (Value) -> U?) -> Signal<U, Error> {
-		return Signal<U, Error> { observer in
-			return self.observe { (event: Event) -> Void in
-				switch event {
-				case let .value(value):
-					if let mapped = transform(value) {
-						observer.send(value: mapped)
-					}
-				case let .failed(error):
-					observer.send(error: error)
-				case .completed:
-					observer.sendCompleted()
-				case .interrupted:
-					observer.sendInterrupted()
-				}
-			}
-		}
-	}
-
-	internal func flatMapEvent<Events: Sequence>(_ transform: @escaping (Signal<Value, Error>.Event) -> Events) -> Signal<Events.Iterator.Element.Value, Events.Iterator.Element.Error> where Events.Iterator.Element: EventProtocol {
-		return Signal<Events.Iterator.Element.Value, Events.Iterator.Element.Error> { observer in
-			return self.observe { event in
-				for e in transform(event) {
-					observer.action(e.event)
-				}
-			}
-		}
+		return flatMapEvent(Signal.Event.filterMap(transform))
 	}
 }
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -527,14 +527,17 @@ extension Signal where Error == NoError {
 }
 
 extension Signal {
-	/// Map each value in the signal to a new value.
+	/// Perform an action upon every event from `self`. The action may generate zero or
+	/// more events.
+	///
+	/// - precondition: The action must be synchronous.
 	///
 	/// - parameters:
-	///   - transform: A closure that accepts a value from the `value` event and
-	///                returns a new value.
+	///   - transform: A closure that creates the said action from the given event
+	///                closure.
 	///
-	/// - returns: A signal that will send new values.
-	public func flatMapEvent<U, E>(_ transform: @escaping (@escaping Signal<U, E>.Observer.Action) -> (Event) -> Void) -> Signal<U, E> {
+	/// - returns: A signal that forwards events yielded by the action.
+	internal func flatMapEvent<U, E>(_ transform: @escaping (@escaping Signal<U, E>.Observer.Action) -> (Event) -> Void) -> Signal<U, E> {
 		return Signal<U, E> { observer in
 			return self.observe(.init(observer, transform))
 		}

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -213,10 +213,10 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	///            `Signal` commences. Both the produced `Signal` and an interrupt handle
 	///            of the signal would be passed to the closure.
 	public func startWithSignal(_ setup: (_ signal: Signal<Value, Error>, _ interruptHandle: Disposable) -> Void) {
-		let receipt = core.makeInstance()
-		setup(receipt.signal, receipt.interruptHandle)
-		guard !receipt.interruptHandle.isDisposed else { return }
-		receipt.observerDidSetup()
+		let instance = core.makeInstance()
+		setup(instance.signal, instance.interruptHandle)
+		guard !instance.interruptHandle.isDisposed else { return }
+		instance.observerDidSetup()
 	}
 }
 
@@ -596,10 +596,10 @@ extension SignalProducer {
 		return SignalProducer<U, F>(SignalCore {
 			// Transform the `Signal`, and pass through the `didCreate` side effect and
 			// the interruptHandle.
-			let receipt = self.core.makeInstance()
-			return .init(signal: transform(receipt.signal),
-			             observerDidSetup: receipt.observerDidSetup,
-			             interruptHandle: receipt.interruptHandle)
+			let instance = self.core.makeInstance()
+			return .init(signal: transform(instance.signal),
+			             observerDidSetup: instance.observerDidSetup,
+			             interruptHandle: instance.interruptHandle)
 		})
 	}
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -243,6 +243,16 @@ internal class SignalProducerCore<Value, Error: Swift.Error> {
 		return disposable
 	}
 
+	/// Perform an action upon every event from `self`. The action may generate zero or
+	/// more events.
+	///
+	/// - precondition: The action must be synchronous.
+	///
+	/// - parameters:
+	///   - transform: A closure that creates the said action from the given event
+	///                closure.
+	///
+	/// - returns: A producer that forwards events yielded by the action.
 	internal func flatMapEvent<U, E>(_ transform: @escaping (@escaping Signal<U, E>.Observer.Action) -> (Signal<Value, Error>.Event) -> Void) -> SignalProducer<U, E> {
 		return SignalProducer<U, E>(EventTransformingCore(source: self, transform: transform))
 	}


### PR DESCRIPTION
### Goals
Taking advantage of the deferred nature of `SignalProducer` to further reduce the overhead.

### TL;DR
1. Composing `SignalProducer` is going to be _way, way_ cheaper than composing `Signal`.

1. Constant `SignalProducer`s, e.g. `init(value:)` and sequence `init(_:)`, are going to do _significantly_ less work.

1. There is still a ~16x overhead over standard library `lazy` for purely collection manipulation. But given the type erasing and reactive (passive) nature of FRP/ReactiveSwift, there is probably very little stuff we can do about it. IOW optimizing for this is a non-goal. :)

![yeah](https://thumbs.gfycat.com/NecessaryIllinformedEnglishpointer-size_restricted.gif)

The actual speedup is subject to the new internal API adoption — unmigrated `SignalProducer` operators would still be relying on the conventional behavior and/or `lift`.

For example, if you do:

```swift
SignalProducer(Array(repeating: 1, count: 1000)).skipRepeats()
```

The performance remains the same as `master`, because `skipRepeats` hasn't been migrated yet.

### Introducing `SignalProducerCore`
`SignalProducerCore` is the new internal abstraction of `SignalProducer`. It has subsumed three major responsibilities from `SignalProducer`:

1. ~~the actual implementation of `startWithSignal`;~~
1. the actual implementation of `start` which accepts an `Signal.Observer`; and
1. the builder closure, now as `Core.make()`, which produces a `Signal` and the relevant context for composition and `startWithSignal`.

`SignalProducerCore` provides default implementations of all these capabilities for its subclasses, except for `Core.make()`.

_The cores are not nested in `SignalProducer` because the Swift 3.1 compiler would get stuck. The Swift 4 compiler has resolved the issue though._

### `SignalProducerCore` subclasses
#### `SignalCore`
This is the conventional `SignalProducer` with the `Signal` operator lifting optimisation in ReactiveSwift 2.0 (#140).

#### `EventTransformingCore`
`EventTransformingCore` composes _event transforms_, and is exposed as a new operator `Core.flatMapEvent` (internal for now).

It takes advantage of the deferred, single-observer nature of `SignalProducer`. For example, when we do:

```swift
upstream.map(transform).filterMap(filteringTransform).start()
```

It is contractually guaranteed that these operators would always end up producing a chain of streams, each with a **single and persistent** observer to its upstream. The multicasting & detaching capabilities of `Signal` is useless in these scenarios.

So `EventTransformingCore` builds on top of this very fact, and composes directly at the level of event transforms. This change implicitly nullifies #129, since producers no longer use `Signal` unless it absolutely has to.

It is intended for all synchronous `SignalProducer` operators. To encourage code reusing, the pilot operators have their implementation moved under `Signal.Event`, and `Signal` has gained `flatMapEvent` to use these `Event`-level operator implementations.

This represents a new type of `SignalProducer` that **does not use `Signal`** unless it is requested via `make()`.

##### Example
```swift
extension Signal {
	public func filterMap<U>(_ transform: @escaping (Value) -> U?) -> Signal<U, Error> {
		return flatMapEvent(Signal.Event. filterMap(transform))
	}
}

extension SignalProducer {
	public func filterMap<U>(_ transform: @escaping (Value) -> U?) -> SignalProducer<U, Error> {
		return core.flatMapEvent(Signal.Event. filterMap(transform))
	}
}
``` 

#### `EventGeneratingCore`
`EventGeneratingCore` wraps a generator closure that would be invoked when started. All the generator closure have are the observer and the cancel disposable.

It is intended for the constant `SignalProducer`s, as in #486, which synchronously emits all events.

It represents a new type of `SignalProducer` that **does not use `Signal`** unless it is requested via `make()`.

### Pilot public APIs

1. `map`, `mapError`, `filter` and `filterMap`.

1. Various `SignalProducer.init` overloads that accept a constant.

### Results

| Test | Sequence<br>(32 items) | Value | SequenceMapFilter |
| --- | --- | --- | --- |
| `master` | avg 30296 ns<br>min 26426 ns | avg 8910 ns<br>min 8171 ns | avg 61555 ns<br>min 50378 ns |
| This PR | avg 14073 ns<br>min 13079 ns | avg 839 ns<br>min 739 ns | avg 8304 ns<br>min 7198 ns | 
| Speedup | ~2.15x | ~10.5x | ~7.5x |
| `master`<br>WMO | avg 29333 ns<br>min 26136 ns | avg 8613 ns<br>min 7169 ns  | 31340 ns<br>min 27497 ns  |
| This PR<br>WMO | avg 13591 ns<br>min 11382 ns | avg 388 ns<br>min 325 ns | avg 5923 ns<br>min 5002 ns |
| Speedup<br >WMO | ~2.15x | ~22.00x | ~5.29x |

[Benchmark Source](https://gist.github.com/andersio/1aae47e6e9173b5dc6e8609356668ec1)

#### Checklist
- [ ] Updated CHANGELOG.md.