### PR TITLE
Fix `schedule(after:interval:leeway:)` disposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # master
 *Please add new entries at the top.*
 
-1. Fixed `schedule(after:interval:leeway:)` being cancelled when the returned `Disposable` is not retained.
+1. Fixed `schedule(after:interval:leeway:)` being cancelled when the returned `Disposable` is not retained. (#584, kudos to @jjoelson)
 
 # 3.1.0-rc.1
 1. Fixed a scenario of downstream interruptions being dropped. (#577, kudos to @andersio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. Fixed `schedule(after:interval:leeway:)` being cancelled when the returned `Disposable` is not retained.
+
 # 3.1.0-rc.1
 1. Fixed a scenario of downstream interruptions being dropped. (#577, kudos to @andersio)
 

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -177,12 +177,15 @@ public final class UIScheduler: Scheduler {
 	}
 }
 
-/// A `Hashable` wrapper for `DispatchSourceTimer`.
+/// A `Hashable` wrapper for `DispatchSourceTimer`. `Hashable` conformance is
+/// based on the identity of the wrapper object rather than the wrapped
+/// `DispatchSourceTimer`, so two wrappers wrapping the same timer will *not*
+/// be equal.
 private final class DispatchSourceTimerWrapper: Hashable {
 	private let value: DispatchSourceTimer
 	
 	fileprivate var hashValue: Int {
-		return ObjectIdentifier(value).hashValue
+		return ObjectIdentifier(self).hashValue
 	}
 	
 	fileprivate init(_ value: DispatchSourceTimer) {
@@ -190,7 +193,7 @@ private final class DispatchSourceTimerWrapper: Hashable {
 	}
 	
 	fileprivate static func ==(lhs: DispatchSourceTimerWrapper, rhs: DispatchSourceTimerWrapper) -> Bool {
-		return lhs.value === rhs.value
+		return lhs === rhs
 	}
 }
 

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -182,7 +182,7 @@ private final class DispatchSourceTimerWrapper: Hashable {
 	private let value: DispatchSourceTimer
 	
 	fileprivate var hashValue: Int {
-		return value.hash
+		return ObjectIdentifier(value).hashValue
 	}
 	
 	fileprivate init(_ value: DispatchSourceTimer) {

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -366,11 +366,13 @@ public final class QueueScheduler: DateScheduler {
 			timers.insert(wrappedTimer)
 		}
 
-		return AnyDisposable {
+		return AnyDisposable { [weak self] in
 			timer.cancel()
 			
-			self.timers.modify { timers in
-				timers.remove(wrappedTimer)
+			if let scheduler = self {
+				scheduler.timers.modify { timers in
+					timers.remove(wrappedTimer)
+				}
 			}
 		}
 	}

--- a/Tests/ReactiveSwiftTests/SchedulerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SchedulerSpec.swift
@@ -230,7 +230,7 @@ class SchedulerSpec: QuickSpec {
 						scheduler.schedule(after: Date(), interval: .milliseconds(10), leeway: .seconds(0)) {
 							expect(Thread.isMainThread) == false
 							
-							if count <= timesToIncrement {
+							if count < timesToIncrement {
 								count += 1
 							}
 						}
@@ -241,7 +241,7 @@ class SchedulerSpec: QuickSpec {
 					expect(count) == 0
 					
 					scheduler.queue.resume()
-					expect(count).toEventually(equal(timesToIncrement))
+					expect(count).toEventually(equal(timesToIncrement), pollInterval: 0.1)
 				}
 				
 				it("should cancel repeatedly run actions on disposal") {

--- a/Tests/ReactiveSwiftTests/SchedulerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SchedulerSpec.swift
@@ -241,7 +241,7 @@ class SchedulerSpec: QuickSpec {
 					expect(count) == 0
 					
 					scheduler.queue.resume()
-					expect{count}.toEventually(equal(timesToIncrement))
+					expect(count).toEventually(equal(timesToIncrement))
 				}
 				
 				it("should cancel repeatedly run actions on disposal") {
@@ -265,7 +265,7 @@ class SchedulerSpec: QuickSpec {
 						count += 1
 						
 						if count == timesToRun {
-							disposable1.dispose()
+							disposable2.dispose()
 						}
 					}
 
@@ -277,7 +277,7 @@ class SchedulerSpec: QuickSpec {
 					
 					// This expectation should take about 2.0 * interval to be fulfilled, and that's
 					// enough time to ensure that the first timer was actually cancelled.
-					expect{count}.toEventually(equal(timesToRun))
+					expect(count).toEventually(equal(timesToRun))
 				}
 			}
 		}


### PR DESCRIPTION
Addresses #582. Retain timers in `QueueScheduler` so that they will not be cancelled if the user doesn’t retain the returned `Disposable`.

Note that the test leaks a timer, but I'm not sure how else to test that the timer continues running even when the `Disposable` is not retained. 

#### Checklist
- [x] Updated CHANGELOG.md.