### PR TITLE
Add `SignalProducer.init` overloads for `NoError`

### DIFF
--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -250,23 +250,6 @@ extension SignalProducer where Error == NoError {
 		}
 	}
 
-	/// Creates a producer for a `Signal` that immediately sends one value, then
-	/// completes.
-	///
-	/// This initializer differs from `init(value:)` in that its sole `value`
-	/// event is constructed lazily by invoking the supplied `action` when
-	/// the `SignalProducer` is started.
-	///
-	/// - parameters:
-	///   - action: A action that yields a value to be sent by the `Signal` as
-	///             a `value` event.
-	public init(_ action: @escaping () -> Value) {
-		self.init { observer, _ in
-			observer.send(value: action())
-			observer.sendCompleted()
-		}
-	}
-
 	/// Creates a producer for a Signal that will immediately send the values
 	/// from the given sequence, then complete.
 	///

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -236,6 +236,69 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	}
 }
 
+extension SignalProducer where Error == NoError {
+	/// Creates a producer for a `Signal` that will immediately send one value
+	/// then complete.
+	///
+	/// - parameters:
+	///   - value: A value that should be sent by the `Signal` in a `value`
+	///            event.
+	public init(value: Value) {
+		self.init { observer, _ in
+			observer.send(value: value)
+			observer.sendCompleted()
+		}
+	}
+
+	/// Creates a producer for a `Signal` that immediately sends one value, then
+	/// completes.
+	///
+	/// This initializer differs from `init(value:)` in that its sole `value`
+	/// event is constructed lazily by invoking the supplied `action` when
+	/// the `SignalProducer` is started.
+	///
+	/// - parameters:
+	///   - action: A action that yields a value to be sent by the `Signal` as
+	///             a `value` event.
+	public init(_ action: @escaping () -> Value) {
+		self.init { observer, _ in
+			observer.send(value: action())
+			observer.sendCompleted()
+		}
+	}
+
+	/// Creates a producer for a Signal that will immediately send the values
+	/// from the given sequence, then complete.
+	///
+	/// - parameters:
+	///   - values: A sequence of values that a `Signal` will send as separate
+	///             `value` events and then complete.
+	public init<S: Sequence>(_ values: S) where S.Iterator.Element == Value {
+		self.init { observer, lifetime in
+			for value in values {
+				observer.send(value: value)
+
+				if lifetime.hasEnded {
+					break
+				}
+			}
+
+			observer.sendCompleted()
+		}
+	}
+
+	/// Creates a producer for a Signal that will immediately send the values
+	/// from the given sequence, then complete.
+	///
+	/// - parameters:
+	///   - first: First value for the `Signal` to send.
+	///   - second: Second value for the `Signal` to send.
+	///   - tail: Rest of the values to be sent by the `Signal`.
+	public init(values first: Value, _ second: Value, _ tail: Value...) {
+		self.init([ first, second ] + tail)
+	}
+}
+
 extension SignalProducer where Error == AnyError {
 	/// Create a `SignalProducer` that will attempt the given failable operation once for
 	/// each invocation of `start()`.

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -229,11 +229,12 @@ class SignalProducerSpec: QuickSpec {
 				let resultAction2: () -> Result<String, AnyError> = { .success("") }
 				let throwableResultAction: () throws -> Result<String, NoError> = { .success("") }
 
-				expect(type(of: SignalProducer(action))) == SignalProducer<String, NoError>.self
-				expect(type(of: SignalProducer<String, AnyError>(action))) == SignalProducer<String, AnyError>.self
+				expect(type(of: SignalProducer(action))) == SignalProducer<String, AnyError>.self
+				expect(type(of: SignalProducer<String, NoError>(action))) == SignalProducer<String, NoError>.self
+				expect(type(of: SignalProducer<String, TestError>(action))) == SignalProducer<String, TestError>.self
 
-				expect(type(of: SignalProducer<String, NoError>(resultAction1))) == SignalProducer<String, NoError>.self
-				expect(type(of: SignalProducer<String, AnyError>(resultAction2))) == SignalProducer<String, AnyError>.self
+				expect(type(of: SignalProducer(resultAction1))) == SignalProducer<String, NoError>.self
+				expect(type(of: SignalProducer(resultAction2))) == SignalProducer<String, AnyError>.self
 
 				expect(type(of: SignalProducer(throwableAction))) == SignalProducer<String, AnyError>.self
 				expect(type(of: SignalProducer(throwableResultAction))) == SignalProducer<Result<String, NoError>, AnyError>.self
@@ -366,8 +367,8 @@ class SignalProducerSpec: QuickSpec {
 					return .success("OperationValue")
 				}
 
-				SignalProducer<String, NSError>(operation).start()
-				SignalProducer<String, NSError>(operation).start()
+				SignalProducer(operation).start()
+				SignalProducer(operation).start()
 
 				expect(operationRunTimes) == 2
 			}
@@ -378,7 +379,7 @@ class SignalProducerSpec: QuickSpec {
 					return .success(operationReturnValue)
 				}
 
-				let signalProducer = SignalProducer<String, NSError>(operation)
+				let signalProducer = SignalProducer(operation)
 
 				expect(signalProducer).to(sendValue(operationReturnValue, sendError: nil, complete: true))
 			}
