### PR TITLE
Separate the serialization and multicast logic in `Signal`.

### DIFF
--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -18,6 +18,10 @@ import Result
 ///    1. its input observer receives a terminating event; or
 ///    2. it has no active observers, and is not being retained.
 public final class Signal<Value, Error: Swift.Error> {
+	internal var lifetime: Lifetime {
+		return Lifetime(core.disposable)
+	}
+
 	/// The `Signal` core which manages the event stream.
 	///
 	/// A `Signal` is the externally retained shell of the `Signal` core. The separation
@@ -51,96 +55,55 @@ public final class Signal<Value, Error: Swift.Error> {
 		/// Disposing of `disposable` is assumed to remove the generator
 		/// observer from its attached `Signal`, so that the generator observer
 		/// as the last +1 retain of the `Signal` core may deinitialize.
-		private let disposable: CompositeDisposable
+		fileprivate let disposable: CompositeDisposable
 
-		/// The state of the signal.
-		private var state: State
-
-		/// Used to ensure that all state accesses are serialized.
+		/// Lock for states.
 		private let stateLock: Lock
 
-		/// Used to ensure that events are serialized during delivery to observers.
-		private let sendLock: Lock
+		/// The observers of the `Signal`.
+		private var observers: Bag<Observer>?
+
+		/// Whether the `Signal` has been deinitialized and hence no any further
+		/// observer can ever be attached.
+		private var hasDeinitialized: Bool
 
 		fileprivate init(_ generator: (Observer, Lifetime) -> Void) {
-			state = .alive(Bag(), hasDeinitialized: false)
-
-			stateLock = Lock.make()
-			sendLock = Lock.make()
 			disposable = CompositeDisposable()
+			stateLock = Lock.make()
+			observers = Bag()
+			hasDeinitialized = false
+
+			disposable += AnyDisposable { [weak self] in
+				guard let strongSelf = self else { return }
+
+				/// Ensure the observers are deinitialized after we release the
+				/// lock, since an observer could eventually result in
+				/// an synchronous attempt to detach observers from `self`.
+				withExtendedLifetime(strongSelf.observers) {
+					strongSelf.stateLock.lock()
+					strongSelf.observers = nil
+					strongSelf.stateLock.unlock()
+				}
+			}
 
 			// The generator observer retains the `Signal` core.
-			generator(Observer(action: self.send, interruptsOnDeinit: true), Lifetime(disposable))
+			let sink = Event.makeSynchronizing(self.send, disposable: disposable)
+			let inputObserver = Observer(action: sink, interruptsOnDeinit: true)
+			generator(inputObserver, Lifetime(disposable))
 		}
 
 		private func send(_ event: Event) {
-			if event.isTerminating {
-				// Recursive events are disallowed for `value` events, but are permitted
-				// for termination events. Specifically:
-				//
-				// - `interrupted`
-				// It can inadvertently be sent by downstream consumers as part of the
-				// `SignalProducer` mechanics.
-				//
-				// - `completed`
-				// If a downstream consumer weakly references an object, invocation of
-				// such consumer may cause a race condition with its weak retain against
-				// the last strong release of the object. If the `Lifetime` of the
-				// object is being referenced by an upstream `take(during:)`, a
-				// signal recursion might occur.
-				//
-				// So we would treat termination events specially. If it happens to
-				// occur while the `sendLock` is acquired, the observer call-out and
-				// the disposal would be delegated to the current sender, or
-				// occasionally one of the senders waiting on `sendLock`.
+			stateLock.lock()
 
-				self.stateLock.lock()
+			guard let observers = self.observers else {
+				stateLock.unlock()
+				return
+			}
 
-				if case let .alive(observers, _) = state {
-					self.state = .terminating(observers, .init(event))
-					self.stateLock.unlock()
-				} else {
-					self.stateLock.unlock()
-				}
+			stateLock.unlock()
 
-				tryToCommitTermination()
-			} else {
-				self.sendLock.lock()
-				self.stateLock.lock()
-
-				if case let .alive(observers, _) = self.state {
-					self.stateLock.unlock()
-
-					for observer in observers {
-						observer.send(event)
-					}
-				} else {
-					self.stateLock.unlock()
-				}
-
-				self.sendLock.unlock()
-
-				// Check if the status has been bumped to `terminating` due to a
-				// terminal event being sent concurrently or recursively.
-				//
-				// The check is deliberately made outside of the `sendLock` so that it
-				// covers also any potential concurrent terminal event in one shot.
-				//
-				// Related PR:
-				// https://github.com/ReactiveCocoa/ReactiveSwift/pull/112
-				//
-				// While calling `tryToCommitTermination` is sufficient, this is a fast
-				// path for the recurring value delivery.
-				//
-				// Note that this cannot be `try` since any concurrent observer bag
-				// manipulation might then cause the terminating state being missed.
-				stateLock.lock()
-				if case .terminating = state {
-					stateLock.unlock()
-					tryToCommitTermination()
-				} else {
-					stateLock.unlock()
-				}
+			for observer in observers {
+				observer.send(event)
 			}
 		}
 
@@ -152,16 +115,8 @@ public final class Signal<Value, Error: Swift.Error> {
 		/// - returns: A `Disposable` which can be used to disconnect the observer,
 		///            or `nil` if the signal has already terminated.
 		fileprivate func observe(_ observer: Observer) -> Disposable? {
-			var token: Bag<Observer>.Token?
-
 			stateLock.lock()
-
-			if case let .alive(observers, hasDeinitialized) = state {
-				var newObservers = observers
-				token = newObservers.insert(observer)
-				self.state = .alive(newObservers, hasDeinitialized: hasDeinitialized)
-			}
-
+			let token = observers?.insert(observer)
 			stateLock.unlock()
 
 			if let token = token {
@@ -180,56 +135,15 @@ public final class Signal<Value, Error: Swift.Error> {
 		///   - token: The token of the observer to remove.
 		private func removeObserver(with token: Bag<Observer>.Token) {
 			stateLock.lock()
+			let observer = observers?.remove(using: token)
 
-			if case let .alive(observers, hasDeinitialized) = state {
-				var newObservers = observers
-				let observer = newObservers.remove(using: token)
-				self.state = .alive(newObservers, hasDeinitialized: hasDeinitialized)
-
-				// Ensure `observer` is deallocated after `stateLock` is
-				// released to avoid deadlocks.
-				withExtendedLifetime(observer) {
-					// Start the disposal of the `Signal` core if the `Signal` has
-					// deinitialized and there is no active observer.
-					tryToDisposeSilentlyIfQualified(unlocking: stateLock)
-				}
-			} else {
-				stateLock.unlock()
+			// Ensure `observer` is deallocated after `stateLock` is
+			// released to avoid deadlocks.
+			withExtendedLifetime(observer) {
+				// Start the disposal of the `Signal` core if the `Signal` has
+				// deinitialized and there is no active observer.
+				tryToDisposeSilentlyIfQualified(unlocking: stateLock)
 			}
-		}
-
-		/// Try to commit the termination, or in other words transition the signal from a
-		/// terminating state to a terminated state.
-		///
-		/// It fails gracefully if the signal is alive or has terminated. Calling this
-		/// method as a result of a false positive `terminating` check is permitted.
-		///
-		/// - precondition: `stateLock` must not be acquired by the caller.
-		private func tryToCommitTermination() {
-			// Acquire `stateLock`. If the termination has still not yet been
-			// handled, take it over and bump the status to `terminated`.
-			stateLock.lock()
-
-			if case let .terminating(observers, terminationKind) = state {
-				// Try to acquire the `sendLock`, and fail gracefully since the current
-				// lock holder would attempt to commit after it is done anyway.
-				if sendLock.try() {
-					state = .terminated
-					stateLock.unlock()
-
-					if let event = terminationKind.materialize() {
-						for observer in observers {
-							observer.send(event)
-						}
-					}
-
-					sendLock.unlock()
-					disposable.dispose()
-					return
-				}
-			}
-
-			stateLock.unlock()
 		}
 
 		/// Try to dispose of the signal silently if the `Signal` has deinitialized and
@@ -243,24 +157,17 @@ public final class Signal<Value, Error: Swift.Error> {
 		/// - parameters:
 		///   - stateLock: The `stateLock` acquired by the caller.
 		private func tryToDisposeSilentlyIfQualified(unlocking stateLock: Lock) {
-			assert(!stateLock.try(), "Calling `unconditionallyTerminate` without acquiring `stateLock`.")
+			assert(!stateLock.try(), "Calling `tryToDisposeSilentlyIfQualified` without acquiring `stateLock`.")
 
-			if case let .alive(observers, true) = state, observers.isEmpty {
-				// Transition to `terminated` directly only if there is no event delivery
-				// on going.
-				if sendLock.try() {
-					self.state = .terminated
-					stateLock.unlock()
-					sendLock.unlock()
-
-					disposable.dispose()
-					return
-				}
-
-				self.state = .terminating(Bag(), .silent)
+			if hasDeinitialized, let observers = self.observers, observers.isEmpty {
+				var observers: Bag<Observer>? = nil
+				swap(&observers, &self.observers)
 				stateLock.unlock()
 
-				tryToCommitTermination()
+				withExtendedLifetime(observers) {
+					disposable.dispose()
+				}
+
 				return
 			}
 
@@ -272,9 +179,7 @@ public final class Signal<Value, Error: Swift.Error> {
 			stateLock.lock()
 
 			// Mark the `Signal` has now deinitialized.
-			if case let .alive(observers, false) = state {
-				state = .alive(observers, hasDeinitialized: true)
-			}
+			hasDeinitialized = true
 
 			// Attempt to start the disposal of the signal if it has no active observer.
 			tryToDisposeSilentlyIfQualified(unlocking: stateLock)
@@ -316,60 +221,6 @@ public final class Signal<Value, Error: Swift.Error> {
 
 	deinit {
 		core.signalDidDeinitialize()
-	}
-
-	/// The state of a `Signal`.
-	///
-	/// `SignalState` is guaranteed to be laid out as a tagged pointer by the Swift
-	/// compiler in the support targets of the Swift 3.0.1 ABI.
-	///
-	/// The Swift compiler has also an optimization for enums with payloads that are
-	/// all reference counted, and at most one no-payload case.
-	private enum State {
-		// `TerminationKind` is constantly pointer-size large to keep `Signal.Core`
-		// allocation size independent of the actual `Value` and `Error` types.
-		enum TerminationKind {
-			case completed
-			case interrupted
-			case failed(Swift.Error)
-			case silent
-
-			init(_ event: Event) {
-				switch event {
-				case .value:
-					fatalError()
-				case .interrupted:
-					self = .interrupted
-				case let .failed(error):
-					self = .failed(error)
-				case .completed:
-					self = .completed
-				}
-			}
-
-			func materialize() -> Event? {
-				switch self {
-				case .completed:
-					return .completed
-				case .interrupted:
-					return .interrupted
-				case let .failed(error):
-					return .failed(error as! Error)
-				case .silent:
-					return nil
-				}
-			}
-		}
-
-		/// The `Signal` is alive.
-		case alive(Bag<Observer>, hasDeinitialized: Bool)
-
-		/// The `Signal` has received a termination event, and is about to be
-		/// terminated.
-		case terminating(Bag<Observer>, TerminationKind)
-
-		/// The `Signal` has terminated.
-		case terminated
 	}
 }
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -106,21 +106,6 @@ public final class Signal<Value, Error: Swift.Error> {
 			generator(inputObserver, Lifetime(disposable))
 		}
 
-		private func send(_ event: Event) {
-			stateLock.lock()
-
-			guard let observers = self.observers else {
-				stateLock.unlock()
-				return
-			}
-
-			stateLock.unlock()
-
-			for observer in observers {
-				observer.send(event)
-			}
-		}
-
 		/// Observe the Signal by sending any future events to the given observer.
 		///
 		/// - parameters:

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -290,23 +290,19 @@ class SignalSpec: QuickSpec {
 					events.append(event)
 				}
 
-				let group = DispatchGroup()
-
-				DispatchQueue.concurrentPerform(iterations: 10) { index in
-					queue.async(group: group) {
+				DispatchQueue.concurrentPerform(iterations: 11) { index in
+					if index < 10 {
 						observer.send(value: index)
-					}
-
-					if index == 0 {
+					} else {
 						semaphore.wait()
 						observer.sendInterrupted()
 					}
 				}
 
-				group.wait()
-
-				expect(events.count) == 2
-				expect(events.first?.value).toNot(beNil())
+				// (1 to 10 values + 1 interruption) = 2 to 11 events
+				expect(events.count) >= 2
+				expect(events.count) <= 11
+				expect(events.dropLast().contains { $0.isTerminating }) == false
 				expect(events.last?.isTerminating) == true
 			}
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -263,7 +263,6 @@ class SignalSpec: QuickSpec {
 		describe("interruption") {
 			it("should not send events after sending an interrupted event") {
 				let queue: DispatchQueue
-				let counter = Atomic<Int>(0)
 
 				if #available(macOS 10.10, *) {
 					queue = DispatchQueue.global(qos: .userInitiated)
@@ -271,39 +270,43 @@ class SignalSpec: QuickSpec {
 					queue = DispatchQueue.global(priority: .high)
 				}
 
-				let (signal, observer) = Signal<Int, NoError>.pipe()
+				// NOTE: Parallelising this test case would cause the issue to
+				//       subdue due to queue oversubscription.
+				for _ in 0 ..< 20 {
+					let (signal, observer) = Signal<Int, NoError>.pipe()
 
-				var hasSlept = false
-				var events: [Signal<Int, NoError>.Event] = []
+					var hasSlept = false
+					var events: [Signal<Int, NoError>.Event] = []
 
-				// Used to synchronize the `interrupt` sender to only act after the
-				// chosen observer has started sending its event, but before it is done.
-				let semaphore = DispatchSemaphore(value: 0)
+					// Used to synchronize the `interrupt` sender to only act after the
+					// chosen observer has started sending its event, but before it is done.
+					let semaphore = DispatchSemaphore(value: 0)
 
-				signal.observe { event in
-					if !hasSlept {
-						semaphore.signal()
-						// 100000 us = 0.1 s
-						usleep(100000)
-						hasSlept = true
+					signal.observe { event in
+						if !hasSlept {
+							semaphore.signal()
+							// 100000 us = 0.1 s
+							usleep(100000)
+							hasSlept = true
+						}
+						events.append(event)
 					}
-					events.append(event)
-				}
 
-				DispatchQueue.concurrentPerform(iterations: 11) { index in
-					if index < 10 {
-						observer.send(value: index)
-					} else {
-						semaphore.wait()
-						observer.sendInterrupted()
+					DispatchQueue.concurrentPerform(iterations: 11) { index in
+						if index < 10 {
+							observer.send(value: index)
+						} else {
+							semaphore.wait()
+							observer.sendInterrupted()
+						}
 					}
-				}
 
-				// (1 to 10 values + 1 interruption) = 2 to 11 events
-				expect(events.count) >= 2
-				expect(events.count) <= 11
-				expect(events.dropLast().contains { $0.isTerminating }) == false
-				expect(events.last?.isTerminating) == true
+					// (1 to 10 values + 1 interruption) = 2 to 11 events
+					expect(events.count) >= 2
+					expect(events.count) <= 11
+					expect(events.dropLast().contains { $0.isTerminating }) == false
+					expect(events.last?.isTerminating) == true
+				}
 			}
 
 			it("should interrupt concurrently") {


### PR DESCRIPTION
Break part of the Signal.Core synchronisation logic out, so that we may reuse it for:

1. lowering n-ary operators as event transforms e.g. #573; and
2. (hopefully) simplifying the `combineLatest` and `zip` implementations, which currently replicates part of the `Signal.Core` to deal with recursive terminal events.