### PR TITLE
Lower binary ops as event transforms.

### DIFF
--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -75,6 +75,10 @@
 		9A681A9E1E5A241B00B097CF /* DeprecationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */; };
 		9A681A9F1E5A241B00B097CF /* DeprecationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */; };
 		9A681AA01E5A241B00B097CF /* DeprecationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */; };
+		9A8E3BFD1FDD7F2300BFBAEF /* EventStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8E3BFC1FDD7F2300BFBAEF /* EventStream.swift */; };
+		9A8E3BFE1FDD7F2300BFBAEF /* EventStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8E3BFC1FDD7F2300BFBAEF /* EventStream.swift */; };
+		9A8E3BFF1FDD7F2300BFBAEF /* EventStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8E3BFC1FDD7F2300BFBAEF /* EventStream.swift */; };
+		9A8E3C001FDD7F2300BFBAEF /* EventStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8E3BFC1FDD7F2300BFBAEF /* EventStream.swift */; };
 		9A9100DF1E0E6E620093E346 /* ValidatingProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */; };
 		9A9100E01E0E6E670093E346 /* ValidatingProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */; };
 		9A9100E11E0E6E680093E346 /* ValidatingProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */; };
@@ -251,6 +255,7 @@
 		9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnidirectionalBindingSpec.swift; sourceTree = "<group>"; };
 		9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UninhabitedTypeGuards.swift; sourceTree = "<group>"; };
 		9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationSpec.swift; sourceTree = "<group>"; };
+		9A8E3BFC1FDD7F2300BFBAEF /* EventStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventStream.swift; sourceTree = "<group>"; };
 		9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidatingProperty.swift; sourceTree = "<group>"; };
 		9ABCB1841D2A5B5A00BCA243 /* Deprecations+Removals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Deprecations+Removals.swift"; sourceTree = "<group>"; };
 		A97451331B3A935E00F48E55 /* watchOS-Application.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Application.xcconfig"; sourceTree = "<group>"; };
@@ -464,6 +469,7 @@
 				D0C312BC19EF2A5800984962 /* Bag.swift */,
 				D0C312BE19EF2A5800984962 /* Disposable.swift */,
 				D08C54B51A69A3DB00AD8286 /* Event.swift */,
+				9A8E3BFC1FDD7F2300BFBAEF /* EventStream.swift */,
 				EBCC7DBB1BBF010C00A2AE92 /* Observer.swift */,
 				D871D69E1B3B29A40070F16C /* Optional.swift */,
 				9A090C131DA0309E00EE97CA /* Reactive.swift */,
@@ -899,6 +905,7 @@
 				EBCC7DBF1BBF01E200A2AE92 /* Observer.swift in Sources */,
 				C79B64801CD52E4E003F2376 /* EventLogger.swift in Sources */,
 				4A0E11021D2A92720065D310 /* Lifetime.swift in Sources */,
+				9A8E3C001FDD7F2300BFBAEF /* EventStream.swift in Sources */,
 				BE9CF3981D751B71003AE479 /* UnidirectionalBinding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -954,6 +961,7 @@
 				EBCC7DBE1BBF01E200A2AE92 /* Observer.swift in Sources */,
 				C79B647F1CD52E4D003F2376 /* EventLogger.swift in Sources */,
 				4A0E11011D2A92720065D310 /* Lifetime.swift in Sources */,
+				9A8E3BFF1FDD7F2300BFBAEF /* EventStream.swift in Sources */,
 				BE9CF3971D751B71003AE479 /* UnidirectionalBinding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -982,6 +990,7 @@
 				C79B647C1CD52E23003F2376 /* EventLogger.swift in Sources */,
 				9ABCB1851D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */,
 				D08C54B81A69A9D000AD8286 /* SignalProducer.swift in Sources */,
