### PR TITLE
Framework Overview

### DIFF
--- a/Documentation/FrameworkOverview.md
+++ b/Documentation/FrameworkOverview.md
@@ -194,7 +194,7 @@ For more information about cancellation, see the RAC [Design Guidelines][].
 
 ## Schedulers
 
-A **scheduler**, represented by the [`SchedulerProtocol`][Scheduler] protocol, is a
+A **scheduler**, represented by the [`Scheduler`][Scheduler] protocol, is a
 serial execution queue to perform work or deliver results upon.
 
 [Signals](#signals) and [signal producers](#signal-producers) can be ordered to


### PR DESCRIPTION
Scheduler Protocol is now just called `Scheduler` instead of `SchedulerProtocol`: https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/Scheduler.swift#L17

#### Checklist
- [ ] Updated CHANGELOG.md.