### PR TITLE
Add map(to:) operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. New operator `map(to:)` (#601, kudos to @ra1028)
+
 # 3.1.0
 1. Fixed `schedule(after:interval:leeway:)` being cancelled when the returned `Disposable` is not retained. (#584, kudos to @jjoelson)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # master
 *Please add new entries at the top.*
 
-1. New operator `map(to:)` (#601, kudos to @ra1028)
+1. New operator `map(value:)` (#601, kudos to @ra1028)
 
 # 3.1.0
 1. Fixed `schedule(after:interval:leeway:)` being cancelled when the returned `Disposable` is not retained. (#584, kudos to @jjoelson)

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -101,6 +101,16 @@ extension PropertyProtocol {
 	public func map<U>(_ transform: @escaping (Value) -> U) -> Property<U> {
 		return lift { $0.map(transform) }
 	}
+	
+	/// Map the current value and all susequent values to a new constant property.
+	///
+	/// - parameters:
+	///   - value: A new value.
+	///
+	/// - returns: A property that holds a mapped value from `self`.
+	public func map<U>(value: U) -> Property<U> {
+		return map { _ in value }
+	}
 
 	/// Maps the current value and all subsequent values to a new property
 	/// by applying a key path.

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -109,7 +109,7 @@ extension PropertyProtocol {
 	///
 	/// - returns: A property that holds a mapped value from `self`.
 	public func map<U>(value: U) -> Property<U> {
-		return map { _ in value }
+		return lift { $0.map(value: value) }
 	}
 
 	/// Maps the current value and all subsequent values to a new property

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -564,7 +564,7 @@ extension Signal {
 	///   - value: A new value.
 	///
 	/// - returns: A signal that will send new values.
-	public func map<U>(to value: U) -> Signal<U, Error> {
+	public func map<U>(value: U) -> Signal<U, Error> {
 		return map { _ in value }
 	}
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -557,6 +557,16 @@ extension Signal {
 	public func map<U>(_ transform: @escaping (Value) -> U) -> Signal<U, Error> {
 		return flatMapEvent(Signal.Event.map(transform))
 	}
+	
+	/// Map each value in the signal to a new constant value.
+	///
+	/// - parameters:
+	///   - value: A new value.
+	///
+	/// - returns: A signal that will send new values.
+	public func map<U>(to value: U) -> Signal<U, Error> {
+		return map { _ in value }
+	}
 
 	/// Map each value in the signal to a new value by applying a key path.
 	///

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -866,7 +866,7 @@ extension SignalProducer {
 	/// - returns: A signal producer that, when started, will send a mapped
 	///            value of `self`.
 	public func map<U>(value: U) -> SignalProducer<U, Error> {
-		return map { _ in value }
+		return lift { $0.map(value: value) }
 	}
 
 	/// Map each value in the producer to a new value by applying a key path.

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -857,6 +857,17 @@ extension SignalProducer {
 	public func map<U>(_ transform: @escaping (Value) -> U) -> SignalProducer<U, Error> {
 		return core.flatMapEvent(Signal.Event.map(transform))
 	}
+	
+	/// Map each value in the producer to a new constant value.
+	///
+	/// - parameters:
+	///   - value: A new value.
+	///
+	/// - returns: A signal producer that, when started, will send a mapped
+	///            value of `self`.
+	public func map<U>(value: U) -> SignalProducer<U, Error> {
+		return map { _ in value }
+	}
 
 	/// Map each value in the producer to a new value by applying a key path.
 	///

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -505,6 +505,22 @@ class PropertySpec: QuickSpec {
 						property.value = 3
 						expect(latestValue) == 4
 					}
+					
+					it("should have the latest value available before sending any value") {
+						var latestValue: Int!
+						
+						let property = MutableProperty("foo")
+						let mappedProperty = property.map(value: 1)
+						mappedProperty.producer.startWithValues { _ in latestValue = mappedProperty.value }
+						
+						expect(latestValue) == 1
+						
+						property.value = "foobar"
+						expect(latestValue) == 1
+						
+						property.value = "foobarbaz"
+						expect(latestValue) == 1
+					}
 
 					it("should not retain its source property") {
 						var property = Optional(MutableProperty(1))

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -505,22 +505,6 @@ class PropertySpec: QuickSpec {
 						property.value = 3
 						expect(latestValue) == 4
 					}
-					
-					it("should have the latest value available before sending any value") {
-						var latestValue: Int!
-						
-						let property = MutableProperty("foo")
-						let mappedProperty = property.map(value: 1)
-						mappedProperty.producer.startWithValues { _ in latestValue = mappedProperty.value }
-						
-						expect(latestValue) == 1
-						
-						property.value = "foobar"
-						expect(latestValue) == 1
-						
-						property.value = "foobarbaz"
-						expect(latestValue) == 1
-					}
 
 					it("should not retain its source property") {
 						var property = Optional(MutableProperty(1))
@@ -748,12 +732,20 @@ class PropertySpec: QuickSpec {
 			describe("map") {
 				it("should transform the current value and all subsequent values") {
 					let property = MutableProperty(1)
-					let mappedProperty = property
-						.map { $0 + 1 }
+					let mappedProperty = property.map { $0 + 1 }
 					expect(mappedProperty.value) == 2
 
 					property.value = 2
 					expect(mappedProperty.value) == 3
+				}
+				
+				it("should transform the current value and all subsequent values to a constant value") {
+					let property = MutableProperty("foo")
+					let mappedProperty = property.map(value: 1)
+					expect(mappedProperty.value) == 1
+					
+					property.value = "foobar"
+					expect(mappedProperty.value) == 1
 				}
 
 				it("should work with key paths") {

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -37,6 +37,27 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue) == "2"
 			}
 		}
+		
+		describe("map") {
+			it("should raplace the values of the signal to constant new value") {
+				let (producer, observer) = SignalProducer<String, NoError>.pipe()
+				let mappedProducer = producer.map(value: 1)
+				
+				var lastValue: Int?
+				
+				mappedProducer.startWithValues {
+					lastValue = $0
+				}
+				
+				expect(lastValue).to(beNil())
+				
+				observer.send(value: "foo")
+				expect(lastValue) == 1
+				
+				observer.send(value: "foobar")
+				expect(lastValue) == 1
+			}
+		}
 
 		describe("mapError") {
 			it("should transform the errors of the signal") {

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -36,9 +36,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.send(value: 1)
 				expect(lastValue) == "2"
 			}
-		}
-		
-		describe("map") {
+			
 			it("should raplace the values of the signal to constant new value") {
 				let (producer, observer) = SignalProducer<String, NoError>.pipe()
 				let mappedProducer = producer.map(value: 1)

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -508,7 +508,7 @@ class SignalSpec: QuickSpec {
 
 			it("should replace the values of the signal to constant new value") {
 				let (signal, observer) = Signal<String, NoError>.pipe()
-				let mappedSignal = signal.map(to: 1)
+				let mappedSignal = signal.map(value: 1)
 
 				var lastValue: Int?
 				mappedSignal.observeValues {

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -506,9 +506,9 @@ class SignalSpec: QuickSpec {
 				expect(lastValue) == "2"
 			}
 
-			it("should support key paths") {
+			it("should replace the values of the signal to constant new value") {
 				let (signal, observer) = Signal<String, NoError>.pipe()
-				let mappedSignal = signal.map(\String.count)
+				let mappedSignal = signal.map(to: 1)
 
 				var lastValue: Int?
 				mappedSignal.observeValues {
@@ -518,8 +518,26 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.send(value: "foo")
-				expect(lastValue) == 3
+				expect(lastValue) == 1
 
+				observer.send(value: "foobar")
+				expect(lastValue) == 1
+			}
+			
+			it("should support key paths") {
+				let (signal, observer) = Signal<String, NoError>.pipe()
+				let mappedSignal = signal.map(\String.count)
+				
+				var lastValue: Int?
+				mappedSignal.observeValues {
+					lastValue = $0
+				}
+				
+				expect(lastValue).to(beNil())
+				
+				observer.send(value: "foo")
+				expect(lastValue) == 3
+				
 				observer.send(value: "foobar")
 				expect(lastValue) == 6
 			}


### PR DESCRIPTION
Refer #597

For example, use as below.

```swift
let (signal, observer) = Signal<String, NoError>.pipe()
let triggerSignal = signal.map(to: ())

triggerSignal.observeValues {
    print("trigger `value` events")
}
```

#### Discassion
I want to add `@autoclosure @escaping`, but occur an error(`Ambiguous reference to member 'map`) on overload `map`.
So, I propose to name it `replace(to:)`, like below.

```swift
public func replace<U>(to value: @autoclosure @escaping () -> U) -> Signal<U, Error> {
    return map { _ in value() }
}
```

#### Checklist
- [x] Updated CHANGELOG.md.
