### PR TITLE
Improve TransformerCore and move `take(first:)`.

### DIFF
--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -180,7 +180,9 @@ extension Signal.Event: EventProtocol {
 }
 
 extension Signal.Event {
-	internal static func filter(_ isIncluded: @escaping (Value) -> Bool) -> (@escaping Signal<Value, Error>.Observer.Action) -> (Signal<Value, Error>.Event) -> Void {
+	internal typealias Transformation<U, E: Swift.Error> = (@escaping Signal<U, E>.Observer.Action) -> (Signal<Value, Error>.Event) -> Void
+
+	internal static func filter(_ isIncluded: @escaping (Value) -> Bool) -> Transformation<Value, Error> {
 		return { action in
 			return { event in
 				switch event {
@@ -202,7 +204,7 @@ extension Signal.Event {
 		}
 	}
 
-	internal static func filterMap<U>(_ transform: @escaping (Value) -> U?) -> (@escaping Signal<U, Error>.Observer.Action) -> (Signal<Value, Error>.Event) -> Void {
+	internal static func filterMap<U>(_ transform: @escaping (Value) -> U?) -> Transformation<U, Error> {
 		return { action in
 			return { event in
 				switch event {
@@ -224,7 +226,7 @@ extension Signal.Event {
 		}
 	}
 
-	internal static func map<U>(_ transform: @escaping (Value) -> U) -> (@escaping Signal<U, Error>.Observer.Action) -> (Signal<Value, Error>.Event) -> Void {
+	internal static func map<U>(_ transform: @escaping (Value) -> U) -> Transformation<U, Error> {
 		return { action in
 			return { event in
 				switch event {
@@ -244,7 +246,7 @@ extension Signal.Event {
 		}
 	}
 
-	internal static func mapError<E>(_ transform: @escaping (Error) -> E) -> (@escaping Signal<Value, E>.Observer.Action) -> (Signal<Value, Error>.Event) -> Void {
+	internal static func mapError<E>(_ transform: @escaping (Error) -> E) -> Transformation<Value, E> {
 		return { action in
 			return { event in
 				switch event {
@@ -264,7 +266,7 @@ extension Signal.Event {
 		}
 	}
 
-	internal static func take(first count: Int) -> (@escaping Signal<Value, Error>.Observer.Action) -> (Signal<Value, Error>.Event) -> Void {
+	internal static func take(first count: Int) -> Transformation<Value, Error> {
 		assert(count >= 1)
 
 		return { action in

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -263,4 +263,28 @@ extension Signal.Event {
 			}
 		}
 	}
+
+	internal static func take(first count: Int) -> (@escaping Signal<Value, Error>.Observer.Action) -> (Signal<Value, Error>.Event) -> Void {
+		assert(count >= 1)
+
+		return { action in
+			var taken = 0
+
+			return { event in
+				guard let value = event.value else {
+					action(event)
+					return
+				}
+
+				if taken < count {
+					taken += 1
+					action(.value(value))
+				}
+
+				if taken == count {
+					action(.completed)
+				}
+			}
+		}
+	}
 }

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -30,8 +30,27 @@ extension Signal {
 		/// - parameters:
 		///   - observer: The observer to transform.
 		///   - transform: The transform.
-		internal init<U, E: Swift.Error>(_ observer: Signal<U, E>.Observer, _ transform: @escaping (@escaping Signal<U, E>.Observer.Action) -> Action) {
-			self.action = transform(observer.action)
+		///   - disposable: The disposable to be disposed of when the transformation
+		///                 yields any terminal event that is not originated from the
+		///                 upstream.
+		internal init<U, E: Swift.Error>(
+			_ observer: Signal<U, E>.Observer,
+			_ transform: @escaping (@escaping Signal<U, E>.Observer.Action) -> Action,
+			_ disposable: Disposable
+		) {
+			var hasDeliveredTerminalEvent = false
+
+			self.action = transform { event in
+				if !hasDeliveredTerminalEvent {
+					observer.action(event)
+
+					if event.isTerminating {
+						hasDeliveredTerminalEvent = true
+						disposable.dispose()
+					}
+				}
+			}
+
 			self.wrapped = observer.interruptsOnDeinit ? observer : nil
 			self.interruptsOnDeinit = false
 		}

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -35,7 +35,7 @@ extension Signal {
 		///                 upstream.
 		internal init<U, E: Swift.Error>(
 			_ observer: Signal<U, E>.Observer,
-			_ transform: @escaping (@escaping Signal<U, E>.Observer.Action) -> Action,
+			_ transform: @escaping Event.Transformation<U, E>,
 			_ disposable: Disposable
 		) {
 			var hasDeliveredTerminalEvent = false

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -30,13 +30,13 @@ extension Signal {
 		/// - parameters:
 		///   - observer: The observer to transform.
 		///   - transform: The transform.
-		///   - disposable: The disposable to be disposed of when the transformation
-		///                 yields any terminal event that is not originated from the
-		///                 upstream.
+		///   - disposable: The disposable to be disposed of when the `TransformerCore`
+		///                 yields any terminal event. If `observer` is a `Signal` input
+		///                 observer, this can be omitted.
 		internal init<U, E: Swift.Error>(
 			_ observer: Signal<U, E>.Observer,
 			_ transform: @escaping Event.Transformation<U, E>,
-			_ disposable: Disposable
+			_ disposable: Disposable? = nil
 		) {
 			var hasDeliveredTerminalEvent = false
 
@@ -46,7 +46,7 @@ extension Signal {
 
 					if event.isTerminating {
 						hasDeliveredTerminalEvent = true
-						disposable.dispose()
+						disposable?.dispose()
 					}
 				}
 			}

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -537,7 +537,7 @@ extension Signal {
 	///                closure.
 	///
 	/// - returns: A signal that forwards events yielded by the action.
-	internal func flatMapEvent<U, E>(_ transform: @escaping (@escaping Signal<U, E>.Observer.Action) -> (Event) -> Void) -> Signal<U, E> {
+	internal func flatMapEvent<U, E>(_ transform: @escaping Event.Transformation<U, E>) -> Signal<U, E> {
 		return Signal<U, E> { observer in
 			return self.observe(.init(observer, transform, NopDisposable.shared))
 		}

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -539,7 +539,7 @@ extension Signal {
 	/// - returns: A signal that forwards events yielded by the action.
 	internal func flatMapEvent<U, E>(_ transform: @escaping Event.Transformation<U, E>) -> Signal<U, E> {
 		return Signal<U, E> { observer in
-			return self.observe(.init(observer, transform, NopDisposable.shared))
+			return self.observe(Signal.Observer(observer, transform))
 		}
 	}
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -539,7 +539,7 @@ extension Signal {
 	/// - returns: A signal that forwards events yielded by the action.
 	internal func flatMapEvent<U, E>(_ transform: @escaping (@escaping Signal<U, E>.Observer.Action) -> (Event) -> Void) -> Signal<U, E> {
 		return Signal<U, E> { observer in
-			return self.observe(.init(observer, transform))
+			return self.observe(.init(observer, transform, NopDisposable.shared))
 		}
 	}
 
@@ -642,31 +642,8 @@ extension Signal {
 	/// - returns: A signal that will yield the first `count` values from `self`
 	public func take(first count: Int) -> Signal<Value, Error> {
 		precondition(count >= 0)
-
-		return Signal { observer in
-			if count == 0 {
-				observer.sendCompleted()
-				return nil
-			}
-
-			var taken = 0
-
-			return self.observe { event in
-				guard let value = event.value else {
-					observer.action(event)
-					return
-				}
-
-				if taken < count {
-					taken += 1
-					observer.send(value: value)
-				}
-
-				if taken == count {
-					observer.sendCompleted()
-				}
-			}
-		}
+		guard count >= 1 else { return .empty }
+		return flatMapEvent(Signal.Event.take(first: count))
 	}
 }
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -336,7 +336,7 @@ private final class TransformerCore<Value, Error: Swift.Error, SourceValue, Sour
 	internal override func makeInstance() -> Instance {
 		let product = source.makeInstance()
 		let signal = Signal<Value, Error> { observer in
-			return product.signal.observe(.init(observer, transform, product.interruptHandle))
+			return product.signal.observe(Signal.Observer(observer, transform))
 		}
 
 		return Instance(signal: signal,


### PR DESCRIPTION
The requirement of `SignalProducerCore.start` has been changed slightly, so as to support `TransformerCore` yielding terminal events from value events.

It intercepts the output of the combined event transformation to:

1. interrupt the upstream when appropriate; and
2. ensure only one terminal event would ever be delivered.

The overhead should be per block of contiguous applications of `TransformerCore` operators.

### Example
Using `master` for this new `take(first:)` (#487) causes the `SignalProducer.repeat` test case to fail with stack overflow.

```swift
SignalProducer<Int, NoError>(value: 1)
    .repeat(.max)
    .take(first: 1)
    .start()
```

This is because the `TransformerCore` implementation in `master` is not designed in mind with transformations that could yield terminal events. So even if `take(first: 1)` yields a `completed` as it receives the first value event, the upstream is not interrupted.

#### Checklist
- ~~Updated CHANGELOG.md.~~