### PR TITLE
Bag performance

### DIFF
--- a/Sources/Bag.swift
+++ b/Sources/Bag.swift
@@ -67,36 +67,12 @@ extension Bag: RandomAccessCollection {
 	public var endIndex: Int {
 		return elements.endIndex
 	}
-
-	public subscript(index: Int) -> Element {
-		return elements[index]
+	
+	public func index(after i: Int) -> Int {
+		return i + 1
 	}
-
-	public func makeIterator() -> Iterator {
-		return Iterator(elements)
-	}
-
-	/// An iterator of `Bag`.
-	public struct Iterator: IteratorProtocol {
-		private let base: ContiguousArray<Element>
-		private var nextIndex: Int
-		private let endIndex: Int
-
-		fileprivate init(_ base: ContiguousArray<Element>) {
-			self.base = base
-			nextIndex = base.startIndex
-			endIndex = base.endIndex
-		}
-
-		public mutating func next() -> Element? {
-			let currentIndex = nextIndex
-
-			if currentIndex < endIndex {
-				nextIndex = currentIndex + 1
-				return base[currentIndex]
-			}
-
-			return nil
-		}
+	
+	public subscript(position: Int) -> Element {
+		return elements[position]
 	}
 }

--- a/Sources/Bag.swift
+++ b/Sources/Bag.swift
@@ -8,46 +8,46 @@
 
 /// An unordered, non-unique collection of values of type `Element`.
 public struct Bag<Element> {
-    /// A uniquely identifying token for removing a value that was inserted into a
-    /// Bag.
-    public struct Token {
-        fileprivate let value: UInt64
-    }
-
-    fileprivate var elements: ContiguousArray<Element> = []
-    fileprivate var tokens: ContiguousArray<UInt64> = []
-
-    private var nextToken = Token(value: 0)
-
-    public init() {}
-
-    /// Insert the given value into `self`, and return a token that can
-    /// later be passed to `remove(using:)`.
-    ///
-    /// - parameters:
-    ///   - value: A value that will be inserted.
-    @discardableResult
-    public mutating func insert(_ value: Element) -> Token {
-        let token = nextToken
-
-        // Practically speaking, this would overflow only if we have 101% uptime and we
-        // manage to call `insert(_:)` every 1 ns for 500+ years non-stop.
-        nextToken = Token(value: token.value + 1)
+	/// A uniquely identifying token for removing a value that was inserted into a
+	/// Bag.
+	public struct Token {
+		fileprivate let value: UInt64
+	}
+	
+	fileprivate var elements: ContiguousArray<Element> = []
+	fileprivate var tokens: ContiguousArray<UInt64> = []
+	
+	private var nextToken = Token(value: 0)
+	
+	public init() {}
+	
+	/// Insert the given value into `self`, and return a token that can
+	/// later be passed to `remove(using:)`.
+	///
+	/// - parameters:
+	///   - value: A value that will be inserted.
+	@discardableResult
+	public mutating func insert(_ value: Element) -> Token {
+		let token = nextToken
 		
-        elements.append(value)
-        tokens.append(token.value)
-
-        return token
-    }
-
-    /// Remove a value, given the token returned from `insert()`.
-    ///
-    /// - note: If the value has already been removed, nothing happens.
-    ///
-    /// - parameters:
-    ///   - token: A token returned from a call to `insert()`.
-    @discardableResult
-    public mutating func remove(using token: Token) -> Element? {
+		// Practically speaking, this would overflow only if we have 101% uptime and we
+		// manage to call `insert(_:)` every 1 ns for 500+ years non-stop.
+		nextToken = Token(value: token.value + 1)
+		
+		elements.append(value)
+		tokens.append(token.value)
+		
+		return token
+	}
+	
+	/// Remove a value, given the token returned from `insert()`.
+	///
+	/// - note: If the value has already been removed, nothing happens.
+	///
+	/// - parameters:
+	///   - token: A token returned from a call to `insert()`.
+	@discardableResult
+	public mutating func remove(using token: Token) -> Element? {
 		let reversedIndices = elements.indices.reversed()
 		
 		guard let i = reversedIndices.first(where: { tokens[$0] == token.value }) else {
@@ -55,24 +55,24 @@ public struct Bag<Element> {
 		}
 		
 		tokens.remove(at: i)
-        return elements.remove(at: i)
-    }
+		return elements.remove(at: i)
+	}
 }
 
 extension Bag: RandomAccessCollection {
-    public var startIndex: Int {
-        return elements.startIndex
-    }
-
-    public var endIndex: Int {
-        return elements.endIndex
-    }
-
-    public func index(after i: Int) -> Int {
-        return i + 1
-    }
-
-    public subscript(position: Int) -> Element {
-        return elements[position]
-    }
+	public var startIndex: Int {
+		return elements.startIndex
+	}
+	
+	public var endIndex: Int {
+		return elements.endIndex
+	}
+	
+	public func index(after i: Int) -> Int {
+		return i + 1
+	}
+	
+	public subscript(position: Int) -> Element {
+		return elements[position]
+	}
 }

--- a/Sources/Bag.swift
+++ b/Sources/Bag.swift
@@ -13,14 +13,14 @@ public struct Bag<Element> {
 	public struct Token {
 		fileprivate let value: UInt64
 	}
-	
+
 	fileprivate var elements: ContiguousArray<Element> = []
 	fileprivate var tokens: ContiguousArray<UInt64> = []
-	
+
 	private var nextToken = Token(value: 0)
-	
+
 	public init() {}
-	
+
 	/// Insert the given value into `self`, and return a token that can
 	/// later be passed to `remove(using:)`.
 	///
@@ -29,17 +29,17 @@ public struct Bag<Element> {
 	@discardableResult
 	public mutating func insert(_ value: Element) -> Token {
 		let token = nextToken
-		
+
 		// Practically speaking, this would overflow only if we have 101% uptime and we
 		// manage to call `insert(_:)` every 1 ns for 500+ years non-stop.
 		nextToken = Token(value: token.value + 1)
-		
+
 		elements.append(value)
 		tokens.append(token.value)
-		
+
 		return token
 	}
-	
+
 	/// Remove a value, given the token returned from `insert()`.
 	///
 	/// - note: If the value has already been removed, nothing happens.
@@ -51,7 +51,7 @@ public struct Bag<Element> {
 		guard let i = indices.first(where: { tokens[$0] == token.value }) else {
 			return nil
 		}
-		
+
 		tokens.remove(at: i)
 		return elements.remove(at: i)
 	}
@@ -61,39 +61,39 @@ extension Bag: RandomAccessCollection {
 	public var startIndex: Int {
 		return elements.startIndex
 	}
-	
+
 	public var endIndex: Int {
 		return elements.endIndex
 	}
-	
+
 	public subscript(index: Int) -> Element {
 		return elements[index]
 	}
-	
+
 	public func makeIterator() -> Iterator {
 		return Iterator(elements)
 	}
-	
+
 	/// An iterator of `Bag`.
 	public struct Iterator: IteratorProtocol {
 		private let base: ContiguousArray<Element>
 		private var nextIndex: Int
 		private let endIndex: Int
-		
+
 		fileprivate init(_ base: ContiguousArray<Element>) {
 			self.base = base
 			nextIndex = base.startIndex
 			endIndex = base.endIndex
 		}
-		
+
 		public mutating func next() -> Element? {
 			let currentIndex = nextIndex
-			
+
 			if currentIndex < endIndex {
 				nextIndex = currentIndex + 1
 				return base[currentIndex]
 			}
-			
+
 			return nil
 		}
 	}

--- a/Sources/Bag.swift
+++ b/Sources/Bag.swift
@@ -48,9 +48,7 @@ public struct Bag<Element> {
 	///   - token: A token returned from a call to `insert()`.
 	@discardableResult
 	public mutating func remove(using token: Token) -> Element? {
-		let reversedIndices = elements.indices.reversed()
-		
-		guard let i = reversedIndices.first(where: { tokens[$0] == token.value }) else {
+		guard let i = indices.first(where: { tokens[$0] == token.value }) else {
 			return nil
 		}
 		

--- a/Sources/Bag.swift
+++ b/Sources/Bag.swift
@@ -48,12 +48,12 @@ public struct Bag<Element> {
 	///   - token: A token returned from a call to `insert()`.
 	@discardableResult
 	public mutating func remove(using token: Token) -> Element? {
-		guard let i = indices.first(where: { tokens[$0] == token.value }) else {
+		guard let index = indices.first(where: { tokens[$0] == token.value }) else {
 			return nil
 		}
 
-		tokens.remove(at: i)
-		return elements.remove(at: i)
+		tokens.remove(at: index)
+		return elements.remove(at: index)
 	}
 }
 

--- a/Sources/Bag.swift
+++ b/Sources/Bag.swift
@@ -68,11 +68,35 @@ extension Bag: RandomAccessCollection {
 		return elements.endIndex
 	}
 	
-	public func index(after i: Int) -> Int {
-		return i + 1
+	public subscript(index: Int) -> Element {
+		return elements[index]
 	}
 	
-	public subscript(position: Int) -> Element {
-		return elements[position]
+	public func makeIterator() -> Iterator {
+		return Iterator(elements)
+	}
+	
+	/// An iterator of `Bag`.
+	public struct Iterator: IteratorProtocol {
+		private let base: ContiguousArray<Element>
+		private var nextIndex: Int
+		private let endIndex: Int
+		
+		fileprivate init(_ base: ContiguousArray<Element>) {
+			self.base = base
+			nextIndex = base.startIndex
+			endIndex = base.endIndex
+		}
+		
+		public mutating func next() -> Element? {
+			let currentIndex = nextIndex
+			
+			if currentIndex < endIndex {
+				nextIndex = currentIndex + 1
+				return base[currentIndex]
+			}
+			
+			return nil
+		}
 	}
 }

--- a/Sources/Bag.swift
+++ b/Sources/Bag.swift
@@ -8,71 +8,71 @@
 
 /// An unordered, non-unique collection of values of type `Element`.
 public struct Bag<Element> {
-	/// A uniquely identifying token for removing a value that was inserted into a
-	/// Bag.
-	public struct Token {
-		fileprivate let value: UInt64
-	}
+    /// A uniquely identifying token for removing a value that was inserted into a
+    /// Bag.
+    public struct Token {
+        fileprivate let value: UInt64
+    }
 
-	fileprivate var elements: ContiguousArray<Element> = []
-	fileprivate var tokens: ContiguousArray<UInt64> = []
+    fileprivate var elements: ContiguousArray<Element> = []
+    fileprivate var tokens: ContiguousArray<UInt64> = []
 
-	private var nextToken: Token = Token(value: 0)
+    private var nextToken = Token(value: 0)
 
-	public init() {}
+    public init() {}
 
-	/// Insert the given value into `self`, and return a token that can
-	/// later be passed to `remove(using:)`.
-	///
-	/// - parameters:
-	///   - value: A value that will be inserted.
-	@discardableResult
-	public mutating func insert(_ value: Element) -> Token {
-		let token = nextToken
+    /// Insert the given value into `self`, and return a token that can
+    /// later be passed to `remove(using:)`.
+    ///
+    /// - parameters:
+    ///   - value: A value that will be inserted.
+    @discardableResult
+    public mutating func insert(_ value: Element) -> Token {
+        let token = nextToken
 
-		// Practically speaking, this would overflow only if we have 101% uptime and we
-		// manage to call `insert(_:)` every 1 ns for 500+ years non-stop.
-		nextToken = Token(value: token.value + 1)
+        // Practically speaking, this would overflow only if we have 101% uptime and we
+        // manage to call `insert(_:)` every 1 ns for 500+ years non-stop.
+        nextToken = Token(value: token.value + 1)
+		
+        elements.append(value)
+        tokens.append(token.value)
 
-		elements.append(value)
-		tokens.append(token.value)
+        return token
+    }
 
-		return token
-	}
-
-	/// Remove a value, given the token returned from `insert()`.
-	///
-	/// - note: If the value has already been removed, nothing happens.
-	///
-	/// - parameters:
-	///   - token: A token returned from a call to `insert()`.
-	@discardableResult
-	public mutating func remove(using token: Token) -> Element? {
-		for i in elements.indices.reversed() {
-			if tokens[i] == token.value {
-				tokens.remove(at: i)
-				return elements.remove(at: i)
-			}
+    /// Remove a value, given the token returned from `insert()`.
+    ///
+    /// - note: If the value has already been removed, nothing happens.
+    ///
+    /// - parameters:
+    ///   - token: A token returned from a call to `insert()`.
+    @discardableResult
+    public mutating func remove(using token: Token) -> Element? {
+		let reversedIndices = elements.indices.reversed()
+		
+		guard let i = reversedIndices.first(where: { tokens[$0] == token.value }) else {
+			return nil
 		}
-
-		return nil
-	}
+		
+		tokens.remove(at: i)
+        return elements.remove(at: i)
+    }
 }
 
 extension Bag: RandomAccessCollection {
-	public var startIndex: Int {
-		return elements.startIndex
-	}
+    public var startIndex: Int {
+        return elements.startIndex
+    }
 
-	public var endIndex: Int {
-		return elements.endIndex
-	}
-	
-	public func index(after i: Int) -> Int {
-		return i + 1
-	}
-	
-	public subscript(position: Int) -> Element {
-		return elements[position]
-	}
+    public var endIndex: Int {
+        return elements.endIndex
+    }
+
+    public func index(after i: Int) -> Int {
+        return i + 1
+    }
+
+    public subscript(position: Int) -> Element {
+        return elements[position]
+    }
 }


### PR DESCRIPTION
1. Simplify nested code of `Bag.remove(using:)`
  Use `Sequence.first(where:)`
  Can be expected to gain a benefit from future Swift performance improvements by using the standard API.

2. Not use `revert()` for removing elements from bag.
  Improve dispose efficiency in `CompositeDisposable`.

#### Checklist
~- [ ] Updated CHANGELOG.md.~
