### PR TITLE
Correct some Linux-specific build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,8 @@ jobs:
       env:
         - JOB=SWIFTPM_DARWIN
     - osx_image: xcode9
+      before_install:
+        - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
       script:
         - swift --version
         - swift build
@@ -92,6 +94,7 @@ jobs:
         submodules: false
       env:
         - JOB=SWIFT_4
+        - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2017-07-13-a
     - os: linux
       language: generic
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,21 @@ jobs:
       git:
         submodules: false
       env: JOB=SWIFTPM_LINUX
+    - os: linux
+      language: generic
+      sudo: required
+      dist: trusty
+      before_install:
+        - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+      script:
+        - swift --version
+        - swift build
+        - SWIFTPM_TEST_ReactiveSwift=YES swift test
+      git:
+        submodules: false
+      env: 
+        - JOB=SWIFTPM_SWIFT_4_LINUX
+        - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2017-07-13-a
     - stage: prepare carthage cache
       script: carthage build --cache-builds
     - stage: carthage

--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -87,7 +87,7 @@ extension Date {
 
 extension DispatchTimeInterval {
 	internal var timeInterval: TimeInterval {
-		#if swift(>=3.2)
+		#if swift(>=3.2) && !os(Linux)
 			switch self {
 			case let .seconds(s):
 				return TimeInterval(s)
@@ -117,7 +117,7 @@ extension DispatchTimeInterval {
 	// This was added purely so that our test scheduler to "go backwards" in
 	// time. See `TestScheduler.rewind(by interval: DispatchTimeInterval)`.
 	internal static prefix func -(lhs: DispatchTimeInterval) -> DispatchTimeInterval {
-		#if swift(>=3.2)
+		#if swift(>=3.2) && !os(Linux)
 			switch lhs {
 			case let .seconds(s):
 				return .seconds(-s)

--- a/Tests/ReactiveSwiftTests/FoundationExtensionsSpec.swift
+++ b/Tests/ReactiveSwiftTests/FoundationExtensionsSpec.swift
@@ -103,7 +103,7 @@ class FoundationExtensionsSpec: QuickSpec {
 
 				expect(DispatchTimeInterval.milliseconds(500).timeInterval).to(beCloseTo(0.5))
 				expect(DispatchTimeInterval.milliseconds(250).timeInterval).to(beCloseTo(0.25))
-				#if swift(>=3.2)
+				#if swift(>=3.2) && !os(Linux)
 					expect(DispatchTimeInterval.never.timeInterval) == Double.infinity
 				#endif
 			}
@@ -113,7 +113,7 @@ class FoundationExtensionsSpec: QuickSpec {
 				expect((-DispatchTimeInterval.milliseconds(1)).timeInterval).to(beCloseTo(-0.001))
 				expect((-DispatchTimeInterval.microseconds(1)).timeInterval).to(beCloseTo(-0.000001, within: 0.0000001))
 				expect((-DispatchTimeInterval.nanoseconds(1)).timeInterval).to(beCloseTo(-0.000000001, within: 0.0000000001))
-				#if swift(>=3.2)
+				#if swift(>=3.2) && !os(Linux)
 					expect((-DispatchTimeInterval.never).timeInterval) == Double.infinity
 				#endif
 			}


### PR DESCRIPTION
While working on a server-side project I noticed that neither of the latest 1.1.x or 2.x releases would build for me on Linux with the latest 4.x snapshots (2017-07-11 and 2017-07-13 as of this writing). Turns out the `DispatchTimeInterval` enum change isn't available there (yet?)

I'd like to think that this will be unnecessary in a future Swift snapshot on Linux, but perhaps it's worth integrating this small fix so that the release candidates aren't busted until that happens.