### PR TITLE
ValidatingProperty: Declarative Rules prototype

### DIFF
--- a/ReactiveSwift.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
@@ -21,5 +21,71 @@ import Foundation
  
  A place where you can build your sand castles 🏖.
 */
+public struct InvalidInput: Error {
+    public let reason: String
 
+    public init(reason: String) {
+        self.reason = reason
+    }
+}
 
+extension EditingProperty.Validation where ValidationError == InvalidInput {
+    public static func none<U>(_ keyPath: WritableKeyPath<Value, U>) -> EditingProperty.Validation {
+        return EditingProperty.Validation(for: keyPath, validate: { _ in nil })
+    }
+
+    public static func mandatory(_ keyPath: WritableKeyPath<Value, String>, _ reason: String) -> EditingProperty.Validation {
+        return EditingProperty.Validation(for: keyPath, validate: { $0.isEmpty ? InvalidInput(reason: reason) : nil })
+    }
+
+    public static func mandatory(_ keyPath: WritableKeyPath<Value, String?>, _ reason: String) -> EditingProperty.Validation {
+        return EditingProperty.Validation(for: keyPath, validate: { ($0?.isEmpty ?? true) ? InvalidInput(reason: reason) : nil })
+    }
+
+    public static func custom<U>(_ keyPath: WritableKeyPath<Value, U>, _ predicate: @escaping (U) -> Bool, _ reason: String) -> EditingProperty.Validation {
+        return EditingProperty.Validation(for: keyPath, validate: { !predicate($0) ? InvalidInput(reason: reason) : nil })
+    }
+}
+
+struct User {
+    var firstName: String = ""
+    var lastName: String = ""
+    var phoneNumber: String = ""
+}
+
+let user = EditingProperty<User, InvalidInput>(User(), validations: [
+    .mandatory(\.firstName, "First name is mandatory."),
+    .mandatory(\.lastName, "Last name is mandatory."),
+    .custom(\.phoneNumber, { $0.hasPrefix("+44") }, "Phone number is not a UK number."),
+])
+
+print("(1)")
+user.validated.producer.startWithValues { result in
+    switch result {
+    case let .success(value):
+        print("SUCCESS: \(value)")
+    case let .failure(error):
+        print("FAILURE: \(error.errors.map { $0.reason })")
+    }
+}
+// FAILURE: ["First name is mandatory.", "Phone number is not a UK number.", "Last name is mandatory."]
+
+print("(2)")
+user[\.firstName] <~ SignalProducer(value: "Steve")
+// FAILURE: ["Phone number is not a UK number.", "Last name is mandatory."]
+
+print("(3)")
+user[\.lastName] <~ SignalProducer(value: "Jobs")
+// FAILURE: ["Phone number is not a UK number."]
+
+print("(4)")
+user[\.phoneNumber] <~ SignalProducer(value: "+00")
+// FAILURE: ["Phone number is not a UK number."]
+
+print("(5)")
+user[\.phoneNumber] <~ SignalProducer(value: "+44")
+// SUCCESS: User(firstName: "Steve", lastName: "Jobs", phoneNumber: "+44")
+
+print("(5)")
+user[\.phoneNumber] <~ SignalProducer(value: "")
+// FAILURE: ["Phone number is not a UK number."]

--- a/ReactiveSwift.playground/contents.xcplayground
+++ b/ReactiveSwift.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='macos' display-mode='rendered'>
+<playground version='6.0' target-platform='macos' display-mode='rendered' executeOnSourceChanges='false' last-migration='0900'>
     <pages>
         <page name='Sandbox'/>
         <page name='SignalProducer'/>


### PR DESCRIPTION
This is an advanced iteration of `ValidatingProperty`. It takes advantage of Smart Key Paths introduced since Swift 4.0 to perform reactive validation based on declarative rules on specific key paths.

It is an API breaking change, because of the signature change in `ValidatingProperty.Result` to accommodate the fact that a validation attempt could now yield multiple errors.

## What does it solve?
Performing the three things below _**altogether**_ with today's ReactiveSwift is not particularly easy and expressive:

1. Managing Swift value type models
2. Binding them reactively to the views
3. Performing live validation

Depending on implementations, some may choose to break one models into multiple reactive streams, and merge them back into one for submission. Some may opt to stick with one `MutableProperty` with custom binding target magic. Either way, boilerplates or a complex composition of streams are often involved, making things harder to manage.

This PR attempts to address this by honouring just a single value store, with the ability to accept values and perform validations on specific key paths.

## How does it work?
`ValidatingProperty` can now accept a collection of `Rule`s.

```swift
ValidatingProperty(Model(), rules: [
    ValidatingProperty.Rule(for: \.property1, validate: { $0.isEmpty ? Error("Property 1 is empty") : nil }),
    ValidatingProperty.Rule(for: \.property2, validate: { $0.isEmpty ? Error("Property 2 is empty") : nil })
])
```

Thanks to contextual lookup, users may build validation DSLs that suit their own business needs on top of it.

```swift
ValidatingProperty(Model(), rules: [
    .mandatory(\.property1),
    .validPhoneNumber(\.property2),
    .validMembershipCode(\. membershipCode)
])

extension ValidatingProperty.Rule where ValidationError == MyValidationError {
   static func mandatory(_ keyPath: WritableKeyPath<Value, String>) -> EditingProperty.Validation
   static func validPhoneNumber(_ keyPath: WritableKeyPath<Value, String>) -> EditingProperty.Validation
   static func validMembershipCode(_ keyPath: WritableKeyPath<Value, String>) -> EditingProperty.Validation
}
```

After building the property, one can perform bindings as usual.

```swift
membershipCodeField.reactive.text <~ viewModel.membershipCodeValues
viewModel.membershipCode <~ membershipCodeField.reactive.textValues

extension ViewModel {
    var membershipCodeValues: SignalProducer<String, NoError> {
        return property.producer.map(\.membershipCode)
    }

    var membershipCode: BindingTarget<String> {
        return property[\.membershipCode]
    }
}
```

## Caveat
The new Rules mode does not support `coerced` decisions, because the behaviour can be indeterministic when multiple rules coerce the value.

cc @liscio 