### PR TITLE
The `once` FlattenStrategy.

### DIFF
--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -863,6 +863,25 @@ extension Signal.Event {
 	}
 }
 
+extension Signal.Event where Value: SignalProducerConvertible, Value.Error == Error {
+	internal static func flattenOnce() -> Transformation<Value.Value, Error> {
+		return { action, lifetime in
+			return { event in
+				switch event {
+				case let .value(stream):
+					lifetime += stream.producer.start(action)
+				case let .failed(error):
+					action(.failed(error))
+				case .completed:
+					action(.completed)
+				case .interrupted:
+					action(.interrupted)
+				}
+			}
+		}
+	}
+}
+
 private struct ThrottleState<Value> {
 	var previousDate: Date?
 	var pendingValue: Value?

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -14,6 +14,7 @@ public struct FlattenStrategy {
 		case concurrent(limit: UInt)
 		case latest
 		case race
+		case once
 	}
 
 	fileprivate let kind: Kind
@@ -98,6 +99,19 @@ public struct FlattenStrategy {
 	/// Any failure from the inner streams is propagated immediately to the flattened
 	/// stream of values.
 	public static let race = FlattenStrategy(kind: .race)
+
+	/// Forward only events from the first inner stream received. The stream of streams
+	/// would be interrupted upon the said stream being started.
+	///
+	/// The flattened stream of values completes when the stream of streams completes
+	/// without emitting any inner stream, or when the sole inner stream completes.
+	///
+	/// Any interruption of inner streams is propagated immediately to the flattened
+	/// stream of values.
+	///
+	/// Any failure from the inner streams is propagated immediately to the flattened
+	/// stream of values.
+	public static let once = FlattenStrategy(kind: .once)
 }
 
 extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
@@ -122,6 +136,9 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 
 		case .race:
 			return self.race()
+
+		case .once:
+			return self.flatMapEvent(Signal.Event.flattenOnce())
 		}
 	}
 }
@@ -164,6 +181,9 @@ extension Signal where Value: SignalProducerConvertible, Error == NoError, Value
 
 		case .race:
 			return self.race()
+
+		case .once:
+			return self.flatMapEvent(Signal.Event.flattenOnce())
 		}
 	}
 }
@@ -207,6 +227,9 @@ extension SignalProducer where Value: SignalProducerConvertible, Error == Value.
 
 		case .race:
 			return self.race()
+
+		case .once:
+			return self.flatMapEvent(Signal.Event.flattenOnce())
 		}
 	}
 }
@@ -249,6 +272,9 @@ extension SignalProducer where Value: SignalProducerConvertible, Error == NoErro
 
 		case .race:
 			return self.race()
+
+		case .once:
+			return self.flatMapEvent(Signal.Event.flattenOnce())
 		}
 	}
 }

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -25,7 +25,7 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	/// 1. handling the single-observer `start`; and
 	/// 2. building `Signal`s on demand via its `makeInstance()` method, which produces a
 	///    `Signal` with the associated side effect and interrupt handle.
-	fileprivate let core: SignalProducerCore<Value, Error>
+	private let core: SignalProducerCore<Value, Error>
 
 	/// Convert an entity into its equivalent representation as `SignalProducer`.
 	///
