### PR TITLE
Fix Signal.map(value:) regression: changed to .replacingValues(with:) to avoid potentially incorrect type inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 1. New property operator: `filter` (#586, kudos to @iv-mexx)
 1. New operator `merge(with:)` (#600, kudos to @ra1028)
-1. New operator `map(value:)` (#601, kudos to @ra1028)
+1. New operator `replacingValues(with:)` (#601, #604, kudos to @ra1028, @NachoSoto)
 
 # 3.1.0
 1. Fixed `schedule(after:interval:leeway:)` being cancelled when the returned `Disposable` is not retained. (#584, kudos to @jjoelson)

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -108,8 +108,8 @@ extension PropertyProtocol {
 	///   - value: A new value.
 	///
 	/// - returns: A property that holds a mapped value from `self`.
-	public func map<U>(value: U) -> Property<U> {
-		return lift { $0.map(value: value) }
+	public func replacingValues<U>(with value: U) -> Property<U> {
+		return lift { $0.replacingValues(with: value) }
 	}
 
 	/// Maps the current value and all subsequent values to a new property

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -564,7 +564,7 @@ extension Signal {
 	///   - value: A new value.
 	///
 	/// - returns: A signal that will send new values.
-	public func map<U>(value: U) -> Signal<U, Error> {
+	public func replacingValues<U>(with value: U) -> Signal<U, Error> {
 		return map { _ in value }
 	}
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -865,8 +865,8 @@ extension SignalProducer {
 	///
 	/// - returns: A signal producer that, when started, will send a mapped
 	///            value of `self`.
-	public func map<U>(value: U) -> SignalProducer<U, Error> {
-		return lift { $0.map(value: value) }
+	public func replacingValues<U>(with value: U) -> SignalProducer<U, Error> {
+		return lift { $0.replacingValues(with: value) }
 	}
 
 	/// Map each value in the producer to a new value by applying a key path.

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -741,7 +741,7 @@ class PropertySpec: QuickSpec {
 				
 				it("should transform the current value and all subsequent values to a constant value") {
 					let property = MutableProperty("foo")
-					let mappedProperty = property.map(value: 1)
+					let mappedProperty = property.replacingValues(with: 1)
 					expect(mappedProperty.value) == 1
 					
 					property.value = "foobar"

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -39,7 +39,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should raplace the values of the signal to constant new value") {
 				let (producer, observer) = SignalProducer<String, NoError>.pipe()
-				let mappedProducer = producer.map(value: 1)
+				let mappedProducer = producer.replacingValues(with: 1)
 				
 				var lastValue: Int?
 				

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -541,6 +541,14 @@ class SignalSpec: QuickSpec {
 				observer.send(value: "foobar")
 				expect(lastValue) == 6
 			}
+			
+			it("does not conflict with other map overloads") {
+				let (signal, observer) = Signal<Int, NoError>.pipe()
+				
+				// These 2 lines verify that the type inference on `mappedSignal` is correct.
+				let mappedSignal = signal.map { $0 as Int? }
+				let expectedType: Signal<Int?, NoError> = mappedSignal
+			}
 		}
 
 		describe("mapError") {

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -508,7 +508,7 @@ class SignalSpec: QuickSpec {
 
 			it("should replace the values of the signal to constant new value") {
 				let (signal, observer) = Signal<String, NoError>.pipe()
-				let mappedSignal = signal.map(value: 1)
+				let mappedSignal = signal.replacingValues(with: 1)
 
 				var lastValue: Int?
 				mappedSignal.observeValues {


### PR DESCRIPTION
See conversation in #601. The `.map` overload lead to potentially bad type inference:
```swift
let (signal, observer) = Signal<Int, NoError>.pipe()

let mappedSignal = signal.map { $0 as Int? }
// // Cannot convert value of type 'Signal<(Int?) -> Int?, NoError>' to specified type 'Signal<Int?, NoError>'
let expectedType: Signal<Int?, NoError> = mappedSignal
```

#### Checklist
- [x] Updated CHANGELOG.md.
- [x] Add regression test
- [x] Fix