### PR TITLE
Tweak flatten operators to take advantage of the new producer cores.

### DIFF
--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -297,34 +297,31 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 		let state = Atomic(ConcurrentFlattenState<Value.Value, Error>(limit: limit))
 
 		func startNextIfNeeded() {
-			while let producer = state.modify({ $0.dequeue() }) {
+			while !lifetime.hasEnded, let producer = state.modify({ $0.dequeue() }) {
 				let producerState = UnsafeAtomicState<ProducerState>(.starting)
 				let deinitializer = ScopedDisposable(AnyDisposable(producerState.deinitialize))
 
-				producer.startWithSignal { signal, inner in
-					let handle = lifetime += inner
+				let handle = SerialDisposable()
+				handle.inner = lifetime += producer.start { event in
+					switch event {
+					case .completed, .interrupted:
+						handle.dispose()
 
-					signal.observe { event in
-						switch event {
-						case .completed, .interrupted:
-							handle?.dispose()
-
-							let shouldComplete: Bool = state.modify { state in
-								state.activeCount -= 1
-								return state.shouldComplete
-							}
-
-							withExtendedLifetime(deinitializer) {
-								if shouldComplete {
-									observer.sendCompleted()
-								} else if producerState.is(.started) {
-									startNextIfNeeded()
-								}
-							}
-
-						case .value, .failed:
-							observer.send(event)
+						let shouldComplete: Bool = state.modify { state in
+							state.activeCount -= 1
+							return state.shouldComplete
 						}
+
+						withExtendedLifetime(deinitializer) {
+							if shouldComplete {
+								observer.sendCompleted()
+							} else if producerState.is(.started) {
+								startNextIfNeeded()
+							}
+						}
+
+					case .value, .failed:
+						observer.send(event)
 					}
 				}
 
@@ -584,50 +581,48 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 		return self.observe { event in
 			switch event {
 			case let .value(p):
-				p.producer.startWithSignal { innerSignal, innerDisposable in
-					state.modify {
-						// When we replace the disposable below, this prevents
-						// the generated Interrupted event from doing any work.
-						$0.replacingInnerSignal = true
-					}
+				state.modify {
+					// When we replace the disposable below, this prevents
+					// the generated Interrupted event from doing any work.
+					$0.replacingInnerSignal = true
+				}
 
-					latestInnerDisposable.inner = innerDisposable
+				latestInnerDisposable.inner = nil
 
-					state.modify {
-						$0.replacingInnerSignal = false
-						$0.innerSignalComplete = false
-					}
+				state.modify {
+					$0.replacingInnerSignal = false
+					$0.innerSignalComplete = false
+				}
 
-					innerSignal.observe { event in
-						switch event {
-						case .interrupted:
-							// If interruption occurred as a result of a new
-							// producer arriving, we don't want to notify our
-							// observer.
-							let shouldComplete: Bool = state.modify { state in
-								if !state.replacingInnerSignal {
-									state.innerSignalComplete = true
-								}
-								return !state.replacingInnerSignal && state.outerSignalComplete
+				latestInnerDisposable.inner = p.producer.start { event in
+					switch event {
+					case .interrupted:
+						// If interruption occurred as a result of a new
+						// producer arriving, we don't want to notify our
+						// observer.
+						let shouldComplete: Bool = state.modify { state in
+							if !state.replacingInnerSignal {
+								state.innerSignalComplete = true
 							}
-
-							if shouldComplete {
-								observer.sendCompleted()
-							}
-
-						case .completed:
-							let shouldComplete: Bool = state.modify {
-								$0.innerSignalComplete = true
-								return $0.outerSignalComplete
-							}
-
-							if shouldComplete {
-								observer.sendCompleted()
-							}
-
-						case .value, .failed:
-							observer.send(event)
+							return !state.replacingInnerSignal && state.outerSignalComplete
 						}
+
+						if shouldComplete {
+							observer.sendCompleted()
+						}
+
+					case .completed:
+						let shouldComplete: Bool = state.modify {
+							$0.innerSignalComplete = true
+							return $0.outerSignalComplete
+						}
+
+						if shouldComplete {
+							observer.sendCompleted()
+						}
+
+					case .value, .failed:
+						observer.send(event)
 					}
 				}
 
@@ -701,54 +696,52 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 
 		return self.observe { event in
 			switch event {
-			case let .value(innerProducer):
+			case let .value(p):
 				// Ignore consecutive `innerProducer`s if any `innerSignal` already sent an event.
 				guard !relayDisposable.isDisposed else {
 					return
 				}
 
-				innerProducer.producer.startWithSignal { innerSignal, innerDisposable in
-					state.modify {
-						$0.innerSignalComplete = false
+				state.modify {
+					$0.innerSignalComplete = false
+				}
+
+				let handle = SerialDisposable()
+				var isWinningSignal = false
+
+				handle.inner = relayDisposable += p.producer.start { event in
+					if !isWinningSignal {
+						isWinningSignal = state.modify { state in
+							guard !state.isActivated else {
+								return false
+							}
+
+							state.isActivated = true
+							return true
+						}
+
+						// Ignore non-winning signals.
+						guard isWinningSignal else { return }
+
+						// The disposals would be run exactly once immediately after
+						// the winning signal flips `state.isActivated`.
+						handle.dispose()
+						relayDisposable.dispose()
 					}
 
-					let disposableHandle = relayDisposable.add(innerDisposable)
-					var isWinningSignal = false
-
-					innerSignal.observe { event in
-						if !isWinningSignal {
-							isWinningSignal = state.modify { state in
-								guard !state.isActivated else {
-									return false
-								}
-
-								state.isActivated = true
-								return true
-							}
-
-							// Ignore non-winning signals.
-							guard isWinningSignal else { return }
-
-							// The disposals would be run exactly once immediately after
-							// the winning signal flips `state.isActivated`.
-							disposableHandle?.dispose()
-							relayDisposable.dispose()
+					switch event {
+					case .completed:
+						let shouldComplete: Bool = state.modify { state in
+							state.innerSignalComplete = true
+							return state.outerSignalComplete
 						}
 
-						switch event {
-						case .completed:
-							let shouldComplete: Bool = state.modify { state in
-								state.innerSignalComplete = true
-								return state.outerSignalComplete
-							}
-
-							if shouldComplete {
-								observer.sendCompleted()
-							}
-
-						case .value, .failed, .interrupted:
-							observer.send(event)
+						if shouldComplete {
+							observer.sendCompleted()
 						}
+
+					case .value, .failed, .interrupted:
+						observer.send(event)
 					}
 				}
 
@@ -940,10 +933,8 @@ extension Signal {
 			case let .value(value):
 				observer.send(value: value)
 			case let .failed(error):
-				handler(error).startWithSignal { signal, disposable in
-					serialDisposable.inner = disposable
-					signal.observe(observer)
-				}
+				serialDisposable.dispose()
+				handler(error).start(observer)
 			case .completed:
 				observer.sendCompleted()
 			case .interrupted:

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -635,6 +635,23 @@ extension SignalProducer {
 			setup(signal)
 		}
 	}
+
+	/// Create a `Signal` from `self`, and observe it with the observer created
+	/// by the given setup closure.
+	///
+	/// The setup closure is passed with an interrupter for an early opportunity
+	/// to interrupt the produced `Signal` before the starting side effect is
+	/// evaluated.
+	///
+	/// - parameters:
+	///   - setup: A closure which creates an observer to observe the produced
+	///            `Signal`.
+	///
+	/// - returns: A disposable to interrupt the produced `Signal`.
+	@discardableResult
+	internal func startWithInterrupter(_ setup: (_ interrupter: Disposable) -> Signal<Value, Error>.Observer) -> Disposable {
+		return core.start(setup)
+	}
 }
 
 extension SignalProducer where Error == NoError {


### PR DESCRIPTION
The implementations now use `startWithInterrupter` instead of `startWithSignal`.

#### Checklist
- ~~Updated CHANGELOG.md.~~
