### PR TITLE
Add bottlenecked(_:on:).

### DIFF
--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1484,6 +1484,32 @@ extension Signal {
 	public func debounce(_ interval: TimeInterval, on scheduler: DateScheduler) -> Signal<Value, Error> {
 		return flatMapEvent(Signal.Event.debounce(interval, on: scheduler))
 	}
+
+	/// Starts delaying values on `scheduler` if not enough `interval`
+	/// seconds have passed since `self` last sent a value.
+	///
+	/// If at least `interval` seconds have passed since `self` last sent a
+	/// value, then the value is going to be forwarded on the given scheduler
+	/// without any delay. You can look at it as a minimum outgoing rate.
+	///
+	/// - seealso: `throttle`, `delay`
+	///
+	/// - note: If multiple values are received before the `interval` has
+	///         elapsed, these values are going to be delayed one by one until
+	///         the `interval` value elapses, until there's no more queued
+	///         values to be sent.
+	///
+	/// - precondition: `interval` must be non-negative number.
+	///
+	/// - parameters:
+	///   - interval: Number of seconds to enqueue sent values.
+	///   - scheduler: A scheduler to send values on.
+	///
+	/// - returns: A signal that sends values with a minimun of `interval`
+	///            seconds appart from each other on a given scheduler.
+	public func bottlenecked(_ interval: TimeInterval, on scheduler: DateScheduler) -> Signal<Value, Error> {
+		return flatMapEvent(Signal.Event.bottlenecked(interval, on: scheduler))
+	}
 }
 
 extension Signal {


### PR DESCRIPTION
This PR adds a bottlenecked function to bottleneck multiple values. It's useful for the cases where we receive a lot of values but we only want to process one value at a time within a desired time interval. If enough time as elapsed then a received value get processed without any delay otherwise it gets queued/delayed until the interval elapses.

The implementation is similar to the current throttle function with the added logic to schedule the pending value instead of replacing it.

PS: Suggestions for a different name are welcome. Initially I named it throttleThenDelay, then changed to enqueue and ended up with bottlenecked.
PS2: Any suggestion are welcome to :)