### PR TITLE
[3.0] Make ReactiveSwift a static framework.

### DIFF
--- a/ReactiveSwift.podspec
+++ b/ReactiveSwift.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveSwift.git", :tag => "#{s.version}" }
   # Directory glob for all Swift files
   s.source_files  = "Sources/*.{swift}"
+  s.static_framework = true
   s.dependency 'Result', '~> 3.2'
 
   s.pod_target_xcconfig = {"OTHER_SWIFT_FLAGS[config=Release]" => "-suppress-warnings" }

--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -1101,6 +1101,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
+				MACH_O_TYPE = staticlib;
 			};
 			name = Debug;
 		};
@@ -1116,6 +1117,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
+				MACH_O_TYPE = staticlib;
 			};
 			name = Test;
 		};
@@ -1131,6 +1133,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
+				MACH_O_TYPE = staticlib;
 			};
 			name = Release;
 		};
@@ -1146,6 +1149,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
+				MACH_O_TYPE = staticlib;
 			};
 			name = Profile;
 		};
@@ -1221,6 +1225,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
+				MACH_O_TYPE = staticlib;
 			};
 			name = Debug;
 		};
@@ -1236,6 +1241,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
+				MACH_O_TYPE = staticlib;
 			};
 			name = Test;
 		};
@@ -1251,6 +1257,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
+				MACH_O_TYPE = staticlib;
 			};
 			name = Release;
 		};
@@ -1266,6 +1273,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
+				MACH_O_TYPE = staticlib;
 			};
 			name = Profile;
 		};
@@ -1318,6 +1326,7 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 			};
 			name = Debug;
 		};
@@ -1330,6 +1339,7 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 			};
 			name = Release;
 		};
@@ -1362,6 +1372,7 @@
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 			};
 			name = Debug;
 		};
@@ -1374,6 +1385,7 @@
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 			};
 			name = Release;
 		};
@@ -1425,6 +1437,7 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 			};
 			name = Profile;
 		};
@@ -1447,6 +1460,7 @@
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 			};
 			name = Profile;
 		};
@@ -1488,6 +1502,7 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 			};
 			name = Test;
 		};
@@ -1510,6 +1525,7 @@
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 			};
 			name = Test;
 		};


### PR DESCRIPTION
CocoaPods support is enabled via https://github.com/CocoaPods/CocoaPods/pull/6811, and is only effective when using CocoaPods 1.4.0 beta.