### PR TITLE
Allow any value signal for trigger in takeUntil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. `Signal.take(until:)` and `SignalProducer.take(until:)` now accept Triggers of any value instead of just `()`
+
 1. `Signal.Observer.action` has been deprecated. Use `Signal.Observer.send` instead. (#515)
 
 1. Workaround an unexpected EGAGIN error being returned by pthread in 32-bit ARM debug builds. (#508)
@@ -50,7 +52,7 @@
 1. The performance of `SignalProducer` has been improved significantly. (#140, kudos to @andersio)
 
    All lifted `SignalProducer` operators no longer yield an extra `Signal`. As a result, the calling overhead of event delivery is generally reduced proportionally to the level of chaining of lifted operators.
-   
+
 1. `interrupted` now respects `observe(on:)`. (#140)
 
    When a produced `Signal` is interrupted, if `observe(on:)` is the last applied operator, `interrupted` would now be delivered on the `Scheduler` passed to `observe(on:)` just like other events.
@@ -90,12 +92,12 @@ let producer = SignalProducer<Int, NoError> { observer, lifetime in
 
 Two `Disposable`-accepting methods `Lifetime.Type.+=` and `Lifetime.add` are provided to aid migration, and are subject to removal in a future release.
 
-### Signal and SignalProducer 
+### Signal and SignalProducer
 1. All `Signal` and `SignalProducer` operators now belongs to the respective concrete types. (#304)
 
    Custom operators should extend the concrete types directly. `SignalProtocol` and `SignalProducerProtocol` should be used only for constraining associated types.
 
-1. `combineLatest` and `zip` are optimised to have a constant overhead regardless of arity, mitigating the possibility of stack overflow. (#345) 
+1. `combineLatest` and `zip` are optimised to have a constant overhead regardless of arity, mitigating the possibility of stack overflow. (#345)
 
 1. `flatMap(_:transform:)` is renamed to `flatMap(_:_:)`. (#339)
 
@@ -152,7 +154,7 @@ Two `Disposable`-accepting methods `Lifetime.Type.+=` and `Lifetime.add` are pro
    `concurrent` starts and flattens inner signals according to the specified concurrency limit. If an inner signal is received after the limit is reached, it would be queued and drained later as the in-flight inner signals terminate.
 
 1. New operators: `reduce(into:)` and `scan(into:)`. (#365, kudos to @ikesyo)
- 
+
    These variants pass to the closure an `inout` reference to the accumulator, which helps the performance when a large value type is used, e.g. collection.
 
 1. `Property(initial:then:)` gains overloads that accept a producer or signal of the wrapped value type when the value type is an `Optional`. (#396)
@@ -172,7 +174,7 @@ Thank you to all of @ReactiveCocoa/reactiveswift and all our contributors, but e
 ## Deprecation
 1. `observe(_:during:)` is now deprecated. It would be removed in ReactiveSwift 2.0.
     Use `take(during:)` and the relevant observation API of `Signal`, `SignalProducer` and `Property` instead. (#374)
-    
+
 # 1.1.2
 ## Changes
 1. Fixed a rare occurrence of `interrupted` events being emitted by a `Property`. (#362)
@@ -226,27 +228,27 @@ This is the first major release of ReactiveSwift, a multi-platform, pure-Swift f
 
 Major changes since ReactiveCocoa 4 include:
 - **Updated for Swift 3**
-  
+
   APIs have been updated and renamed to adhere to the Swift 3 [API Design Guidelines](https://swift.org/documentation/api-design-guidelines/).
 - **Signal Lifetime Semantics**
-  
+
   `Signal`s now live and continue to emit events only while either (a) they have observers or (b) they are retained. This clears up a number of unexpected cases and makes Signals much less dangerous.
 - **Reactive Proxies**
-  
+
   Types can now declare conformance to `ReactiveExtensionsProvider` to expose a `reactive` property that’s generic over `self`. This property hosts reactive extensions to the type, such as the ones provided on `NotificationCenter` and `URLSession`.
 - **Property Composition**
-  
+
   `Property`s can now be composed. They expose many of the familiar operators from `Signal` and `SignalProducer`, including `map`, `flatMap`, `combineLatest`, etc.
 - **Binding Primitives**
-  
+
   `BindingTargetProtocol` and `BindingSourceProtocol` have been introduced to allow binding of observable instances to targets. `BindingTarget` is a new concrete type that can be used to wrap a settable but non-observable property.
 - **Lifetime**
-  
+
   `Lifetime` is introduced to represent the lifetime of any arbitrary reference type. This can be used with the new `take(during:)` operator, but also forms part of the new binding APIs.
 - **Race-free Action**
-  
+
    A new `Action` initializer `Action(state:enabledIf:_:)` has been introduced. It allows the latest value of any arbitrary property to be supplied to the execution closure in addition to the input from `apply(_:)`, while having the availability being derived from the property.
-  
+
    This eliminates a data race in ReactiveCocoa 4.x, when both the `enabledIf` predicate and the execution closure depend on an overlapping set of properties.
 
 Extensive use of Swift’s `@available` declaration has been used to ease migration from ReactiveCocoa 4. Xcode should have fix-its for almost all changes from older APIs.

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1106,12 +1106,12 @@ extension Signal {
 	///
 	/// - returns: A signal that will deliver events until `trigger` sends
 	///            `value` or `completed` events.
-	public func take(until trigger: Signal<(), NoError>) -> Signal<Value, Error> {
+	public func take<Trigger: SignalProtocol>(until trigger: Trigger) -> Signal<Value, Error> where Trigger.Error == NoError {
 		return Signal<Value, Error> { observer in
 			let disposable = CompositeDisposable()
 			disposable += self.observe(observer)
 
-			disposable += trigger.observe { event in
+			disposable += trigger.signal.observe { event in
 				switch event {
 				case .value, .completed:
 					observer.sendCompleted()

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1145,7 +1145,7 @@ extension SignalProducer {
 	///
 	/// - returns: A producer that will deliver events until `trigger` sends
 	///            `value` or `completed` events.
-	public func take<Trigger: SignalProducerConvertible>(until trigger: Trigger) -> SignalProducer<Value, Error> where Trigger.Value == (), Trigger.Error == NoError {
+	public func take<Trigger: SignalProducerConvertible>(until trigger: Trigger) -> SignalProducer<Value, Error> where Trigger.Error == NoError {
 		return liftRight(Signal.take(until:))(trigger.producer)
 	}
 


### PR DESCRIPTION
#### Checklist
- [x] Updated CHANGELOG.md.


I was wondering why the trigger signal for `take(until:)` was constrained to only signals/signal producers of value `()`. 
If there is a specific reason for that constraint, please ignore this PR.



This change allows the trigger signal for `take(until:)` to have any value. In my experience, my trigger signals usually are "normal" signals that I currently have to map to `()`. 

So, before: 

```swift
let someSignal: Signal<Int, NoError>
let triggerSignal: Signal<Any, NoError>
...
someSignal.take(until: triggerSignal.map { _ in return })
```

After:

```swift
let someSignal: Signal<Int, NoError>
let triggerSignal: Signal<Any, NoError>
...
someSignal.take(until: triggerSignal)
```


Regarding tests, should I write additional tests with a trigger signal of another value, or should I change the value of the trigger signal in the current tests, or is it fine already?



PS: Apologies for the unnecessary changes in CHANGELOG.md. My Editor was configured to strip trailing whitespace and I did not notice until the diff here. I can revert these changes if you like, but I guess they don't hurt anyway...
