### PR TITLE
Concat error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. `concat` for `SignalProducer` now has an overload that accepts an error.
+
 1. Fix some documentation errors (#560, kudos to @ikesyo)
 
 # 3.0.0-rc.1

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -397,6 +397,17 @@ extension SignalProducer {
 		return self.concat(SignalProducer(value: value))
 	}
 
+	/// `concat`s `error` onto `self`.
+	///
+	/// - parameters:
+	///   - error: An error to concat onto `self`.
+	///
+	/// - returns: A producer that, when started, will emit own values and on
+	///            completion will emit an `error`.
+	public func concat(error: Error) -> SignalProducer<Value, Error> {
+		return self.concat(SignalProducer(error: error))
+	}
+
 	/// `concat`s `self` onto initial `previous`.
 	///
 	/// - parameters:

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -1011,6 +1011,28 @@ class FlattenSpec: QuickSpec {
 			}
 		}
 
+		describe("SignalProducer.concat(error:)") {
+			it("should emit final error") {
+				let (signal, observer) = SignalProducer<Int, TestError>.pipe()
+
+				let mergedSignals = signal.concat(error: TestError.default)
+
+				var results: [Result<Int, TestError>] = []
+				mergedSignals.startWithResult { results.append($0) }
+
+				observer.send(value: 1)
+				observer.send(value: 2)
+				observer.send(value: 3)
+				observer.sendCompleted()
+
+				expect(results).to(haveCount(4))
+				expect(results[0].value) == 1
+				expect(results[1].value) == 2
+				expect(results[2].value) == 3
+				expect(results[3].error) == .default
+			}
+		}
+
 		describe("FlattenStrategy.concurrent") {
 			func run(_ modifier: (SignalProducer<UInt, NoError>) -> SignalProducer<UInt, NoError>) {
 				let concurrentLimit: UInt = 4

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -1012,7 +1012,7 @@ class FlattenSpec: QuickSpec {
 		}
 
 		describe("SignalProducer.concat(error:)") {
-			it("should emit final error") {
+			it("should emit concatenated error") {
 				let (signal, observer) = SignalProducer<Int, TestError>.pipe()
 
 				let mergedSignals = signal.concat(error: TestError.default)
@@ -1030,6 +1030,20 @@ class FlattenSpec: QuickSpec {
 				expect(results[1].value) == 2
 				expect(results[2].value) == 3
 				expect(results[3].error) == .default
+			}
+
+			it("should emit own error when present") {
+				let (signal, observer) = SignalProducer<Int, TestError>.pipe()
+
+				let mergedSignals = signal.concat(error: TestError.default)
+
+				var results: [Result<Int, TestError>] = []
+				mergedSignals.startWithResult { results.append($0) }
+
+				observer.send(error: TestError.error1)
+
+				expect(results).to(haveCount(1))
+				expect(results[0].error) == .error1
 			}
 		}
 

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -1032,7 +1032,7 @@ class FlattenSpec: QuickSpec {
 				expect(results[3].error) == .default
 			}
 
-			it("should emit own error when present") {
+			it("should not emit concatenated error for failed producer") {
 				let (signal, observer) = SignalProducer<Int, TestError>.pipe()
 
 				let mergedSignals = signal.concat(error: TestError.default)


### PR DESCRIPTION
Given that `SignalProducer` already supports concatenating a value or a signal, being able to concatenate an error seemed logical. I personally found this useful when implementing a signal that defaulted to an error if nothing matched a filter. For example:

```
filtered.concat(error: notFound).take(first: 1)
```

#### Checklist
- [x] Updated CHANGELOG.md.