### PR TITLE
Rename filterMap, skipNil to compactMap, compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. Rename filterMap, skipNil to compactMap, compact (#594, kudos to @ra1028)
+
 # 3.1.0
 1. Fixed `schedule(after:interval:leeway:)` being cancelled when the returned `Disposable` is not retained. (#584, kudos to @jjoelson)
 

--- a/ReactiveSwift-UIExamples.playground/Pages/ValidatingProperty.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift-UIExamples.playground/Pages/ValidatingProperty.xcplaygroundpage/Contents.swift
@@ -96,10 +96,10 @@ final class ViewController: UIViewController {
 
 		// Setup bindings with the interactive controls.
 		viewModel.email <~ formView.emailField.reactive
-			.continuousTextValues.skipNil()
+			.continuousTextValues.compact()
 
 		viewModel.emailConfirmation <~ formView.emailConfirmationField.reactive
-			.continuousTextValues.skipNil()
+			.continuousTextValues.compact()
 
 		viewModel.termsAccepted <~ formView.termsSwitch.reactive
 			.isOnValues

--- a/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
@@ -185,18 +185,18 @@ scopedExample("`filter`") {
 }
 
 /*:
-### `skipNil`
+### `compact`
 Unwraps non-`nil` values and forwards them on the returned signal, `nil`
 values are dropped.
 */
-scopedExample("`skipNil`") {
+scopedExample("`compact`") {
 	let (signal, observer) = Signal<Int?, NoError>.pipe()
 	// note that the signal is of type `Int?` and observer is of type `Int`, given we're unwrapping
 	// non-`nil` values
 	let subscriber = Signal<Int, NoError>.Observer(value: { print("Subscriber received \($0)") } )
-	let skipNilSignal = signal.skipNil()
+	let compactSignal = signal.compact()
 
-	skipNilSignal.observe(subscriber)
+	compactSignal.observe(subscriber)
 	observer.send(value: 1)
 	observer.send(value: nil)
 	observer.send(value: 3)

--- a/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -574,13 +574,13 @@ scopedExample("`take(last:)`") {
 }
 
 /*:
-### `skipNil`
+### `compact`
 Unwraps non-`nil` values and forwards them on the returned signal, `nil`
 values are dropped.
 */
-scopedExample("`skipNil`") {
+scopedExample("`compact`") {
 	SignalProducer<Int?, NoError>([ nil, 1, 2, nil, 3, 4, nil ])
-		.skipNil()
+		.compact()
 		.startWithValues { value in
 			print(value)
 		}

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -103,9 +103,9 @@ public final class Action<Input, Output, Error: Swift.Error> {
 		(events, eventsObserver) = Signal<Signal<Output, Error>.Event, NoError>.pipe()
 		(disabledErrors, disabledErrorsObserver) = Signal<(), NoError>.pipe()
 
-		values = events.filterMap { $0.value }
-		errors = events.filterMap { $0.error }
-		completed = events.filterMap { $0.isCompleted ? () : nil }
+		values = events.compactMap { $0.value }
+		errors = events.compactMap { $0.error }
+		completed = events.compactMap { $0.isCompleted ? () : nil }
 
 		let actionState = MutableProperty(ActionState<State.Value>(isUserEnabled: true, isExecuting: false, value: state.value))
 

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -15,3 +15,31 @@ extension Lifetime {
 }
 
 // MARK: Deprecated types
+
+extension Signal {
+	@available(*, deprecated, renamed: "compactMap(_:)")
+	public func filterMap<U>(_ transform: @escaping (Value) -> U?) -> Signal<U, Error> {
+		return compactMap(transform)
+	}
+}
+
+extension Signal where Value: OptionalProtocol {
+	@available(*, deprecated, renamed: "compact()")
+	public func skipNil() -> Signal<Value.Wrapped, Error> {
+		return compact()
+	}
+}
+
+extension SignalProducer {
+	@available(*, deprecated, renamed: "compactMap(_:)")
+	public func filterMap<U>(_ transform: @escaping (Value) -> U?) -> SignalProducer<U, Error> {
+		return compactMap(transform)
+	}
+}
+
+extension SignalProducer where Value: OptionalProtocol {
+	@available(*, deprecated, renamed: "compact()")
+	public func skipNil() -> SignalProducer<Value.Wrapped, Error> {
+		return compact()
+	}
+}

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -476,7 +476,7 @@ extension Signal.Event where Value: EventProtocol {
 }
 
 extension Signal.Event where Value: OptionalProtocol {
-	internal static var skipNil: Transformation<Value.Wrapped, Error> {
+	internal static var compact: Transformation<Value.Wrapped, Error> {
 		return compactMap { $0.optional }
 	}
 }

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -227,7 +227,7 @@ extension Signal.Event {
 		}
 	}
 
-	internal static func filterMap<U>(_ transform: @escaping (Value) -> U?) -> Transformation<U, Error> {
+	internal static func compactMap<U>(_ transform: @escaping (Value) -> U?) -> Transformation<U, Error> {
 		return { action, _ in
 			return { event in
 				switch event {
@@ -477,7 +477,7 @@ extension Signal.Event where Value: EventProtocol {
 
 extension Signal.Event where Value: OptionalProtocol {
 	internal static var skipNil: Transformation<Value.Wrapped, Error> {
-		return filterMap { $0.optional }
+		return compactMap { $0.optional }
 	}
 }
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -615,8 +615,8 @@ extension Signal {
 	///                returns a new optional value.
 	///
 	/// - returns: A signal that will send new values, that are non `nil` after the transformation.
-	public func filterMap<U>(_ transform: @escaping (Value) -> U?) -> Signal<U, Error> {
-		return flatMapEvent(Signal.Event.filterMap(transform))
+	public func compactMap<U>(_ transform: @escaping (Value) -> U?) -> Signal<U, Error> {
+		return flatMapEvent(Signal.Event.compactMap(transform))
 	}
 }
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -625,8 +625,8 @@ extension Signal where Value: OptionalProtocol {
 	/// values are dropped.
 	///
 	/// - returns: A signal that sends only non-nil values.
-	public func skipNil() -> Signal<Value.Wrapped, Error> {
-		return flatMapEvent(Signal.Event.skipNil)
+	public func compact() -> Signal<Value.Wrapped, Error> {
+		return flatMapEvent(Signal.Event.compact)
 	}
 }
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1531,8 +1531,8 @@ extension SignalProducer where Value: OptionalProtocol {
 	/// values are dropped.
 	///
 	/// - returns: A producer that sends only non-nil values.
-	public func skipNil() -> SignalProducer<Value.Wrapped, Error> {
-		return core.flatMapEvent(Signal.Event.skipNil)
+	public func compact() -> SignalProducer<Value.Wrapped, Error> {
+		return core.flatMapEvent(Signal.Event.compact)
 	}
 }
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -311,7 +311,7 @@ private final class SignalCore<Value, Error: Swift.Error>: SignalProducerCore<Va
 /// example, when we do:
 ///
 /// ```
-/// upstream.map(transform).filterMap(filteringTransform).start()
+/// upstream.map(transform).compactMap(compactTransform).start()
 /// ```
 ///
 /// It is contractually guaranteed that these operators would always end up producing a
@@ -865,7 +865,7 @@ extension SignalProducer {
 	///
 	/// - returns: A producer that will send new values.
 	public func map<U>(_ keyPath: KeyPath<Value, U>) -> SignalProducer<U, Error> {
-		return core.flatMapEvent(Signal.Event.filterMap { $0[keyPath: keyPath] })
+		return core.flatMapEvent(Signal.Event.compactMap { $0[keyPath: keyPath] })
 	}
 
 	/// Map errors in the producer to a new error.
@@ -916,8 +916,8 @@ extension SignalProducer {
 	///                returns a new optional value.
 	///
 	/// - returns: A producer that will send new values, that are non `nil` after the transformation.
-	public func filterMap<U>(_ transform: @escaping (Value) -> U?) -> SignalProducer<U, Error> {
-		return core.flatMapEvent(Signal.Event.filterMap(transform))
+	public func compactMap<U>(_ transform: @escaping (Value) -> U?) -> SignalProducer<U, Error> {
+		return core.flatMapEvent(Signal.Event.compactMap(transform))
 	}
 
 	/// Yield the first `count` values from the input producer.

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -139,7 +139,7 @@ class ActionSpec: QuickSpec {
 				var isFirstResponder = false
 
 				action.isEnabled.producer
-					.filterMap { isActionEnabled in !isActionEnabled && isFirstResponder ? () : nil }
+					.compactMap { isActionEnabled in !isActionEnabled && isFirstResponder ? () : nil }
 					.startWithValues { _ in enabled.value = false }
 
 				enabled.value = true

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -343,10 +343,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 			}
 		}
 
-		describe("skipNil") {
+		describe("compact") {
 			it("should forward only non-nil values") {
 				let (producer, observer) = SignalProducer<Int?, NoError>.pipe()
-				let mappedProducer = producer.skipNil()
+				let mappedProducer = producer.compact()
 
 				var lastValue: Int?
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -749,10 +749,10 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
-		describe("skipNil") {
+		describe("compact") {
 			it("should forward only non-nil values") {
 				let (signal, observer) = Signal<Int?, NoError>.pipe()
-				let mappedSignal = signal.skipNil()
+				let mappedSignal = signal.compact()
 
 				var lastValue: Int?
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -661,10 +661,10 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
-		describe("filterMap") {
+		describe("compactMap") {
 			it("should omit values from the signal that are nil after the transformation") {
 				let (signal, observer) = Signal<String, NoError>.pipe()
-				let mappedSignal: Signal<Int, NoError> = signal.filterMap { Int.init($0) }
+				let mappedSignal: Signal<Int, NoError> = signal.compactMap { Int.init($0) }
 
 				var lastValue: Int?
 
@@ -684,7 +684,7 @@ class SignalSpec: QuickSpec {
 
 			it("should stop emiting values after an error") {
 				let (signal, observer) = Signal<String, TestError>.pipe()
-				let mappedSignal: Signal<Int, TestError> = signal.filterMap { Int.init($0) }
+				let mappedSignal: Signal<Int, TestError> = signal.compactMap { Int.init($0) }
 
 				var lastValue: Int?
 
@@ -707,7 +707,7 @@ class SignalSpec: QuickSpec {
 
 			it("should stop emiting values after a complete") {
 				let (signal, observer) = Signal<String, NoError>.pipe()
-				let mappedSignal: Signal<Int, NoError> = signal.filterMap { Int.init($0) }
+				let mappedSignal: Signal<Int, NoError> = signal.compactMap { Int.init($0) }
 
 				var lastValue: Int?
 
@@ -726,7 +726,7 @@ class SignalSpec: QuickSpec {
 
 			it("should send completed") {
 				let (signal, observer) = Signal<String, NoError>.pipe()
-				let mappedSignal: Signal<Int, NoError> = signal.filterMap { Int.init($0) }
+				let mappedSignal: Signal<Int, NoError> = signal.compactMap { Int.init($0) }
 
 				var completed: Bool = false
 
@@ -738,7 +738,7 @@ class SignalSpec: QuickSpec {
 
 			it("should send failure") {
 				let (signal, observer) = Signal<String, TestError>.pipe()
-				let mappedSignal: Signal<Int, TestError> = signal.filterMap { Int.init($0) }
+				let mappedSignal: Signal<Int, TestError> = signal.compactMap { Int.init($0) }
 
 				var failure: TestError?
 


### PR DESCRIPTION
Rename filterMap to compactMap and skipNil to compact, based on the new API of Swift 4.1.

#### Checklist
- [x] Updated CHANGELOG.md.
