### PR TITLE
Fixed a pthread issue in 32-bit ARM debug builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. Workaround an unexpected EGAGIN error being returned by pthread in 32-bit ARM debug builds. (#508)
+
 1. The `SignalProducer` internals have undergone a significant refactoring, which bootstraps the effort to reduce the overhead of constant producers and producer compositions. (#487, kudos to @andersio)
 
 # 2.0.1

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -155,7 +155,9 @@ internal class Lock {
 				attr.deallocate(capacity: 1)
 			}
 
-			#if DEBUG
+			// Darwin pthread for 32-bit ARM somehow returns `EAGAIN` when
+			// using `trylock` on a `PTHREAD_MUTEX_ERRORCHECK` mutex.
+			#if DEBUG && !arch(arm)
 			pthread_mutexattr_settype(attr, Int32(recursive ? PTHREAD_MUTEX_RECURSIVE : PTHREAD_MUTEX_ERRORCHECK))
 			#else
 			pthread_mutexattr_settype(attr, Int32(recursive ? PTHREAD_MUTEX_RECURSIVE : PTHREAD_MUTEX_NORMAL))


### PR DESCRIPTION
https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3507

`pthread_mutex_trylock` somehow returns `EAGAIN` on 32-bit ARM devices when the mutex is configured to be error checking. It should either succeed or return `EBUSY` according to the documentation.

#### Checklist
- [x] Updated CHANGELOG.md.
