### PR TITLE
Make `startWithSignal()` return the result of `setup(…)`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. `SignalProducer.startWithSignal` now returns the value of the setup closure.
+
 # 2.1.0-alpha.2
 1. Disabled code coverage data to allow app submissions with Xcode 9.0 (see https://github.com/Carthage/Carthage/issues/2056, kudos to @NachoSoto)
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -217,11 +217,15 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	///   - setup: A closure to be invoked before the work associated with the produced
 	///            `Signal` commences. Both the produced `Signal` and an interrupt handle
 	///            of the signal would be passed to the closure.
-	public func startWithSignal(_ setup: (_ signal: Signal<Value, Error>, _ interruptHandle: Disposable) -> Void) {
+	/// - returns: The return value of the given setup closure.
+	@discardableResult
+	public func startWithSignal<Result>(_ setup: (_ signal: Signal<Value, Error>, _ interruptHandle: Disposable) -> Result) -> Result {
 		let instance = core.makeInstance()
-		setup(instance.signal, instance.interruptHandle)
-		guard !instance.interruptHandle.isDisposed else { return }
-		instance.observerDidSetup()
+		let result = setup(instance.signal, instance.interruptHandle)
+		if !instance.interruptHandle.isDisposed {
+			instance.observerDidSetup()
+		}
+		return result
 	}
 }
 

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -594,6 +594,11 @@ class SignalProducerSpec: QuickSpec {
 				expect(disposed) == true
 				expect(addedDisposable.isDisposed) == true
 			}
+
+			it("should return whatever value is returned by the setup closure") {
+				let producer = SignalProducer<Never, NoError>.empty
+				expect(producer.startWithSignal { _, _ in "Hello" }) == "Hello"
+			}
 		}
 
 		describe("start") {


### PR DESCRIPTION
Personally I'd use it to return the `Disposable` given to the block, so that I have an interruption handle for the started producer, similar to the other `start()`-methods.

By using `@discardableResult` we retain backwards-compatibility without causing warnings about unused return values.

#### Example usage

``` swift
let disposable = producer.startWithSignal { signal, disposable in
  // …
  return disposable
}
```

_Note: I have not discussed this feature with anybody beforehand, but the change was easy enough so I wrote it and submitted a PR_

#### Checklist
- [x] Updated CHANGELOG.md.