### PR TITLE
[gardening] Address “Redundant conformance constraint” warnings

### DIFF
--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -40,7 +40,7 @@ extension Signal {
 		///   - disposable: The disposable to be disposed of when the `TransformerCore`
 		///                 yields any terminal event. If `observer` is a `Signal` input
 		///                 observer, this can be omitted.
-		internal init<U, E: Swift.Error>(
+		internal init<U, E>(
 			_ observer: Signal<U, E>.Observer,
 			_ transform: @escaping Event.Transformation<U, E>,
 			_ disposable: Disposable? = nil

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1856,7 +1856,7 @@ extension Signal {
 		}
 	}
 
-	private convenience init<Strategy: SignalAggregateStrategy>(_ builder: AggregateBuilder<Strategy>, _ transform: @escaping (ContiguousArray<Any>) -> Value) {
+	private convenience init<Strategy>(_ builder: AggregateBuilder<Strategy>, _ transform: @escaping (ContiguousArray<Any>) -> Value) {
 		self.init { observer in
 			let disposables = CompositeDisposable()
 			let strategy = Strategy(count: builder.startHandlers.count) { event in


### PR DESCRIPTION
This should be compatible on both Swift 3.1 and Swift 3.2/Swift 4.


#### Checklist
- ~~[ ] Updated CHANGELOG.md.~~