@@ -389,7 +390,7 @@ class SignalProducerSpec: QuickSpec {
 					return .failure(operationError)
 				}
 
-				let signalProducer = SignalProducer<String, NSError>(operation)
+				let signalProducer = SignalProducer(operation)
 
 				expect(signalProducer).to(sendValue(nil, sendError: operationError, complete: false))
 			}

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -229,12 +229,11 @@ class SignalProducerSpec: QuickSpec {
 				let resultAction2: () -> Result<String, AnyError> = { .success("") }
 				let throwableResultAction: () throws -> Result<String, NoError> = { .success("") }
 
-				expect(type(of: SignalProducer(action))) == SignalProducer<String, AnyError>.self
-				expect(type(of: SignalProducer<String, NoError>(action))) == SignalProducer<String, NoError>.self
-				expect(type(of: SignalProducer<String, TestError>(action))) == SignalProducer<String, TestError>.self
+				expect(type(of: SignalProducer(action))) == SignalProducer<String, NoError>.self
+				expect(type(of: SignalProducer<String, AnyError>(action))) == SignalProducer<String, AnyError>.self
 
-				expect(type(of: SignalProducer(resultAction1))) == SignalProducer<String, NoError>.self
-				expect(type(of: SignalProducer(resultAction2))) == SignalProducer<String, AnyError>.self
+				expect(type(of: SignalProducer<String, NoError>(resultAction1))) == SignalProducer<String, NoError>.self
+				expect(type(of: SignalProducer<String, AnyError>(resultAction2))) == SignalProducer<String, AnyError>.self
 
 				expect(type(of: SignalProducer(throwableAction))) == SignalProducer<String, AnyError>.self
 				expect(type(of: SignalProducer(throwableResultAction))) == SignalProducer<Result<String, NoError>, AnyError>.self
@@ -367,8 +366,8 @@ class SignalProducerSpec: QuickSpec {
 					return .success("OperationValue")
 				}
 
-				SignalProducer(operation).start()
-				SignalProducer(operation).start()
+				SignalProducer<String, NSError>(operation).start()
+				SignalProducer<String, NSError>(operation).start()
 
 				expect(operationRunTimes) == 2
 			}
@@ -379,7 +378,7 @@ class SignalProducerSpec: QuickSpec {
 					return .success(operationReturnValue)
 				}
 
-				let signalProducer = SignalProducer(operation)
+				let signalProducer = SignalProducer<String, NSError>(operation)
 
 				expect(signalProducer).to(sendValue(operationReturnValue, sendError: nil, complete: true))
 			}
@@ -390,7 +389,7 @@ class SignalProducerSpec: QuickSpec {
 					return .failure(operationError)
 				}
 
-				let signalProducer = SignalProducer(operation)
+				let signalProducer = SignalProducer<String, NSError>(operation)
 
 				expect(signalProducer).to(sendValue(nil, sendError: operationError, complete: false))
 			}
@@ -400,7 +399,7 @@ class SignalProducerSpec: QuickSpec {
 			it("should send a successful value then complete") {
 				let operationReturnValue = "OperationValue"
 
-				let signalProducer = SignalProducer { () throws -> String in
+				let signalProducer = SignalProducer<String, AnyError> { () throws -> String in
 					operationReturnValue
 				}
 
@@ -415,7 +414,7 @@ class SignalProducerSpec: QuickSpec {
 			it("should send the error") {
 				let operationError = TestError.default
 
-				let signalProducer = SignalProducer { () throws -> String in
+				let signalProducer = SignalProducer<String, AnyError> { () throws -> String in
 					throw operationError
 				}
 


### PR DESCRIPTION
See https://github.com/Carthage/Carthage/pull/2077#discussion_r129483994 and https://github.com/Carthage/Carthage/pull/2077#discussion_r129484077.

#### Checklist
- ~~[ ] Updated CHANGELOG.md.~~