@@ -652,6 +652,20 @@ extension SignalProducer where Error == NoError {
 }
 
 extension SignalProducer {
+	/// Perform an action upon every event from `self`. The action may generate zero or
+	/// more events.
+	///
+	/// - precondition: The action must be synchronous.
+	///
+	/// - parameters:
+	///   - transform: A closure that creates the said action from the given event
+	///                closure.
+	///
+	/// - returns: A signal that forwards events yielded by the action.
+	internal func flatMapEvent<U, E>(_ transform: @escaping ProducedSignal.Event.Transformation<U, E>) -> SignalProducer<U, E> {
+		return core.flatMapEvent(transform)
+	}
+
 	/// Lift an unary Signal operator to operate upon SignalProducers instead.
 	///
 	/// In other words, this will create a new `SignalProducer` which will apply

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -70,6 +70,9 @@ class FlattenSpec: QuickSpec {
 			describeSignalFlattenDisposal(.concat, name: "concat")
 			describeSignalFlattenDisposal(.concurrent(limit: 1024), name: "concurrent(limit: 1024)")
 			describeSignalFlattenDisposal(.race, name: "race")
+
+			// The `once` strategy have a different slightly behavior that does not match
+			// the above test cases.
 		}
 
 		func describeSignalProducerFlattenDisposal(_ flattenStrategy: FlattenStrategy, name: String) {
@@ -95,6 +98,7 @@ class FlattenSpec: QuickSpec {
 			describeSignalProducerFlattenDisposal(.concat, name: "concat")
 			describeSignalProducerFlattenDisposal(.concurrent(limit: 1024), name: "concurrent(limit: 1024)")
 			describeSignalProducerFlattenDisposal(.race, name: "race")
+			describeSignalProducerFlattenDisposal(.once, name: "once")
 		}
 
 		describe("Signal.flatten()") {
@@ -1249,6 +1253,148 @@ class FlattenSpec: QuickSpec {
 				}
 
 				run { $0.start(on: scheduler) }
+			}
+		}
+
+		describe("FlattenStrategy.once") {
+			it("should complete immediately if the producer of streams completes without emitting any stream") {
+				let (signal, observer) = Signal<SignalProducer<(), NoError>, NoError>.pipe()
+				var isCompleted = false
+
+				signal
+					.flatten(.once)
+					.observeCompleted { isCompleted = true }
+
+				expect(isCompleted) == false
+
+				observer.sendCompleted()
+				expect(isCompleted) == true
+			}
+
+			it("should complete immediately if the producer of streams completes without emitting any stream") {
+				let (signal, observer) = Signal<SignalProducer<(), NoError>, NoError>.pipe()
+				let producer = SignalProducer<SignalProducer<(), NoError>, NoError>(signal)
+				var isCompleted = false
+
+				producer
+					.flatten(.once)
+					.startWithCompleted { isCompleted = true }
+
+				expect(isCompleted) == false
+
+				observer.sendCompleted()
+				expect(isCompleted) == true
+			}
+
+			it("should interrupt immediately if the producer of streams interrupts without emitting any stream") {
+				let (signal, observer) = Signal<SignalProducer<(), NoError>, NoError>.pipe()
+				var isInterrupted = false
+
+				signal
+					.flatten(.once)
+					.observeInterrupted { isInterrupted = true }
+
+				expect(isInterrupted) == false
+
+				observer.sendInterrupted()
+				expect(isInterrupted) == true
+			}
+
+			it("should interrupt immediately if the producer of streams interrupts without emitting any stream") {
+				let (signal, observer) = Signal<SignalProducer<(), NoError>, NoError>.pipe()
+				let producer = SignalProducer<SignalProducer<(), NoError>, NoError>(signal)
+				var isInterrupted = false
+
+				producer
+					.flatten(.once)
+					.startWithInterrupted { isInterrupted = true }
+
+				expect(isInterrupted) == false
+
+				observer.sendInterrupted()
+				expect(isInterrupted) == true
+			}
+
+			it("should fail immediately if the producer of streams fails without emitting any stream") {
+				let (signal, observer) = Signal<SignalProducer<(), NoError>, TestError>.pipe()
+				var error: TestError?
+
+				signal
+					.flatten(.once)
+					.observeFailed { error = $0 }
+
+				expect(error).to(beNil())
+
+				observer.send(error: .default)
+				expect(error) == .default
+			}
+
+			it("should fail immediately if the producer of streams fails without emitting any stream") {
+				let (signal, observer) = Signal<SignalProducer<(), NoError>, TestError>.pipe()
+				let producer = SignalProducer<SignalProducer<(), NoError>, TestError>(signal)
+				var error: TestError?
+
+				producer
+					.flatten(.once)
+					.startWithFailed { error = $0 }
+
+				expect(error).to(beNil())
+
+				observer.send(error: .default)
+				expect(error) == .default
+			}
+
+			it("should dispose of the signal of streams immediately when an inner stream is received") {
+				let disposable = AnyDisposable()
+				var observer: Signal<SignalProducer<(), NoError>, NoError>.Observer!
+
+				func make() -> Signal<SignalProducer<(), NoError>, NoError> {
+					let (signal, innerObserver) = Signal<SignalProducer<(), NoError>, NoError>.pipe(disposable: disposable)
+					observer = innerObserver
+					return signal
+				}
+
+				make()
+					.flatten(.once)
+					.observe(Signal.Observer())
+
+				expect(disposable.isDisposed) == false
+
+				observer.send(value: SignalProducer(value: ()))
+				expect(disposable.isDisposed) == true
+			}
+
+			it("should interrupt the producer of streams immediately when an inner stream is received") {
+				let (signal, observer) = Signal<SignalProducer<(), NoError>, NoError>.pipe()
+				let producer = SignalProducer<SignalProducer<(), NoError>, NoError>(signal)
+
+				var isProducerOfStreamsInterrupted = false
+
+				producer
+					.on(interrupted: { isProducerOfStreamsInterrupted = true })
+					.flatten(.once)
+					.start()
+
+				expect(isProducerOfStreamsInterrupted) == false
+
+				observer.send(value: SignalProducer(value: ()))
+				expect(isProducerOfStreamsInterrupted) == true
+			}
+
+			it("should forward the values from the received inner producer") {
+				let (signal, observer) = Signal<SignalProducer<Int, NoError>, NoError>.pipe()
+				let producer = SignalProducer<SignalProducer<Int, NoError>, NoError>(signal)
+
+				var values: [Int] = []
+
+				producer
+					.flatten(.once)
+					.startWithValues { values.append($0) }
+
+				expect(values) == []
+
+				observer.send(value: SignalProducer(CountableRange(0 ..< 10)))
+				expect(values) == Array(CountableRange(0 ..< 10))
 			}
 		}
 	}


### PR DESCRIPTION
Related: #423

This is a convenience that has been using in our codebase for a while, implemented as `take(first: 1).race()`. There are a lot of circumstances that we need only one value from a continuous producer (e.g. property).

For example, we can fold this:
```swift
property.producer
    .take(first: 1)
    // Since we have just one value, any strategy is irrelevant.
    .flatMap(.latest) { value in
        // Spawn a network request from the value.
    }
```

into:
```swift
property.producer
    .flatMap(.once) { value in
        // Spawn one network request from the first value received.
    }
```

While it doesn't add substantial functionality, it offers a sensible choice for flattening single-value stream of streams, that also reduces verbosity, from an API consumer POV.

#### Checklist
- [ ] Updated CHANGELOG.md.