### PR TITLE
Replace BindingTargetProtocol with BindingTargetProvider in doc

### DIFF
--- a/Documentation/FrameworkOverview.md
+++ b/Documentation/FrameworkOverview.md
@@ -164,7 +164,7 @@ The current value of a property can be obtained from the `value` getter. The
 the property’s current value, followed by all changes over time. The `signal` getter returns a [signal](#signals) that will send all changes over time, but not the initial value.
 
 The `<~` operator can be used to bind properties in different ways. Note that in
-all cases, the target has to be a binding target, represented by the [`BindingTargetProtocol`][BindingTarget]. All mutable property types, represented by the  [`MutablePropertyProtocol`][MutableProperty], are inherently binding targets.
+all cases, the target has to be a binding target, represented by the [`BindingTargetProvider`][BindingTarget]. All mutable property types, represented by the  [`MutablePropertyProtocol`][MutableProperty], are inherently binding targets.
 
 * `property <~ signal` binds a [signal](#signals) to the property, updating the
   property’s value to the latest value sent by the signal.

--- a/ReactiveSwift.playground/Pages/Property.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Property.xcplaygroundpage/Contents.swift
@@ -67,7 +67,7 @@ scopedExample("Creation") {
  ### Binding
  
  The `<~` operator can be used to bind properties in different ways. Note that in
- all cases, the target has to be a binding target, represented by the [`BindingTargetProtocol`](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/UnidirectionalBinding.swift). All mutable property types, represented by the  [`MutablePropertyProtocol`](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/Property.swift#L38), are inherently binding targets.
+ all cases, the target has to be a binding target, represented by the [`BindingTargetProvider`](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/UnidirectionalBinding.swift). All mutable property types, represented by the  [`MutablePropertyProtocol`](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/Property.swift#L38), are inherently binding targets.
  
  * `property <~ signal` binds a [signal](Signal) to the property, updating the
  property’s value to the latest value sent by the signal.


### PR DESCRIPTION
#### Checklist

- [x] Replaced `BindingTargetProtocol` with `BindingTargetProvider` in doc.
