### PR TITLE
[Proposal] Merge SignalProducerConvertibles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. New property operator: `filter` (#586, kudos to @iv-mexx)
 1. New operator `merge(with:)` (#600, kudos to @ra1028)
 1. New operator `map(value:)` (#601, kudos to @ra1028)
+1. `SignalProducer.merge` is now accept any generic type that conformed to `SignalProducerConvertible` (#610, kudos to @1028)
 
 # 3.1.0
 1. Fixed `schedule(after:interval:leeway:)` being cancelled when the returned `Disposable` is not retained. (#584, kudos to @jjoelson)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 1. New property operator: `filter` (#586, kudos to @iv-mexx)
 1. New operator `merge(with:)` (#600, kudos to @ra1028)
 1. New operator `map(value:)` (#601, kudos to @ra1028)
-1. `SignalProducer.merge` is now accept any generic type that conformed to `SignalProducerConvertible` (#610, kudos to @1028)
+1. `SignalProducer.merge` now accepts any combination of `SignalProducerConvertible` conforming types (#610, kudos to @1028)
 1. Bag can be created with the initial elements now (#609, kudos to @ra1028)
 
 # 3.1.0

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -514,15 +514,50 @@ extension SignalProducer {
 	{
 		return SignalProducer<Seq.Iterator.Element, NoError>(producers).flatten(.merge)
 	}
-	
-	/// Merges the given producers into a single `SignalProducer` that will emit
-	/// all values from each of them, and complete when all of them have
-	/// completed.
-	///
-	/// - parameters:
-	///   - producers: A sequence of producers to merge.
-	public static func merge(_ producers: SignalProducer<Value, Error>...) -> SignalProducer<Value, Error> {
-		return SignalProducer.merge(producers)
+
+	/// Merge the values of all the given producers, in the manner described by `merge(_:)`.
+	public static func merge<A: SignalProducerConvertible, B: SignalProducerConvertible>(_ a: A, _ b: B) -> SignalProducer<Value, Error> where A.Value == Value, A.Error == Error, B.Value == Value, B.Error == Error {
+		return SignalProducer.merge([a.producer, b.producer])
+	}
+
+	/// Merge the values of all the given producers, in the manner described by `merge(_:)`.
+	public static func merge<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C) -> SignalProducer<Value, Error> where A.Value == Value, A.Error == Error, B.Value == Value, B.Error == Error, C.Value == Value, C.Error == Error {
+		return SignalProducer.merge([a.producer, b.producer, c.producer])
+	}
+
+	/// Merge the values of all the given producers, in the manner described by `merge(_:)`.
+	public static func merge<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D) -> SignalProducer<Value, Error> where A.Value == Value, A.Error == Error, B.Value == Value, B.Error == Error, C.Value == Value, C.Error == Error, D.Value == Value, D.Error == Error {
+		return SignalProducer.merge([a.producer, b.producer, c.producer, d.producer])
+	}
+
+	/// Merge the values of all the given producers, in the manner described by `merge(_:)`.
+	public static func merge<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> SignalProducer<Value, Error> where A.Value == Value, A.Error == Error, B.Value == Value, B.Error == Error, C.Value == Value, C.Error == Error, D.Value == Value, D.Error == Error, E.Value == Value, E.Error == Error {
+		return SignalProducer.merge([a.producer, b.producer, c.producer, d.producer, e.producer])
+	}
+
+	/// Merge the values of all the given producers, in the manner described by `merge(_:)`.
+	public static func merge<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> SignalProducer<Value, Error> where A.Value == Value, A.Error == Error, B.Value == Value, B.Error == Error, C.Value == Value, C.Error == Error, D.Value == Value, D.Error == Error, E.Value == Value, E.Error == Error, F.Value == Value, F.Error == Error {
+		return SignalProducer.merge([a.producer, b.producer, c.producer, d.producer, e.producer, f.producer])
+	}
+
+	/// Merge the values of all the given producers, in the manner described by `merge(_:)`.
+	public static func merge<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> SignalProducer<Value, Error> where A.Value == Value, A.Error == Error, B.Value == Value, B.Error == Error, C.Value == Value, C.Error == Error, D.Value == Value, D.Error == Error, E.Value == Value, E.Error == Error, F.Value == Value, F.Error == Error, G.Value == Value, G.Error == Error {
+		return SignalProducer.merge([a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer])
+	}
+
+	/// Merge the values of all the given producers, in the manner described by `merge(_:)`.
+	public static func merge<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible, H: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> SignalProducer<Value, Error> where A.Value == Value, A.Error == Error, B.Value == Value, B.Error == Error, C.Value == Value, C.Error == Error, D.Value == Value, D.Error == Error, E.Value == Value, E.Error == Error, F.Value == Value, F.Error == Error, G.Value == Value, G.Error == Error, H.Value == Value, H.Error == Error {
+		return SignalProducer.merge([a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer, h.producer])
+	}
+
+	/// Merge the values of all the given producers, in the manner described by `merge(_:)`.
+	public static func merge<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible, H: SignalProducerConvertible, I: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> SignalProducer<Value, Error> where A.Value == Value, A.Error == Error, B.Value == Value, B.Error == Error, C.Value == Value, C.Error == Error, D.Value == Value, D.Error == Error, E.Value == Value, E.Error == Error, F.Value == Value, F.Error == Error, G.Value == Value, G.Error == Error, H.Value == Value, H.Error == Error, I.Value == Value, I.Error == Error {
+		return SignalProducer.merge([a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer, h.producer, i.producer])
+	}
+
+	/// Merge the values of all the given producers, in the manner described by `merge(_:)`.
+	public static func merge<A: SignalProducerConvertible, B: SignalProducerConvertible, C: SignalProducerConvertible, D: SignalProducerConvertible, E: SignalProducerConvertible, F: SignalProducerConvertible, G: SignalProducerConvertible, H: SignalProducerConvertible, I: SignalProducerConvertible, J: SignalProducerConvertible>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> SignalProducer<Value, Error> where A.Value == Value, A.Error == Error, B.Value == Value, B.Error == Error, C.Value == Value, C.Error == Error, D.Value == Value, D.Error == Error, E.Value == Value, E.Error == Error, F.Value == Value, F.Error == Error, G.Value == Value, G.Error == Error, H.Value == Value, H.Error == Error, I.Value == Value, I.Error == Error, J.Value == Value, J.Error == Error {
+		return SignalProducer.merge([a.producer, b.producer, c.producer, d.producer, e.producer, f.producer, g.producer, h.producer, i.producer, j.producer])
 	}
 }
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1095,7 +1095,7 @@ extension SignalProducer {
 	///   - other: A producer to merge `self`'s value with.
 	///
 	/// - returns: A producer that sends all values of `self` and given producer.
-	public func merge(with other: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
+	public func merge<Other: SignalProducerConvertible>(with other: Other) -> SignalProducer<Value, Error> where Other.Value == Value, Other.Error == Error {
 		return SignalProducer.merge(self, other)
 	}
 


### PR DESCRIPTION
Make `SignalProducer.merge` to accepts n-ary generic type that conformed to `SignalProducerConvertible`.
If this is acceptable, how about to write high-arity operators(merge,zip, and combineLatest) into files like `Merge.swift`?

#### Checklist
- [x] Updated CHANGELOG.md.
