### PR TITLE
Fixed a scenario of downstream interruptions being dropped.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # master
 *Please add new entries at the top.*
 
+1. Fixed a scenario of downstream interruptions being dropped. (#577, kudos to @andersio)
+
+   Manual interruption of time shifted producers, including `delay`, `observe(on:)`, `throttle`, `debounce` and `lazyMap`, should discard outstanding events at best effort ASAP.
+
+   But in ReactiveSwift 2.0 to 3.0, the manual interruption is ignored if the upstream producer has terminated. For example:
+
+   ```swift
+   // Completed upstream + `delay`.
+   SignalProducer.empty
+       .delay(10.0, on: QueueScheduler.main)
+       .startWithCompleted { print("Value should have been discarded!") }
+       .dispose()
+
+   // Console(t+10): Value should have been discarded!
+   ```
+
+   The expected behavior has now been restored.
+
+   Please note that, since ReactiveSwift 2.0, while the interruption is handled immediately, the `interrupted` event delivery is not synchronous — it generally respects the closest asynchronous operator applied, and delivers on that scheduler.
+
 1. `concat` for `SignalProducer` now has an overload that accepts an error.
 
 1. Fix some documentation errors (#560, kudos to @ikesyo)

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -16,58 +16,6 @@ extension Signal {
 		/// Whether the observer should send an `interrupted` event as it deinitializes.
 		private let interruptsOnDeinit: Bool
 
-		/// An initializer that transforms the action of the given observer with the
-		/// given transform.
-		///
-		/// If the given observer would perform side effect on deinitialization, the
-		/// created observer would retain it.
-		///
-		/// - parameters:
-		///   - observer: The observer to transform.
-		///   - transform: The transform.
-		///   - disposables: The disposable to be disposed of upon termination.
-		internal init<U, E>(
-			producerObserver: Signal<U, E>.Observer,
-			applying transform: @escaping Event.Transformation<U, E>,
-			disposables: CompositeDisposable
-		) {
-			var hasDeliveredTerminalEvent = false
-
-			let wrappedOutputSink: Signal<U, E>.Observer.Action = { event in
-				if !hasDeliveredTerminalEvent {
-					producerObserver._send(event)
-
-					if event.isTerminating {
-						hasDeliveredTerminalEvent = true
-						disposables.dispose()
-					}
-				}
-			}
-
-			self._send = transform(wrappedOutputSink, Lifetime(disposables))
-			self.interruptsOnDeinit = false
-		}
-
-		/// An initializer that transforms the action of the given observer with the
-		/// given transform.
-		///
-		/// If the given observer would perform side effect on deinitialization, the
-		/// created observer would retain it.
-		///
-		/// - parameters:
-		///   - observer: The observer to transform.
-		///   - transform: The transform.
-		///   - disposables: The disposable to be disposed of upon termination.
-		///                 Used by `SignalProducer` only, since `Signal` takes.
-		internal init<U, E>(
-			signalObserver: Signal<U, E>.Observer,
-			applying transform: @escaping Event.Transformation<U, E>,
-			lifetime: Lifetime
-		) {
-			self._send = transform({ signalObserver._send($0) }, lifetime)
-			self.interruptsOnDeinit = false
-		}
-
 		/// An initializer that accepts a closure accepting an event for the
 		/// observer.
 		///

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -538,10 +538,12 @@ extension Signal {
 	///
 	/// - returns: A signal that forwards events yielded by the action.
 	internal func flatMapEvent<U, E>(_ transform: @escaping Event.Transformation<U, E>) -> Signal<U, E> {
-		return Signal<U, E> { observer, lifetime in
-			lifetime += self.observe(Signal.Observer(signalObserver: observer,
-													 applying: transform,
-													 lifetime: lifetime))
+		return Signal<U, E> { output, lifetime in
+			// Create an input sink whose events would go through the given
+			// event transformation, and have the resulting events propagated
+			// to the resulting `Signal`.
+			let input = transform(output.send, lifetime)
+			lifetime += self.observe(input)
 		}
 	}
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -539,7 +539,9 @@ extension Signal {
 	/// - returns: A signal that forwards events yielded by the action.
 	internal func flatMapEvent<U, E>(_ transform: @escaping Event.Transformation<U, E>) -> Signal<U, E> {
 		return Signal<U, E> { observer, lifetime in
-			lifetime += self.observe(Signal.Observer(observer, transform))
+			lifetime += self.observe(Signal.Observer(signalObserver: observer,
+													 applying: transform,
+													 lifetime: lifetime))
 		}
 	}
 


### PR DESCRIPTION
### Scope
The issue apparently exists since 2.0 with producer lifting optimisation (#140), and is also applicable to `TransformerCore`.

### Symptom
With a terminated upstream, manual interruption of time shifted producers, including `delay`, `observe(on:)`, `throttle`, `debounce` and `lazyMap`, would be ignored.

This is due to the operator lifting scheme introduced in #140, which blatantly assumes the upstream always lives longer than the downstream & therefore is always available to handle the downstream/user interruption.

Simple example:
```swift
// Completed upstream + `delay`.
SignalProducer.empty
    .delay(10.0, on: QueueScheduler.main)
    .startWithCompleted { print("Value should have been discarded!") }
    .dispose()

// Console(t+10): Value should have been discarded!
```

### Proposed Fix
#### Transformation Core

The first part of the fix establishes a `CompositeDisposable` specifically for the event transformation (the combined version if nested), which is disposed of only if the transformation outputs a terminal event.

(Pretty much like operator lifting in 1.0 and earlier, but one `CompositeDisposable` being shared by all operators).

 This allows asynchronous event transformation to response to user/downstream interruption properly.

#### Operator Lifting for `SignalProducer`

The second part of the fix reverts the implementation of `SignalProducer.lift` to pre-#140 times.

Operator lifting has a significantly reduced role since 3.0. With a large set of operators already being lowered as event transforms, I believe the impact would be minimal.

#### Note on async operators & `interrupted` delivery
The fix _still_ maintains the semantic of `interrupted` respecting async operators, introduced in 2.0 (#140).

Summary: When the product of async operators like `observe(on:)` gets interrupted, unless otherwise specified, the `interrupted` event should be delivered on the respective scheduler.

`lazyMap` does not follow this yet, and we should probably reimplement it as event transform at a later point.

`timeout` is an odd one with only the failure delivered asynchronously, so it isn't bound by the said semantic.

#### Acknowledgement
Special thanks to Takeru Chuganji (@chuganzy) raising this on Slack.

#### Checklist
- [x] Updated CHANGELOG.md.