+				9A8E3BFD1FDD7F2300BFBAEF /* EventStream.swift in Sources */,
 				BE9CF3951D751B6B003AE479 /* UnidirectionalBinding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1037,6 +1046,7 @@
 				D0C312E819EF2A5800984962 /* Scheduler.swift in Sources */,
 				D0C312D019EF2A5800984962 /* Bag.swift in Sources */,
 				D0D11ABA1A6AE87700C1F8B1 /* Action.swift in Sources */,
+				9A8E3BFE1FDD7F2300BFBAEF /* EventStream.swift in Sources */,
 				BE9CF3961D751B70003AE479 /* UnidirectionalBinding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -174,39 +174,44 @@ extension Signal.Event: EventProtocol {
 	}
 }
 
-// Event Transformations
-//
-// Operators backed by event transformations have such characteristics:
-//
-// 1. Unary
-//    The operator applies to only one stream.
-//
-// 2. Serial
-//    The outcome need not be synchronously emitted, but all events must be delivered in
-//    serial order.
-//
-// 3. No side effect upon interruption.
-//    The operator must not perform any side effect upon receving `interrupted`.
-//
-// Examples of ineligible operators (for now):
-//
-// 1. `timeout`
-//    This operator forwards the `failed` event on a different scheduler.
-//
-// 2. `combineLatest`
-//    This operator applies to two or more streams.
-//
-// 3. `SignalProducer.then`
-//    This operator starts a second stream when the first stream completes.
-//
-// 4. `on`
-//    This operator performs side effect upon interruption.
+extension Signal.Event {
+	/// Event Transformation
+	///
+	/// Given an output sink and a upstream lifetime, an event transformation
+	/// yields an input sink which, for every event received, evaluates certain
+	/// side effects that emits zero or more events to the given output sink.
+	///
+	/// Operators are obliged to maintain:
+	///
+	/// 1. Serial event order
+	///    The outcome need not be synchronously emitted, but every event must
+	///    be delivered exclusively in serial order.
+	///
+	/// 2. No side effect upon interruption.
+	///    The operator must not perform any side effect upon receving `interrupted`.
+	///
+	/// When implementing operators with event transformations, one must
+	/// acknowledge that the output sink is not necessarily synchronized.
+	internal typealias Transformation<U, E: Swift.Error> = (_ outputSink: @escaping Signal<U, E>.Observer.Action, _ upstream: Lifetime) -> Signal<Value, Error>.Observer.Action
+
+	// Examples of ineligible operators (for now):
+	//
+	// 1. `timeout`
+	//    This operator forwards the `failed` event on a different scheduler.
+	//
+	// 2. `combineLatest`
+	//    This operator applies to two or more streams.
+	//
+	// 3. `SignalProducer.then`
+	//    This operator starts a second stream when the first stream completes.
+	//
+	// 4. `on`
+	//    This operator performs side effect upon interruption.
+}
 
 extension Signal.Event {
-	internal typealias Transformation<U, E: Swift.Error> = (@escaping Signal<U, E>.Observer.Action) -> (Signal<Value, Error>.Event) -> Void
-
 	internal static func filter(_ isIncluded: @escaping (Value) -> Bool) -> Transformation<Value, Error> {
-		return { action in
+		return { action, _ in
 			return { event in
 				switch event {
 				case let .value(value):
@@ -228,7 +233,7 @@ extension Signal.Event {
 	}
 
 	internal static func filterMap<U>(_ transform: @escaping (Value) -> U?) -> Transformation<U, Error> {
-		return { action in
+		return { action, _ in
 			return { event in
 				switch event {
 				case let .value(value):
@@ -250,7 +255,7 @@ extension Signal.Event {
 	}
 
 	internal static func map<U>(_ transform: @escaping (Value) -> U) -> Transformation<U, Error> {
-		return { action in
+		return { action, _ in
 			return { event in
 				switch event {
 				case let .value(value):
@@ -270,7 +275,7 @@ extension Signal.Event {
 	}
 
 	internal static func mapError<E>(_ transform: @escaping (Error) -> E) -> Transformation<Value, E> {
-		return { action in
+		return { action, _ in
 			return { event in
 				switch event {
 				case let .value(value):
@@ -290,7 +295,7 @@ extension Signal.Event {
 	}
 
 	internal static var materialize: Transformation<Signal<Value, Error>.Event, NoError> {
-		return { action in
+		return { action, _ in
 			return { event in
 				action(.value(event))
 
@@ -309,7 +314,7 @@ extension Signal.Event {
 	}
 
 	internal static func attemptMap<U>(_ transform: @escaping (Value) -> Result<U, Error>) -> Transformation<U, Error> {
-		return { action in
+		return { action, _ in
 			return { event in
 				switch event {
 				case let .value(value):
@@ -356,7 +361,7 @@ extension Signal.Event {
 	internal static func take(first count: Int) -> Transformation<Value, Error> {
 		assert(count >= 1)
 
-		return { action in
+		return { action, _ in
 			var taken = 0
 
 			return { event in
@@ -378,7 +383,7 @@ extension Signal.Event {
 	}
 
 	internal static func take(last count: Int) -> Transformation<Value, Error> {
-		return { action in
+		return { action, _ in
 			var buffer: [Value] = []
 			buffer.reserveCapacity(count)
 
@@ -406,7 +411,7 @@ extension Signal.Event {
 	}
 
 	internal static func take(while shouldContinue: @escaping (Value) -> Bool) -> Transformation<Value, Error> {
-		return { action in
+		return { action, _ in
 			return { event in
 				if let value = event.value, !shouldContinue(value) {
 					action(.completed)
@@ -420,7 +425,7 @@ extension Signal.Event {
 	internal static func skip(first count: Int) -> Transformation<Value, Error> {
 		precondition(count > 0)
 
-		return { action in
+		return { action, _ in
 			var skipped = 0
 
 			return { event in
@@ -434,7 +439,7 @@ extension Signal.Event {
 	}
 
 	internal static func skip(while shouldContinue: @escaping (Value) -> Bool) -> Transformation<Value, Error> {
-		return { action in
+		return { action, _ in
 			var isSkipping = true
 
 			return { event in
@@ -455,7 +460,7 @@ extension Signal.Event {
 
 extension Signal.Event where Value: EventProtocol {
 	internal static var dematerialize: Transformation<Value.Value, Value.Error> {
-		return { action in
+		return { action, _ in
 			return { event in
 				switch event {
 				case let .value(innerEvent):
@@ -524,7 +529,7 @@ extension Signal.Event {
 	}
 
 	internal static func collect(_ shouldEmit: @escaping (_ collectedValues: [Value]) -> Bool) -> Transformation<[Value], Error> {
-		return { action in
+		return { action, _ in
 			let state = CollectState<Value>()
 
 			return { event in
@@ -550,7 +555,7 @@ extension Signal.Event {
 	}
 
 	internal static func collect(_ shouldEmit: @escaping (_ collected: [Value], _ latest: Value) -> Bool) -> Transformation<[Value], Error> {
-		return { action in
+		return { action, _ in
 			let state = CollectState<Value>()
 
 			return { event in
@@ -580,7 +585,7 @@ extension Signal.Event {
 	/// `nil` literal would be materialized as `Optional<Value>.none` instead of `Value`,
 	/// thus changing the semantic.
 	internal static func combinePrevious(initial: Value?) -> Transformation<(Value, Value), Error> {
-		return { action in
+		return { action, _ in
 			var previous = initial
 
 			return { event in
@@ -602,7 +607,7 @@ extension Signal.Event {
 	}
 
 	internal static func skipRepeats(_ isEquivalent: @escaping (Value, Value) -> Bool) -> Transformation<Value, Error> {
-		return { action in
+		return { action, _ in
 			var previous: Value?
 
 			return { event in
@@ -621,7 +626,7 @@ extension Signal.Event {
 	}
 
 	internal static func uniqueValues<Identity: Hashable>(_ transform: @escaping (Value) -> Identity) -> Transformation<Value, Error> {
-		return { action in
+		return { action, _ in
 			var seenValues: Set<Identity> = []
 
 			return { event in
@@ -641,7 +646,7 @@ extension Signal.Event {
 	}
 
 	internal static func scan<U>(into initialResult: U, _ nextPartialResult: @escaping (inout U, Value) -> Void) -> Transformation<U, Error> {
-		return { action in
+		return { action, _ in
 			var accumulator = initialResult
 
 			return { event in
@@ -658,7 +663,7 @@ extension Signal.Event {
 	}
 
 	internal static func reduce<U>(into initialResult: U, _ nextPartialResult: @escaping (inout U, Value) -> Void) -> Transformation<U, Error> {
-		return { action in
+		return { action, _ in
 			var accumulator = initialResult
 
 			return { event in
@@ -682,7 +687,7 @@ extension Signal.Event {
 	}
 
 	internal static func observe(on scheduler: Scheduler) -> Transformation<Value, Error> {
-		return { action in
+		return { action, _ in
 			return { event in
 				scheduler.schedule {
 					action(event)
@@ -694,7 +699,7 @@ extension Signal.Event {
 	internal static func delay(_ interval: TimeInterval, on scheduler: DateScheduler) -> Transformation<Value, Error> {
 		precondition(interval >= 0)
 
-		return { action in
+		return { action, _ in
 			return { event in
 				switch event {
 				case .failed, .interrupted:
@@ -715,7 +720,7 @@ extension Signal.Event {
 	internal static func throttle(_ interval: TimeInterval, on scheduler: DateScheduler) -> Transformation<Value, Error> {
 		precondition(interval >= 0)
 
-		return { action in
+		return { action, _ in
 			let state: Atomic<ThrottleState<Value>> = Atomic(ThrottleState())
 			let schedulerDisposable = SerialDisposable()
 
@@ -769,7 +774,7 @@ extension Signal.Event {
 	internal static func debounce(_ interval: TimeInterval, on scheduler: DateScheduler) -> Transformation<Value, Error> {
 		precondition(interval >= 0)
 
-		return { action in
+		return { action, _ in
 			let d = SerialDisposable()
 
 			return { event in
@@ -797,7 +802,7 @@ private struct ThrottleState<Value> {
 
 extension Signal.Event where Error == NoError {
 	internal static func promoteError<F>(_: F.Type) -> Transformation<Value, F> {
-		return { action in
+		return { action, _ in
 			return { event in
 				switch event {
 				case let .value(value):
@@ -816,7 +821,7 @@ extension Signal.Event where Error == NoError {
 
 extension Signal.Event where Value == Never {
 	internal static func promoteValue<U>(_: U.Type) -> Transformation<U, Error> {
-		return { action in
+		return { action, _ in
 			return { event in
 				switch event {
 				case .value:
@@ -829,6 +834,37 @@ extension Signal.Event where Value == Never {
 					action(.interrupted)
 				}
 			}
+		}
+	}
+}
+
+extension Signal.Event {
+	internal static func take(during lifetime: Lifetime) -> Transformation<Value, Error> {
+		return { action, innerLifetime in
+			innerLifetime += lifetime.observeEnded {
+				action(.completed)
+			}
+
+			return action
+		}
+	}
+
+	internal static func take<S: EventStream>(until stream: S) -> Transformation<Value, Error> where S.Value == (), S.Error == NoError {
+		return { action, lifetime in
+			stream.subscribe { interrupter in
+				lifetime += interrupter
+
+				return Signal<(), NoError>.Observer { event in
+					switch event {
+					case .value, .completed:
+						action(.completed)
+					case .failed, .interrupted:
+						break
+					}
+				}
+			}
+
+			return action
 		}
 	}
 }

--- a/Sources/EventStream.swift
+++ b/Sources/EventStream.swift
@@ -1,0 +1,26 @@
+internal protocol EventStream {
+	associatedtype Value
+	associatedtype Error: Swift.Error
+
+	@discardableResult
+	func subscribe(_ setup: (Disposable) -> Signal<Value, Error>.Observer) -> Disposable
+}
+
+extension Signal: EventStream {
+	internal func subscribe(_ setup: (Disposable) -> Signal<Value, Error>.Observer) -> Disposable {
+		let d = _SimpleDisposable()
+		let observer = setup(d)
+
+		guard !d.isDisposed, let detacher = observe(observer) else {
+			return NopDisposable.shared
+		}
+
+		return detacher
+	}
+}
+
+extension SignalProducer: EventStream {
+	internal func subscribe(_ setup: (Disposable) -> Signal<Value, Error>.Observer) -> Disposable {
+		return startWithInterrupter(setup)
+	}
+}

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -57,94 +57,44 @@ public final class Signal<Value, Error: Swift.Error> {
 		/// as the last +1 retain of the `Signal` core may deinitialize.
 		fileprivate let disposable: CompositeDisposable
 
-		/// The state of the signal.
-		private var state: State
-
-		/// Used to ensure that all state accesses are serialized.
+		/// Lock for states.
 		private let stateLock: Lock
 
-		/// Used to ensure that events are serialized during delivery to observers.
-		private let sendLock: Lock
+		/// The observers of the `Signal`.
+		private var observers: Bag<Observer>?
+
+		/// Whether the `Signal` has been deinitialized and hence no any further
+		/// observer can ever be attached.
+		private var hasDeinitialized: Bool
 
 		fileprivate init(_ generator: (Observer, Lifetime) -> Void) {
-			state = .alive(Bag(), hasDeinitialized: false)
-
-			stateLock = Lock.make()
-			sendLock = Lock.make()
 			disposable = CompositeDisposable()
+			stateLock = Lock.make()
+			observers = Bag()
+			hasDeinitialized = false
 
 			// The generator observer retains the `Signal` core.
-			generator(Observer(action: self.send, interruptsOnDeinit: true), Lifetime(disposable))
+			let sink = Event.makeSynchronizing(self.send, disposable: disposable)
+			let inputObserver = Observer(action: sink, interruptsOnDeinit: true)
+			generator(inputObserver, Lifetime(disposable))
 		}
 
 		private func send(_ event: Event) {
+			stateLock.lock()
+
+			guard let observers = self.observers else {
+				stateLock.unlock()
+				return
+			}
+
 			if event.isTerminating {
-				// Recursive events are disallowed for `value` events, but are permitted
-				// for termination events. Specifically:
-				//
-				// - `interrupted`
-				// It can inadvertently be sent by downstream consumers as part of the
-				// `SignalProducer` mechanics.
-				//
-				// - `completed`
-				// If a downstream consumer weakly references an object, invocation of
-				// such consumer may cause a race condition with its weak retain against
-				// the last strong release of the object. If the `Lifetime` of the
-				// object is being referenced by an upstream `take(during:)`, a
-				// signal recursion might occur.
-				//
-				// So we would treat termination events specially. If it happens to
-				// occur while the `sendLock` is acquired, the observer call-out and
-				// the disposal would be delegated to the current sender, or
-				// occasionally one of the senders waiting on `sendLock`.
+				self.observers = nil
+			}
 
-				self.stateLock.lock()
+			stateLock.unlock()
 
-				if case let .alive(observers, _) = state {
-					self.state = .terminating(observers, .init(event))
-					self.stateLock.unlock()
-				} else {
-					self.stateLock.unlock()
-				}
-
-				tryToCommitTermination()
-			} else {
-				self.sendLock.lock()
-				self.stateLock.lock()
-
-				if case let .alive(observers, _) = self.state {
-					self.stateLock.unlock()
-
-					for observer in observers {
-						observer.send(event)
-					}
-				} else {
-					self.stateLock.unlock()
-				}
-
-				self.sendLock.unlock()
-
-				// Check if the status has been bumped to `terminating` due to a
-				// terminal event being sent concurrently or recursively.
-				//
-				// The check is deliberately made outside of the `sendLock` so that it
-				// covers also any potential concurrent terminal event in one shot.
-				//
-				// Related PR:
-				// https://github.com/ReactiveCocoa/ReactiveSwift/pull/112
-				//
-				// While calling `tryToCommitTermination` is sufficient, this is a fast
-				// path for the recurring value delivery.
-				//
-				// Note that this cannot be `try` since any concurrent observer bag
-				// manipulation might then cause the terminating state being missed.
-				stateLock.lock()
-				if case .terminating = state {
-					stateLock.unlock()
-					tryToCommitTermination()
-				} else {
-					stateLock.unlock()
-				}
+			for observer in observers {
+				observer.send(event)
 			}
 		}
 
@@ -156,16 +106,8 @@ public final class Signal<Value, Error: Swift.Error> {
 		/// - returns: A `Disposable` which can be used to disconnect the observer,
 		///            or `nil` if the signal has already terminated.
 		fileprivate func observe(_ observer: Observer) -> Disposable? {
-			var token: Bag<Observer>.Token?
-
 			stateLock.lock()
-
-			if case let .alive(observers, hasDeinitialized) = state {
-				var newObservers = observers
-				token = newObservers.insert(observer)
-				self.state = .alive(newObservers, hasDeinitialized: hasDeinitialized)
-			}
-
+			let token = observers?.insert(observer)
 			stateLock.unlock()
 
 			if let token = token {
@@ -184,56 +126,15 @@ public final class Signal<Value, Error: Swift.Error> {
 		///   - token: The token of the observer to remove.
 		private func removeObserver(with token: Bag<Observer>.Token) {
 			stateLock.lock()
+			let observer = observers?.remove(using: token)
 
-			if case let .alive(observers, hasDeinitialized) = state {
-				var newObservers = observers
-				let observer = newObservers.remove(using: token)
-				self.state = .alive(newObservers, hasDeinitialized: hasDeinitialized)
-
-				// Ensure `observer` is deallocated after `stateLock` is
-				// released to avoid deadlocks.
-				withExtendedLifetime(observer) {
-					// Start the disposal of the `Signal` core if the `Signal` has
-					// deinitialized and there is no active observer.
-					tryToDisposeSilentlyIfQualified(unlocking: stateLock)
-				}
-			} else {
-				stateLock.unlock()
+			// Ensure `observer` is deallocated after `stateLock` is
+			// released to avoid deadlocks.
+			withExtendedLifetime(observer) {
+				// Start the disposal of the `Signal` core if the `Signal` has
+				// deinitialized and there is no active observer.
+				tryToDisposeSilentlyIfQualified(unlocking: stateLock)
 			}
-		}
-
-		/// Try to commit the termination, or in other words transition the signal from a
-		/// terminating state to a terminated state.
-		///
-		/// It fails gracefully if the signal is alive or has terminated. Calling this
-		/// method as a result of a false positive `terminating` check is permitted.
-		///
-		/// - precondition: `stateLock` must not be acquired by the caller.
-		private func tryToCommitTermination() {
-			// Acquire `stateLock`. If the termination has still not yet been
-			// handled, take it over and bump the status to `terminated`.
-			stateLock.lock()
-
-			if case let .terminating(observers, terminationKind) = state {
-				// Try to acquire the `sendLock`, and fail gracefully since the current
-				// lock holder would attempt to commit after it is done anyway.
-				if sendLock.try() {
-					state = .terminated
-					stateLock.unlock()
-
-					if let event = terminationKind.materialize() {
-						for observer in observers {
-							observer.send(event)
-						}
-					}
-
-					sendLock.unlock()
-					disposable.dispose()
-					return
-				}
-			}
-
-			stateLock.unlock()
 		}
 
 		/// Try to dispose of the signal silently if the `Signal` has deinitialized and
@@ -247,24 +148,17 @@ public final class Signal<Value, Error: Swift.Error> {
 		/// - parameters:
 		///   - stateLock: The `stateLock` acquired by the caller.
 		private func tryToDisposeSilentlyIfQualified(unlocking stateLock: Lock) {
-			assert(!stateLock.try(), "Calling `unconditionallyTerminate` without acquiring `stateLock`.")
+			assert(!stateLock.try(), "Calling `tryToDisposeSilentlyIfQualified` without acquiring `stateLock`.")
 
-			if case let .alive(observers, true) = state, observers.isEmpty {
-				// Transition to `terminated` directly only if there is no event delivery
-				// on going.
-				if sendLock.try() {
-					self.state = .terminated
-					stateLock.unlock()
-					sendLock.unlock()
-
-					disposable.dispose()
-					return
-				}
-
-				self.state = .terminating(Bag(), .silent)
+			if hasDeinitialized, let observers = self.observers, observers.isEmpty {
+				var observers: Bag<Observer>? = nil
+				swap(&observers, &self.observers)
 				stateLock.unlock()
 
-				tryToCommitTermination()
+				withExtendedLifetime(observers) {
+					disposable.dispose()
+				}
+
 				return
 			}
 
@@ -276,9 +170,7 @@ public final class Signal<Value, Error: Swift.Error> {
 			stateLock.lock()
 
 			// Mark the `Signal` has now deinitialized.
-			if case let .alive(observers, false) = state {
-				state = .alive(observers, hasDeinitialized: true)
-			}
+			hasDeinitialized = true
 
 			// Attempt to start the disposal of the signal if it has no active observer.
 			tryToDisposeSilentlyIfQualified(unlocking: stateLock)
@@ -320,60 +212,6 @@ public final class Signal<Value, Error: Swift.Error> {
 
 	deinit {
 		core.signalDidDeinitialize()
-	}
-
-	/// The state of a `Signal`.
-	///
-	/// `SignalState` is guaranteed to be laid out as a tagged pointer by the Swift
-	/// compiler in the support targets of the Swift 3.0.1 ABI.
-	///
-	/// The Swift compiler has also an optimization for enums with payloads that are
-	/// all reference counted, and at most one no-payload case.
-	private enum State {
-		// `TerminationKind` is constantly pointer-size large to keep `Signal.Core`
-		// allocation size independent of the actual `Value` and `Error` types.
-		enum TerminationKind {
-			case completed
-			case interrupted
-			case failed(Swift.Error)
-			case silent
-
-			init(_ event: Event) {
-				switch event {
-				case .value:
-					fatalError()
-				case .interrupted:
-					self = .interrupted
-				case let .failed(error):
-					self = .failed(error)
-				case .completed:
-					self = .completed
-				}
-			}
-
-			func materialize() -> Event? {
-				switch self {
-				case .completed:
-					return .completed
-				case .interrupted:
-					return .interrupted
-				case let .failed(error):
-					return .failed(error as! Error)
-				case .silent:
-					return nil
-				}
-			}
-		}
-
-		/// The `Signal` is alive.
-		case alive(Bag<Observer>, hasDeinitialized: Bool)
-
-		/// The `Signal` has received a termination event, and is about to be
-		/// terminated.
-		case terminating(Bag<Observer>, TerminationKind)
-
-		/// The `Signal` has terminated.
-		case terminated
 	}
 }
 


### PR DESCRIPTION
Depends on #575.

Lower binary ops like how the unary ops already do.

Two pilots `take(during:)` and `take(until:)` are lowered here, and they are particularly important given how commonly recursive terminal events happen to them.