### PR TITLE
Replace `Observer.action` with `Observer.send`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. `Signal.Observer.action` has been deprecated. Use `Signal.Observer.send` instead. (#515)
+
 1. Workaround an unexpected EGAGIN error being returned by pthread in 32-bit ARM debug builds. (#508)
 
 1. The `SignalProducer` internals have undergone a significant refactoring, which bootstraps the effort to reduce the overhead of constant producers and producer compositions. (#487, kudos to @andersio)

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -161,7 +161,7 @@ public final class Action<Input, Output, Error: Swift.Error> {
 				}
 
 				let interruptHandle = execute(state, input).start { event in
-					observer.action(event.mapError(ActionError.producerFailed))
+					observer.send(event.mapError(ActionError.producerFailed))
 					action.eventsObserver.send(value: event)
 				}
 

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -329,7 +329,7 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 							}
 
 						case .value, .failed:
-							observer.action(event)
+							observer.send(event)
 						}
 					}
 				}
@@ -592,7 +592,7 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 							}
 
 						case .value, .failed:
-							observer.action(event)
+							observer.send(event)
 						}
 					}
 				}
@@ -720,7 +720,7 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 							}
 
 						case .value, .failed, .interrupted:
-							observer.action(event)
+							observer.send(event)
 						}
 					}
 				}

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -11,9 +11,16 @@ extension Signal {
 	/// (typically from a Signal).
 	public final class Observer {
 		public typealias Action = (Event) -> Void
+		private let _action: Action
 
 		/// An action that will be performed upon arrival of the event.
-		public let action: Action
+		@available(*, deprecated: 2.0, renamed:"send(_:)")
+		public var action: Action {
+			guard !interruptsOnDeinit && wrapped == nil else {
+				return { self._action($0) }
+			}
+			return _action
+		}
 
 		/// Whether the observer should send an `interrupted` event as it deinitializes.
 		private let interruptsOnDeinit: Bool
@@ -40,9 +47,9 @@ extension Signal {
 		) {
 			var hasDeliveredTerminalEvent = false
 
-			self.action = transform { event in
+			self._action = transform { event in
 				if !hasDeliveredTerminalEvent {
-					observer.action(event)
+					observer._action(event)
 
 					if event.isTerminating {
 						hasDeliveredTerminalEvent = true
@@ -63,7 +70,7 @@ extension Signal {
 		///   - interruptsOnDeinit: `true` if the observer should send an `interrupted`
 		///                         event as it deinitializes. `false` otherwise.
 		internal init(action: @escaping Action, interruptsOnDeinit: Bool) {
-			self.action = action
+			self._action = action
 			self.wrapped = nil
 			self.interruptsOnDeinit = interruptsOnDeinit
 		}
@@ -74,7 +81,7 @@ extension Signal {
 		/// - parameters:
 		///   - action: A closure to lift over received event.
 		public init(_ action: @escaping Action) {
-			self.action = action
+			self._action = action
 			self.wrapped = nil
 			self.interruptsOnDeinit = false
 		}
@@ -128,8 +135,13 @@ extension Signal {
 				// Since `Signal` would ensure that only one terminal event would ever be
 				// sent for any given `Signal`, we do not need to assert any condition
 				// here.
-				action(.interrupted)
+				_action(.interrupted)
 			}
+		}
+
+		/// Puts an event into `self`.
+		public func send(_ event: Event) {
+			_action(event)
 		}
 
 		/// Puts a `value` event into `self`.
@@ -137,7 +149,7 @@ extension Signal {
 		/// - parameters:
 		///   - value: A value sent with the `value` event.
 		public func send(value: Value) {
-			action(.value(value))
+			_action(.value(value))
 		}
 
 		/// Puts a failed event into `self`.
@@ -145,17 +157,17 @@ extension Signal {
 		/// - parameters:
 		///   - error: An error object sent with failed event.
 		public func send(error: Error) {
-			action(.failed(error))
+			_action(.failed(error))
 		}
 
 		/// Puts a `completed` event into `self`.
 		public func sendCompleted() {
-			action(.completed)
+			_action(.completed)
 		}
 
 		/// Puts an `interrupted` event into `self`.
 		public func sendInterrupted() {
-			action(.interrupted)
+			_action(.interrupted)
 		}
 	}
 }

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -11,15 +11,15 @@ extension Signal {
 	/// (typically from a Signal).
 	public final class Observer {
 		public typealias Action = (Event) -> Void
-		private let _action: Action
+		private let _send: Action
 
 		/// An action that will be performed upon arrival of the event.
 		@available(*, deprecated: 2.0, renamed:"send(_:)")
 		public var action: Action {
 			guard !interruptsOnDeinit && wrapped == nil else {
-				return { self._action($0) }
+				return { self._send($0) }
 			}
-			return _action
+			return _send
 		}
 
 		/// Whether the observer should send an `interrupted` event as it deinitializes.
@@ -47,9 +47,9 @@ extension Signal {
 		) {
 			var hasDeliveredTerminalEvent = false
 
-			self._action = transform { event in
+			self._send = transform { event in
 				if !hasDeliveredTerminalEvent {
-					observer._action(event)
+					observer._send(event)
 
 					if event.isTerminating {
 						hasDeliveredTerminalEvent = true
@@ -70,7 +70,7 @@ extension Signal {
 		///   - interruptsOnDeinit: `true` if the observer should send an `interrupted`
 		///                         event as it deinitializes. `false` otherwise.
 		internal init(action: @escaping Action, interruptsOnDeinit: Bool) {
-			self._action = action
+			self._send = action
 			self.wrapped = nil
 			self.interruptsOnDeinit = interruptsOnDeinit
 		}
@@ -81,7 +81,7 @@ extension Signal {
 		/// - parameters:
 		///   - action: A closure to lift over received event.
 		public init(_ action: @escaping Action) {
-			self._action = action
+			self._send = action
 			self.wrapped = nil
 			self.interruptsOnDeinit = false
 		}
@@ -135,13 +135,13 @@ extension Signal {
 				// Since `Signal` would ensure that only one terminal event would ever be
 				// sent for any given `Signal`, we do not need to assert any condition
 				// here.
-				_action(.interrupted)
+				_send(.interrupted)
 			}
 		}
 
 		/// Puts an event into `self`.
 		public func send(_ event: Event) {
-			_action(event)
+			_send(event)
 		}
 
 		/// Puts a `value` event into `self`.
@@ -149,7 +149,7 @@ extension Signal {
 		/// - parameters:
 		///   - value: A value sent with the `value` event.
 		public func send(value: Value) {
-			_action(.value(value))
+			_send(.value(value))
 		}
 
 		/// Puts a failed event into `self`.
@@ -157,17 +157,17 @@ extension Signal {
 		/// - parameters:
 		///   - error: An error object sent with failed event.
 		public func send(error: Error) {
-			_action(.failed(error))
+			_send(.failed(error))
 		}
 
 		/// Puts a `completed` event into `self`.
 		public func sendCompleted() {
-			_action(.completed)
+			_send(.completed)
 		}
 
 		/// Puts an `interrupted` event into `self`.
 		public func sendInterrupted() {
-			_action(.interrupted)
+			_send(.interrupted)
 		}
 	}
 }

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -123,7 +123,7 @@ extension Signal {
 			self.init { event in
 				switch event {
 				case .value, .completed, .failed:
-					observer.action(event)
+					observer.send(event)
 				case .interrupted:
 					observer.sendCompleted()
 				}

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -553,7 +553,7 @@ public final class Property<Value>: PropertyProtocol {
 				guard let box = box else {
 					// Just forward the event, since no one owns the box or IOW no demand
 					// for a cached latest value.
-					return observer.action(event)
+					return observer.send(event)
 				}
 
 				box.begin { storage in
@@ -562,7 +562,7 @@ public final class Property<Value>: PropertyProtocol {
 							value = newValue
 						}
 					}
-					observer.action(event)
+					observer.send(event)
 				}
 			}
 		}

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -112,7 +112,7 @@ public final class Signal<Value, Error: Swift.Error> {
 					self.stateLock.unlock()
 
 					for observer in observers {
-						observer.action(event)
+						observer.send(event)
 					}
 				} else {
 					self.stateLock.unlock()
@@ -219,7 +219,7 @@ public final class Signal<Value, Error: Swift.Error> {
 
 					if let event = terminationKind.materialize() {
 						for observer in observers {
-							observer.action(event)
+							observer.send(event)
 						}
 					}
 
@@ -902,7 +902,7 @@ extension Signal {
 					terminated?()
 				}
 
-				observer.action(receivedEvent)
+				observer.send(receivedEvent)
 			}
 
 			return disposable
@@ -1312,14 +1312,14 @@ extension Signal {
 					break
 
 				case .value, .failed, .interrupted:
-					observer.action(event)
+					observer.send(event)
 				}
 			}
 
 			disposable += signalDisposable
 			disposable += signal.observe { event in
 				signalDisposable?.dispose()
-				observer.action(event)
+				observer.send(event)
 			}
 
 			return disposable
@@ -1405,7 +1405,7 @@ extension Signal {
 			disposable += self.observe { event in
 				guard let value = event.value else {
 					schedulerDisposable.inner = scheduler.schedule {
-						observer.action(event)
+						observer.send(event)
 					}
 					return
 				}
@@ -1533,7 +1533,7 @@ extension Signal {
 
 				if let event = eventToSend {
 					schedulerDisposable.inner = scheduler.schedule {
-						observer.action(event)
+						observer.send(event)
 					}
 				}
 			}
@@ -1584,7 +1584,7 @@ extension Signal {
 
 				case .completed, .failed, .interrupted:
 					d.inner = scheduler.schedule {
-						observer.action(event)
+						observer.send(event)
 					}
 				}
 			}
@@ -1869,7 +1869,7 @@ extension Signal {
 			}
 
 			for (index, action) in builder.startHandlers.enumerated() where !disposables.isDisposed {
-				disposables += action(index, strategy) { observer.action($0.map { _ in fatalError() }) }
+				disposables += action(index, strategy) { observer.send($0.map { _ in fatalError() }) }
 			}
 
 			return disposables

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1978,7 +1978,7 @@ extension SignalProducer {
 								observer.sendCompleted()
 							}
 						} else {
-							observer.action(event)
+							observer.send(event)
 						}
 					}
 				}
@@ -2271,7 +2271,7 @@ extension SignalProducer {
 						defer { state.enqueue(event) }
 						return state.observers
 					}
-					observers?.forEach { $0.action(event) }
+					observers?.forEach { $0.send(event) }
 				}
 		}
 
@@ -2420,7 +2420,7 @@ private struct ReplayState<Value, Error: Swift.Error> {
 		}
 
 		if let event = terminationEvent {
-			observer.action(event)
+			observer.send(event)
 		}
 
 		return .success(observers?.insert(observer))

--- a/Tests/ReactiveSwiftTests/SignalLifetimeSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalLifetimeSpec.swift
@@ -481,7 +481,7 @@ class SignalLifetimeSpec: QuickSpec {
 private extension Signal {
 	func testTransform() -> Signal<Value, Error> {
 		return Signal { observer in
-			return self.observe(observer.action)
+			return self.observe(observer.send)
 		}
 	}
 }


### PR DESCRIPTION
`Signal.Observer.action` does not capture the `Signal.Observer` it derived from. This might cause issues with `Signal` inputs and transformed observer, since these rely on the lifetime of the `Signal.Observer`. This also implies a semantic inconsistency between `action` and any method reference to `send*`.

While patching `Observer.action` is sufficient, it appears to be a great opportunity to hide the closure as an implementation detail, and complete the `send` method family with a new overload taking the event sum type.

#### Checklist
- [x] Updated CHANGELOG.md.
