### PR TITLE
[api breaking]Make some operators to accept SignalProducerConvertible conforming types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 1. New property operator: `filter` (#586, kudos to @iv-mexx)
 1. New operator `merge(with:)` (#600, kudos to @ra1028)
 1. New operator `map(value:)` (#601, kudos to @ra1028)
-1. `SignalProducer.merge`, `SignalProducer.concat`, `SignalProducer.prefix`, `SignalProducer.then`, `SignalProducer.flatMapError` `Signal.flatMapError`, `Signal.withLatest` and `Property.init(initial:then:)` now accept `SignalProducerConvertible` conforming types (#610, #611, kudos to @1028)
+1. `SignalProducer.merge(with:)`, `SignalProducer.concat`, `SignalProducer.prefix`, `SignalProducer.then`, `SignalProducer.and`, `SignalProducer.or`, `SignalProducer.zip(with:)`, `SignalProducer.sample(with:)`, `SignalProducer.sample(on:)`, `SignalProducer.take(until:)`, `SignalProducer.take(untilReplacement:)`, `SignalProducer.skip(until:)`,`SignalProducer.flatMap`, `SignalProducer.flatMapError`, `SignalProducer.combineLatest(with:)`, `Signal.flatMap`, `Signal.flatMapError`, `Signal.withLatest(from:)` and `Property.init(initial:then:)` now accept `SignalProducerConvertible` conforming types (#610, #611, kudos to @1028)
 1. Bag can be created with the initial elements now (#609, kudos to @ra1028)
 
 # 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 1. New property operator: `filter` (#586, kudos to @iv-mexx)
 1. New operator `merge(with:)` (#600, kudos to @ra1028)
 1. New operator `map(value:)` (#601, kudos to @ra1028)
-1. `SignalProducer.merge` now accepts any combination of `SignalProducerConvertible` conforming types (#610, kudos to @1028)
+1. `SignalProducer.merge`, `SignalProducer.concat`, `SignalProducer.prefix`, `SignalProducer.then`, `SignalProducer.flatMapError` `Signal.flatMapError`, `Signal.withLatest` and `Property.init(initial:values:)` are now accept `SignalProducerConvertible` conforming types (#610, #611, kudos to @1028)
 1. Bag can be created with the initial elements now (#609, kudos to @ra1028)
 
 # 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 1. New property operator: `filter` (#586, kudos to @iv-mexx)
 1. New operator `merge(with:)` (#600, kudos to @ra1028)
 1. New operator `map(value:)` (#601, kudos to @ra1028)
-1. `SignalProducer.merge`, `SignalProducer.concat`, `SignalProducer.prefix`, `SignalProducer.then`, `SignalProducer.flatMapError` `Signal.flatMapError`, `Signal.withLatest` and `Property.init(initial:values:)` are now accept `SignalProducerConvertible` conforming types (#610, #611, kudos to @1028)
+1. `SignalProducer.merge`, `SignalProducer.concat`, `SignalProducer.prefix`, `SignalProducer.then`, `SignalProducer.flatMapError` `Signal.flatMapError`, `Signal.withLatest` and `Property.init(initial:then:)` are now accept `SignalProducerConvertible` conforming types (#610, #611, kudos to @1028)
 1. Bag can be created with the initial elements now (#609, kudos to @ra1028)
 
 # 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 1. New property operator: `filter` (#586, kudos to @iv-mexx)
 1. New operator `merge(with:)` (#600, kudos to @ra1028)
 1. New operator `map(value:)` (#601, kudos to @ra1028)
-1. `SignalProducer.merge(with:)`, `SignalProducer.concat`, `SignalProducer.prefix`, `SignalProducer.then`, `SignalProducer.and`, `SignalProducer.or`, `SignalProducer.zip(with:)`, `SignalProducer.sample(with:)`, `SignalProducer.sample(on:)`, `SignalProducer.take(until:)`, `SignalProducer.take(untilReplacement:)`, `SignalProducer.skip(until:)`,`SignalProducer.flatMap`, `SignalProducer.flatMapError`, `SignalProducer.combineLatest(with:)`, `Signal.flatMap`, `Signal.flatMapError`, `Signal.withLatest(from:)` and `Property.init(initial:then:)` now accept `SignalProducerConvertible` conforming types (#610, #611, kudos to @1028)
+1. `SignalProducer.merge(with:)`, `SignalProducer.concat`, `SignalProducer.prefix`, `SignalProducer.then`, `SignalProducer.and`, `SignalProducer.or`, `SignalProducer.zip(with:)`, `SignalProducer.sample(with:)`, `SignalProducer.sample(on:)`, `SignalProducer.take(until:)`, `SignalProducer.take(untilReplacement:)`, `SignalProducer.skip(until:)`, `SignalProducer.flatMap`, `SignalProducer.flatMapError`, `SignalProducer.combineLatest(with:)`, `Signal.flatMap`, `Signal.flatMapError`, `Signal.withLatest(from:)` and `Property.init(initial:then:)` now accept `SignalProducerConvertible` conforming types (#610, #611, kudos to @1028)
 1. Bag can be created with the initial elements now (#609, kudos to @ra1028)
 
 # 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 1. New property operator: `filter` (#586, kudos to @iv-mexx)
 1. New operator `merge(with:)` (#600, kudos to @ra1028)
 1. New operator `map(value:)` (#601, kudos to @ra1028)
-1. `SignalProducer.merge`, `SignalProducer.concat`, `SignalProducer.prefix`, `SignalProducer.then`, `SignalProducer.flatMapError` `Signal.flatMapError`, `Signal.withLatest` and `Property.init(initial:then:)` are now accept `SignalProducerConvertible` conforming types (#610, #611, kudos to @1028)
+1. `SignalProducer.merge`, `SignalProducer.concat`, `SignalProducer.prefix`, `SignalProducer.then`, `SignalProducer.flatMapError` `Signal.flatMapError`, `Signal.withLatest` and `Property.init(initial:then:)` now accept `SignalProducerConvertible` conforming types (#610, #611, kudos to @1028)
 1. Bag can be created with the initial elements now (#609, kudos to @ra1028)
 
 # 3.1.0

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -405,7 +405,7 @@ extension SignalProducer {
 	/// - returns: A producer that, when started, will emit own values and on
 	///            completion will emit a `value`.
 	public func concat(value: Value) -> SignalProducer<Value, Error> {
-		return self.concat(SignalProducer(value: value))
+		return concat(SignalProducer(value: value))
 	}
 
 	/// `concat`s `error` onto `self`.
@@ -416,7 +416,7 @@ extension SignalProducer {
 	/// - returns: A producer that, when started, will emit own values and on
 	///            completion will emit an `error`.
 	public func concat(error: Error) -> SignalProducer<Value, Error> {
-		return self.concat(SignalProducer(error: error))
+		return concat(SignalProducer(error: error))
 	}
 
 	/// `concat`s `self` onto initial `previous`.
@@ -449,7 +449,7 @@ extension SignalProducer {
 	/// - returns: A producer that, when started, first emits `value`, then all
     ///            values emited by `self`.
 	public func prefix(value: Value) -> SignalProducer<Value, Error> {
-		return self.prefix(SignalProducer(value: value))
+		return prefix(SignalProducer(value: value))
 	}
 }
 

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -385,7 +385,7 @@ extension SignalProducer {
 	public func concat(_ next: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
 		return SignalProducer<SignalProducer<Value, Error>, Error>([ self, next ]).flatten(.concat)
 	}
-	
+
 	/// `concat`s `next` onto `self`.
 	///
 	/// - parameters:

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -928,16 +928,16 @@ extension Signal {
 	/// - parameters:
 	///   - transform: A closure that accepts emitted error and returns a signal
 	///                producer with a different type of error.
-	public func flatMapError<F, Inner: SignalProducerConvertible>(_ transform: @escaping (Error) -> Inner) -> Signal<Value, F> where Inner.Value == Value, Inner.Error == F {
-		return Signal<Value, F> { observer, lifetime in
+	public func flatMapError<Inner: SignalProducerConvertible>(_ transform: @escaping (Error) -> Inner) -> Signal<Value, Inner.Error> where Inner.Value == Value {
+		return Signal<Value, Inner.Error> { observer, lifetime in
 			lifetime += self.observeFlatMapError(transform, observer, SerialDisposable())
 		}
 	}
 
-	fileprivate func observeFlatMapError<F, Inner: SignalProducerConvertible>(
+	fileprivate func observeFlatMapError<Inner: SignalProducerConvertible>(
 		_ handler: @escaping (Error) -> Inner,
-		_ observer: Signal<Value, F>.Observer,
-		_ serialDisposable: SerialDisposable) -> Disposable? where Inner.Value == Value, Inner.Error == F {
+		_ observer: Signal<Value, Inner.Error>.Observer,
+		_ serialDisposable: SerialDisposable) -> Disposable? where Inner.Value == Value {
 		return self.observe { event in
 			switch event {
 			case let .value(value):
@@ -963,8 +963,8 @@ extension SignalProducer {
 	/// - parameters:
 	///   - transform: A closure that accepts emitted error and returns a signal
 	///                producer with a different type of error.
-	public func flatMapError<F, Inner: SignalProducerConvertible>(_ transform: @escaping (Error) -> Inner) -> SignalProducer<Value, F> where Inner.Value == Value, Inner.Error == F {
-		return SignalProducer<Value, F> { observer, lifetime in
+	public func flatMapError<Inner: SignalProducerConvertible>(_ transform: @escaping (Error) -> Inner) -> SignalProducer<Value, Inner.Error> where Inner.Value == Value {
+		return SignalProducer<Value, Inner.Error> { observer, lifetime in
 			let serialDisposable = SerialDisposable()
 			lifetime += serialDisposable
 

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -811,8 +811,23 @@ extension Signal {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
-	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Error> where Inner.Error == Error {
+	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error>{
 		return map(transform).flatten(strategy)
+	}
+
+	/// Maps each event from `signal` to a new signal, then flattens the
+	/// resulting producers (into a signal of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// - warning: If `signal` or any of the created producers fail, the
+	///            returned signal will forward that failure immediately.
+	///
+	/// - parameters:
+	///	  - strategy: Strategy used when flattening signals.
+	///   - transform: A closure that takes a value emitted by `self` and
+	///                returns a signal producer with transformed value.
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Error> where Inner.Error == Error {
+		return flatMap(strategy) { transform($0).producer }
 	}
 
 	/// Maps each event from `signal` to a new signal, then flattens the
@@ -826,8 +841,23 @@ extension Signal {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
-	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Error> where Inner.Error == NoError {
+	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, NoError>) -> Signal<U, Error> {
 		return map(transform).flatten(strategy)
+	}
+	
+	/// Maps each event from `signal` to a new signal, then flattens the
+	/// resulting producers (into a signal of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// - warning: If `signal` fails, the returned signal will forward that
+	///            failure immediately.
+	///
+	/// - parameters:
+	///	  - strategy: Strategy used when flattening signals.
+	///   - transform: A closure that takes a value emitted by `self` and
+	///                returns a signal producer with transformed value.
+	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Error> where Inner.Error == NoError {
+		return flatMap(strategy) { transform($0).producer }
 	}
 }
 
@@ -843,7 +873,34 @@ extension Signal where Error == NoError {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
+	public func flatMap<U, F>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, F>) -> Signal<U, F> {
+		return map(transform).flatten(strategy)
+	}
+
+	/// Maps each event from `signal` to a new signal, then flattens the
+	/// resulting signals (into a signal of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// - warning: If any of the created signals emit an error, the returned
+	///            signal will forward that error immediately.
+	///
+	/// - parameters:
+	///	  - strategy: Strategy used when flattening signals.
+	///   - transform: A closure that takes a value emitted by `self` and
+	///                returns a signal producer with transformed value.
 	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, Inner.Error> {
+		return flatMap(strategy) { transform($0).producer }
+	}
+
+	/// Maps each event from `signal` to a new signal, then flattens the
+	/// resulting signals (into a signal of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// - parameters:
+	///	  - strategy: Strategy used when flattening signals.
+	///   - transform: A closure that takes a value emitted by `self` and
+	///                returns a signal producer with transformed value.
+	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, NoError>) -> Signal<U, NoError> {
 		return map(transform).flatten(strategy)
 	}
 
@@ -856,7 +913,7 @@ extension Signal where Error == NoError {
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
 	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> Signal<Inner.Value, NoError> where Inner.Error == NoError {
-		return map(transform).flatten(strategy)
+		return flatMap(strategy) { transform($0).producer }
 	}
 }
 
@@ -872,7 +929,37 @@ extension SignalProducer {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
+	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
+		return map(transform).flatten(strategy)
+	}
+
+	/// Maps each event from `self` to a new producer, then flattens the
+	/// resulting producers (into a producer of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// - warning: If `self` or any of the created producers fail, the returned
+	///            producer will forward that failure immediately.
+	///
+	/// - parameters:
+	///	  - strategy: Strategy used when flattening signals.
+	///   - transform: A closure that takes a value emitted by `self` and
+	///                returns a signal producer with transformed value.
 	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Error> where Inner.Error == Error {
+		return flatMap(strategy) { transform($0).producer }
+	}
+
+	/// Maps each event from `self` to a new producer, then flattens the
+	/// resulting producers (into a producer of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// - warning: If `self` fails, the returned producer will forward that
+	///            failure immediately.
+	///
+	/// - parameters:
+	///	  - strategy: Strategy used when flattening signals.
+	///   - transform: A closure that takes a value emitted by `self` and
+	///                returns a signal producer with transformed value.
+	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, NoError>) -> SignalProducer<U, Error> {
 		return map(transform).flatten(strategy)
 	}
 
@@ -888,7 +975,7 @@ extension SignalProducer {
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
 	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Error> where Inner.Error == NoError {
-		return map(transform).flatten(strategy)
+		return flatMap(strategy) { transform($0).producer }
 	}
 }
 
@@ -901,7 +988,34 @@ extension SignalProducer where Error == NoError {
 	///	  - strategy: Strategy used when flattening signals.
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
+	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
+		return map(transform).flatten(strategy)
+	}
+
+	/// Maps each event from `self` to a new producer, then flattens the
+	/// resulting producers (into a producer of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// - parameters:
+	///	  - strategy: Strategy used when flattening signals.
+	///   - transform: A closure that takes a value emitted by `self` and
+	///                returns a signal producer with transformed value.
 	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Error> where Inner.Error == Error {
+		return flatMap(strategy) { transform($0).producer }
+	}
+
+	/// Maps each event from `self` to a new producer, then flattens the
+	/// resulting producers (into a producer of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// - warning: If any of the created producers fail, the returned producer
+	///            will forward that failure immediately.
+	///
+	/// - parameters:
+	///	  - strategy: Strategy used when flattening signals.
+	///   - transform: A closure that takes a value emitted by `self` and
+	///                returns a signal producer with transformed value.
+	public func flatMap<U, F>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, F>) -> SignalProducer<U, F> {
 		return map(transform).flatten(strategy)
 	}
 
@@ -917,7 +1031,7 @@ extension SignalProducer where Error == NoError {
 	///   - transform: A closure that takes a value emitted by `self` and
 	///                returns a signal producer with transformed value.
 	public func flatMap<Inner: SignalProducerConvertible>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> Inner) -> SignalProducer<Inner.Value, Inner.Error> {
-		return map(transform).flatten(strategy)
+		return flatMap(strategy) { transform($0).producer }
 	}
 }
 
@@ -928,12 +1042,12 @@ extension Signal {
 	/// - parameters:
 	///   - transform: A closure that accepts emitted error and returns a signal
 	///                producer with a different type of error.
-	public func flatMapError<NewError>(_ transform: @escaping (Error) -> SignalProducer<Value, NewError>) -> Signal<Value, NewError> {
-		return Signal<Value, NewError> { observer, lifetime in
+	public func flatMapError<F>(_ transform: @escaping (Error) -> SignalProducer<Value, F>) -> Signal<Value, F> {
+		return Signal<Value, F> { observer, lifetime in
 			lifetime += self.observeFlatMapError(transform, observer, SerialDisposable())
 		}
 	}
-	
+
 	/// Catches any failure that may occur on the input signal, mapping to a new
 	/// producer that starts in its place.
 	///
@@ -973,8 +1087,8 @@ extension SignalProducer {
 	/// - parameters:
 	///   - transform: A closure that accepts emitted error and returns a signal
 	///                producer with a different type of error.
-	public func flatMapError<NewError>(_ transform: @escaping (Error) -> SignalProducer<Value, NewError>) -> SignalProducer<Value, NewError> {
-		return SignalProducer<Value, NewError> { observer, lifetime in
+	public func flatMapError<F>(_ transform: @escaping (Error) -> SignalProducer<Value, F>) -> SignalProducer<Value, F> {
+		return SignalProducer<Value, F> { observer, lifetime in
 			let serialDisposable = SerialDisposable()
 			lifetime += serialDisposable
 
@@ -985,7 +1099,7 @@ extension SignalProducer {
 			}
 		}
 	}
-	
+
 	/// Catches any failure that may occur on the input producer, mapping to a
 	/// new producer that starts in its place.
 	///

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -418,7 +418,7 @@ extension SignalProducer {
 	public func concat(error: Error) -> SignalProducer<Value, Error> {
 		return self.concat(SignalProducer(error: error))
 	}
-	
+
 	/// `concat`s `self` onto initial `previous`.
 	///
 	/// - parameters:
@@ -866,7 +866,7 @@ extension Signal {
 	public func flatMap<U>(_ strategy: FlattenStrategy, _ transform: @escaping (Value) -> SignalProducer<U, NoError>) -> Signal<U, Error> {
 		return map(transform).flatten(strategy)
 	}
-	
+
 	/// Maps each event from `signal` to a new signal, then flattens the
 	/// resulting producers (into a signal of values), according to the
 	/// semantics of the given strategy.

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -501,7 +501,7 @@ public final class Property<Value>: PropertyProtocol {
 	public convenience init<P: PropertyProtocol>(_ property: P) where P.Value == Value {
 		self.init(unsafeProducer: property.producer)
 	}
-	
+
 	/// Initializes a composed property that first takes on `initial`, then each
 	/// value sent on a signal created by `producer`.
 	///
@@ -610,7 +610,7 @@ extension Property where Value: OptionalProtocol {
 	public convenience init(initial: Value, then values: SignalProducer<Value.Wrapped, NoError>) {
 		self.init(initial: initial, then: values.map(Value.init(reconstructing:)))
 	}
-	
+
 	/// Initializes a composed property that first takes on `initial`, then each
 	/// value sent on a signal created by `producer`.
 	///

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -509,21 +509,11 @@ public final class Property<Value>: PropertyProtocol {
 	///   - initial: Starting value for the property.
 	///   - values: A producer that will start immediately and send values to
 	///             the property.
-	public convenience init(initial: Value, then values: SignalProducer<Value, NoError>) {
+	public convenience init<Values: SignalProducerConvertible>(initial: Value, then values: Values) where Values.Value == Value, Values.Error == NoError {
 		self.init(unsafeProducer: SignalProducer { observer, lifetime in
 			observer.send(value: initial)
-			lifetime += values.start(Signal.Observer(mappingInterruptedToCompleted: observer))
+			lifetime += values.producer.start(Signal.Observer(mappingInterruptedToCompleted: observer))
 		})
-	}
-
-	/// Initialize a composed property that first takes on `initial`, then each
-	/// value sent on `signal`.
-	///
-	/// - parameters:
-	///   - initialValue: Starting value for the property.
-	///   - values: A signal that will send values to the property.
-	public convenience init(initial: Value, then values: Signal<Value, NoError>) {
-		self.init(initial: initial, then: SignalProducer(values))
 	}
 
 	/// Initialize a composed property from a producer that promises to send
@@ -606,18 +596,8 @@ extension Property where Value: OptionalProtocol {
 	///   - initial: Starting value for the property.
 	///   - values: A producer that will start immediately and send values to
 	///             the property.
-	public convenience init(initial: Value, then values: SignalProducer<Value.Wrapped, NoError>) {
-		self.init(initial: initial, then: values.map(Value.init(reconstructing:)))
-	}
-
-	/// Initialize a composed property that first takes on `initial`, then each
-	/// value sent on `signal`.
-	///
-	/// - parameters:
-	///   - initialValue: Starting value for the property.
-	///   - values: A signal that will send values to the property.
-	public convenience init(initial: Value, then values: Signal<Value.Wrapped, NoError>) {
-		self.init(initial: initial, then: SignalProducer(values))
+	public convenience init<Values: SignalProducerConvertible>(initial: Value, then values: Values) where Values.Value == Value.Wrapped, Values.Error == NoError {
+		self.init(initial: initial, then: values.producer.map(Value.init(reconstructing:)))
 	}
 }
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1083,7 +1083,7 @@ extension Signal {
 			}
 		}
 	}
-	
+
 	/// Forward the latest value from `samplee` with the value from `self` as a
 	/// tuple, only when `self` sends a `value` event.
 	/// This is like a flipped version of `sample(with:)`, but `samplee`'s

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1075,8 +1075,8 @@ extension Signal {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func withLatest<U, Samplee: SignalProducerConvertible>(from samplee: Samplee) -> Signal<(Value, U), Error> where Samplee.Value == U, Samplee.Error == NoError {
-		return Signal<(Value, U), Error> { observer, lifetime in
+	public func withLatest<Samplee: SignalProducerConvertible>(from samplee: Samplee) -> Signal<(Value, Samplee.Value), Error> where Samplee.Error == NoError {
+		return Signal<(Value, Samplee.Value), Error> { observer, lifetime in
 			samplee.producer.startWithSignal { signal, disposable in
 				lifetime += disposable
 				lifetime += self.withLatest(from: signal).observe(observer)

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1075,13 +1075,32 @@ extension Signal {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func withLatest<Samplee: SignalProducerConvertible>(from samplee: Samplee) -> Signal<(Value, Samplee.Value), Error> where Samplee.Error == NoError {
-		return Signal<(Value, Samplee.Value), Error> { observer, lifetime in
-			samplee.producer.startWithSignal { signal, disposable in
+	public func withLatest<U>(from samplee: SignalProducer<U, NoError>) -> Signal<(Value, U), Error> {
+		return Signal<(Value, U), Error> { observer, lifetime in
+			samplee.startWithSignal { signal, disposable in
 				lifetime += disposable
 				lifetime += self.withLatest(from: signal).observe(observer)
 			}
 		}
+	}
+	
+	/// Forward the latest value from `samplee` with the value from `self` as a
+	/// tuple, only when `self` sends a `value` event.
+	/// This is like a flipped version of `sample(with:)`, but `samplee`'s
+	/// terminal events are completely ignored.
+	///
+	/// - note: If `self` fires before a value has been observed on `samplee`,
+	///         nothing happens.
+	///
+	/// - parameters:
+	///   - samplee: A producer whose latest value is sampled by `self`.
+	///
+	/// - returns: A signal that will send values from `self` and `samplee`,
+	///            sampled (possibly multiple times) by `self`, then terminate
+	///            once `self` has terminated. **`samplee`'s terminated events
+	///            are ignored**.
+	public func withLatest<Samplee: SignalProducerConvertible>(from samplee: Samplee) -> Signal<(Value, Samplee.Value), Error> where Samplee.Error == NoError {
+		return withLatest(from: samplee.producer)
 	}
 }
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1075,9 +1075,9 @@ extension Signal {
 	///            sampled (possibly multiple times) by `self`, then terminate
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
-	public func withLatest<U>(from samplee: SignalProducer<U, NoError>) -> Signal<(Value, U), Error> {
+	public func withLatest<U, Samplee: SignalProducerConvertible>(from samplee: Samplee) -> Signal<(Value, U), Error> where Samplee.Value == U, Samplee.Error == NoError {
 		return Signal<(Value, U), Error> { observer, lifetime in
-			samplee.startWithSignal { signal, disposable in
+			samplee.producer.startWithSignal { signal, disposable in
 				lifetime += disposable
 				lifetime += self.withLatest(from: signal).observe(observer)
 			}

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2127,7 +2127,7 @@ extension SignalProducer {
 	///
 	/// - returns: A producer that sends events from `self` and then from
 	///            `replacement` when `self` completes.
-	public func then<U, Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<U, Error> where Replacement.Value == U, Replacement.Error == NoError {
+	public func then<Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<Replacement.Value, Error> where Replacement.Error == NoError {
 		return _then(replacement.producer.promoteError(Error.self))
 	}
 
@@ -2143,7 +2143,7 @@ extension SignalProducer {
 	///
 	/// - returns: A producer that sends events from `self` and then from
 	///            `replacement` when `self` completes.
-	public func then<U, Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<U, Error> where Replacement.Value == U, Replacement.Error == Error {
+	public func then<Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<Replacement.Value, Error> where Replacement.Error == Error {
 		return _then(replacement)
 	}
 
@@ -2170,8 +2170,8 @@ extension SignalProducer {
 	//       prefix is added to avoid self referencing in `then(_:)` overloads with
 	//       regard to the most specific rule of overload selection in Swift.
 
-	internal func _then<U, Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<U, Error> where Replacement.Value == U, Replacement.Error == Error {
-		return SignalProducer<U, Error> { observer, lifetime in
+	internal func _then<Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<Replacement.Value, Error> where Replacement.Error == Error {
+		return SignalProducer<Replacement.Value, Error> { observer, lifetime in
 			self.startWithSignal { signal, signalDisposable in
 				lifetime += signalDisposable
 
@@ -2203,8 +2203,8 @@ extension SignalProducer where Error == NoError {
 	///
 	/// - returns: A producer that sends events from `self` and then from
 	///            `replacement` when `self` completes.
-	public func then<U, NewError, Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<U, NewError> where Replacement.Value == U, Replacement.Error == NewError {
-		return promoteError(NewError.self)._then(replacement)
+	public func then<Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<Replacement.Value, Replacement.Error> {
+		return promoteError(Replacement.Error.self)._then(replacement)
 	}
 
 	// NOTE: The overload below is added to disambiguate compile-time selection of
@@ -2220,7 +2220,7 @@ extension SignalProducer where Error == NoError {
 	///
 	/// - returns: A producer that sends events from `self` and then from
 	///            `replacement` when `self` completes.
-	public func then<U, Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<U, NoError> where Replacement.Value == U, Replacement.Error == NoError {
+	public func then<Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<Replacement.Value, NoError> where Replacement.Error == NoError {
 		return _then(replacement)
 	}
 	

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2635,6 +2635,17 @@ extension SignalProducer where Value == Bool {
 	public func negate() -> SignalProducer<Value, Error> {
 		return map(!)
 	}
+	
+	/// Create a producer that computes a logical AND between the latest values of `self`
+	/// and `producer`.
+	///
+	/// - parameters:
+	///   - booleans: A producer of booleans to be combined with `self`.
+	///
+	/// - returns: A producer that emits the logical AND results.
+	public func and(_ booleans: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
+		return combineLatest(with: booleans).map { $0.0 && $0.1 }
+	}
 
 	/// Create a producer that computes a logical AND between the latest values of `self`
 	/// and `producer`.
@@ -2644,7 +2655,18 @@ extension SignalProducer where Value == Bool {
 	///
 	/// - returns: A producer that emits the logical AND results.
 	public func and<Booleans: SignalProducerConvertible>(_ booleans: Booleans) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error {
-		return combineLatest(with: booleans).map { $0.0 && $0.1 }
+		return and(booleans.producer)
+	}
+
+	/// Create a producer that computes a logical OR between the latest values of `self`
+	/// and `producer`.
+	///
+	/// - parameters:
+	///   - booleans: A producer of booleans to be combined with `self`.
+	///
+	/// - returns: A producer that emits the logical OR results.
+	public func or(_ booleans: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
+		return combineLatest(with: booleans).map { $0.0 || $0.1 }
 	}
 
 	/// Create a producer that computes a logical OR between the latest values of `self`
@@ -2655,7 +2677,7 @@ extension SignalProducer where Value == Bool {
 	///
 	/// - returns: A producer that emits the logical OR results.
 	public func or<Booleans: SignalProducerConvertible>(_ booleans: Booleans) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error {
-		return combineLatest(with: booleans).map { $0.0 || $0.1 }
+		return or(booleans.producer)
 	}
 }
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2093,14 +2093,14 @@ extension SignalProducer {
 	/// - returns: A signal producer that restarts up to `count` times.
 	public func retry(upTo count: Int, interval: TimeInterval, on scheduler: DateScheduler) -> SignalProducer<Value, Error> {
 		precondition(count >= 0)
-		
+
 		if count == 0 {
 			return producer
 		}
-		
+
 		var retries = count
-		
-		return flatMapError { error in
+
+		return flatMapError { error -> SignalProducer<Value, Error> in
 				// The final attempt shouldn't defer the error if it fails
 				var producer = SignalProducer<Value, Error>(error: error)
 				if retries > 0 {
@@ -2108,7 +2108,7 @@ extension SignalProducer {
 						.delay(interval, on: scheduler)
 						.concat(producer)
 				}
-			
+
 				retries -= 1
 				return producer
 			}

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1108,7 +1108,7 @@ extension SignalProducer {
 	public func combineLatest<Other: SignalProducerConvertible>(with other: Other) -> SignalProducer<(Value, Other.Value), Error> where Other.Error == Error {
 		return combineLatest(with: other.producer)
 	}
-	
+
 	/// Merge the given producer into a single `SignalProducer` that will emit all
 	/// values from both of them, and complete when all of them have completed.
 	///
@@ -1119,7 +1119,7 @@ extension SignalProducer {
 	public func merge(with other: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
 		return SignalProducer.merge(self, other)
 	}
-	
+
 	/// Merge the given producer into a single `SignalProducer` that will emit all
 	/// values from both of them, and complete when all of them have completed.
 	///
@@ -1191,7 +1191,7 @@ extension SignalProducer {
 	public func sample<U>(with sampler: SignalProducer<U, NoError>) -> SignalProducer<(Value, U), Error> {
 		return liftLeft(Signal.sample(with:))(sampler)
 	}
-	
+
 	/// Forward the latest value from `self` with the value from `sampler` as a
 	/// tuple, only when `sampler` sends a `value` event.
 	///
@@ -1209,7 +1209,7 @@ extension SignalProducer {
 	public func sample<Sampler: SignalProducerConvertible>(with sampler: Sampler) -> SignalProducer<(Value, Sampler.Value), Error> where Sampler.Error == NoError {
 		return sample(with: sampler.producer)
 	}
-	
+
 	/// Forward the latest value from `self` whenever `sampler` sends a `value`
 	/// event.
 	///
@@ -1264,7 +1264,7 @@ extension SignalProducer {
 	public func withLatest<U>(from samplee: SignalProducer<U, NoError>) -> SignalProducer<(Value, U), Error> {
 		return liftRight(Signal.withLatest)(samplee.producer)
 	}
-	
+
 	/// Forward the latest value from `samplee` with the value from `self` as a
 	/// tuple, only when `self` sends a `value` event.
 	/// This is like a flipped version of `sample(with:)`, but `samplee`'s
@@ -1308,7 +1308,7 @@ extension SignalProducer {
 	public func take(until trigger: SignalProducer<(), NoError>) -> SignalProducer<Value, Error> {
 		return liftRight(Signal.take(until:))(trigger)
 	}
-	
+
 	/// Forward events from `self` until `trigger` sends a `value` or `completed`
 	/// event, at which point the returned producer will complete.
 	///
@@ -1335,7 +1335,7 @@ extension SignalProducer {
 	public func skip(until trigger: SignalProducer<(), NoError>) -> SignalProducer<Value, Error> {
 		return liftRight(Signal.skip(until:))(trigger)
 	}
-	
+
 	/// Do not forward any values from `self` until `trigger` sends a `value`
 	/// or `completed`, at which point the returned producer behaves exactly
 	/// like `producer`.
@@ -1488,7 +1488,7 @@ extension SignalProducer {
 	public func take(untilReplacement replacement: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
 		return liftRight(Signal.take(untilReplacement:))(replacement)
 	}
-	
+
 	/// Forwards events from `self` until `replacement` begins sending events.
 	///
 	/// - parameters:
@@ -1539,7 +1539,7 @@ extension SignalProducer {
 	public func zip<U>(with other: SignalProducer<U, Error>) -> SignalProducer<(Value, U), Error> {
 		return SignalProducer.zip(self, other)
 	}
-	
+
 	/// Zip elements of two producers into pairs. The elements of any Nth pair
 	/// are the Nth elements of the two input producers.
 	///
@@ -2255,7 +2255,7 @@ extension SignalProducer {
 			}
 			.retry(upTo: count)
 	}
-	
+
 	/// Wait for completion of `self`, *then* forward all events from
 	/// `replacement`. Any failure or interruption sent from `self` is
 	/// forwarded immediately, in which case `replacement` will not be started,
@@ -2271,7 +2271,7 @@ extension SignalProducer {
 	public func then<U>(_ replacement: SignalProducer<U, NoError>) -> SignalProducer<U, Error> {
 		return _then(replacement.promoteError(Error.self))
 	}
-	
+
 	/// Wait for completion of `self`, *then* forward all events from
 	/// `replacement`. Any failure or interruption sent from `self` is
 	/// forwarded immediately, in which case `replacement` will not be started,
@@ -2287,7 +2287,7 @@ extension SignalProducer {
 	public func then<Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<Replacement.Value, Error> where Replacement.Error == NoError {
 		return then(replacement.producer)
 	}
-	
+
 	/// Wait for completion of `self`, *then* forward all events from
 	/// `replacement`. Any failure or interruption sent from `self` is
 	/// forwarded immediately, in which case `replacement` will not be started,
@@ -2338,7 +2338,7 @@ extension SignalProducer {
 	public func then(_ replacement: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
 		return _then(replacement)
 	}
-	
+
 	/// Wait for completion of `self`, *then* forward all events from
 	/// `replacement`. Any failure or interruption sent from `self` is
 	/// forwarded immediately, in which case `replacement` will not be started,
@@ -2395,7 +2395,7 @@ extension SignalProducer where Error == NoError {
 	public func then<U, F>(_ replacement: SignalProducer<U, F>) -> SignalProducer<U, F> {
 		return promoteError(F.self)._then(replacement)
 	}
-	
+
 	/// Wait for completion of `self`, *then* forward all events from
 	/// `replacement`.
 	///
@@ -2426,7 +2426,7 @@ extension SignalProducer where Error == NoError {
 	public func then<U>(_ replacement: SignalProducer<U, NoError>) -> SignalProducer<U, NoError> {
 		return _then(replacement)
 	}
-	
+
 	/// Wait for completion of `self`, *then* forward all events from
 	/// `replacement`.
 	///
@@ -2440,7 +2440,7 @@ extension SignalProducer where Error == NoError {
 	public func then<Replacement: SignalProducerConvertible>(_ replacement: Replacement) -> SignalProducer<Replacement.Value, NoError> where Replacement.Error == NoError {
 		return then(replacement.producer)
 	}
-	
+
 	/// Wait for completion of `self`, *then* forward all events from
 	/// `replacement`.
 	///
@@ -2454,7 +2454,7 @@ extension SignalProducer where Error == NoError {
 	public func then(_ replacement: SignalProducer<Value, NoError>) -> SignalProducer<Value, NoError> {
 		return _then(replacement)
 	}
-	
+
 	/// Wait for completion of `self`, *then* forward all events from
 	/// `replacement`.
 	///
@@ -2635,7 +2635,7 @@ extension SignalProducer where Value == Bool {
 	public func negate() -> SignalProducer<Value, Error> {
 		return map(!)
 	}
-	
+
 	/// Create a producer that computes a logical AND between the latest values of `self`
 	/// and `producer`.
 	///

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -1120,29 +1120,54 @@ class FlattenSpec: QuickSpec {
 				observer.send(value: 3)
 				expect(lastValue) == 3
 			}
-
+			
 			it("should emit initial value") {
 				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
-
+				
 				let mergedSignals = signal.prefix(SignalProducer(value: 0))
-
+				
 				var lastValue: Int?
 				mergedSignals.startWithValues { lastValue = $0 }
-
+				
+				expect(lastValue) == 0
+				
+				observer.send(value: 1)
+				expect(lastValue) == 1
+				
+				observer.send(value: 2)
+				expect(lastValue) == 2
+				
+				observer.send(value: 3)
+				expect(lastValue) == 3
+			}
+			
+			it("should accept SignalProducerConvertible conforming type") {
+				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
+				
+				let mergedSignals = signal.prefix(Property(value: 0))
+				
+				var lastValue: Int?
+				mergedSignals.startWithValues { lastValue = $0 }
+				
 				expect(lastValue) == 0
 
 				observer.send(value: 1)
 				expect(lastValue) == 1
-
+				
 				observer.send(value: 2)
 				expect(lastValue) == 2
-
+				
 				observer.send(value: 3)
 				expect(lastValue) == 3
 			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Int, NoError>.empty
+					.prefix(.init(value: 0))
+			}
 		}
 
-		describe("SignalProducer.concat(value:)") {
+		describe("SignalProducer.concat()") {
 			it("should emit final value") {
 				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
 
@@ -1163,9 +1188,49 @@ class FlattenSpec: QuickSpec {
 				observer.sendCompleted()
 				expect(lastValue) == 4
 			}
-		}
-
-		describe("SignalProducer.concat(error:)") {
+			
+			it("should emit final value") {
+				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
+				
+				let mergedSignals = signal.concat(SignalProducer(value: 4))
+				
+				var lastValue: Int?
+				mergedSignals.startWithValues { lastValue = $0 }
+				
+				observer.send(value: 1)
+				expect(lastValue) == 1
+				
+				observer.send(value: 2)
+				expect(lastValue) == 2
+				
+				observer.send(value: 3)
+				expect(lastValue) == 3
+				
+				observer.sendCompleted()
+				expect(lastValue) == 4
+			}
+			
+			it("should accept SignalProducerConvertible conforming type") {
+				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
+				
+				let mergedSignals = signal.concat(Property(value: 4))
+				
+				var lastValue: Int?
+				mergedSignals.startWithValues { lastValue = $0 }
+				
+				observer.send(value: 1)
+				expect(lastValue) == 1
+				
+				observer.send(value: 2)
+				expect(lastValue) == 2
+				
+				observer.send(value: 3)
+				expect(lastValue) == 3
+				
+				observer.sendCompleted()
+				expect(lastValue) == 4
+			}
+			
 			it("should emit concatenated error") {
 				let (signal, observer) = SignalProducer<Int, TestError>.pipe()
 
@@ -1198,6 +1263,11 @@ class FlattenSpec: QuickSpec {
 
 				expect(results).to(haveCount(1))
 				expect(results[0].error) == .error1
+			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Int, NoError>.empty
+					.concat(.init(value: 0))
 			}
 		}
 

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -644,6 +644,26 @@ class FlattenSpec: QuickSpec {
 				_ = Signal<Int, NoError>.empty
 					.flatMap(.latest) { _ in Property(value: 0) }
 			}
+			
+			it("sould available to use contextual lookup for arbitrary error outer signal and arbitrary error inner signal") {
+				_ = Signal<Int, TestError>.empty
+					.flatMap(.latest) { _ in .init(error: .default) } as Signal<Int, TestError>
+			}
+			
+			it("sould available to use contextual lookup for NoError outer signal and NoError inner signal") {
+				_ = Signal<Int, NoError>.empty
+					.flatMap(.latest) { _ in .init(value: 0) }
+			}
+			
+			it("sould available to use contextual lookup for arbitrary error outer signal and NoError inner signal") {
+				_ = Signal<Int, TestError>.empty
+					.flatMap(.latest) { _ in .init(value: 0) }
+			}
+			
+			it("sould available to use contextual lookup for NoError outer signal and arbitrary error inner signal") {
+				_ = Signal<Int, NoError>.empty
+					.flatMap(.latest) { _ in .init(error: .default) } as Signal<Int, TestError>
+			}
 		}
 
 		describe("SignalProducer.flatMap()") {
@@ -813,6 +833,26 @@ class FlattenSpec: QuickSpec {
 			it("works with Property and NoError") {
 				_ = SignalProducer<Int, NoError>.empty
 					.flatMap(.latest) { _ in Property(value: 0) }
+			}
+			
+			it("sould available to use contextual lookup for arbitrary error outer signal and arbitrary error inner signal") {
+				_ = SignalProducer<Int, TestError>.empty
+					.flatMap(.latest) { _ in .init(error: .default) } as SignalProducer<Int, TestError>
+			}
+			
+			it("sould available to use contextual lookup for NoError outer signal and NoError inner signal") {
+				_ = SignalProducer<Int, NoError>.empty
+					.flatMap(.latest) { _ in .init(value: 0) }
+			}
+			
+			it("sould available to use contextual lookup for arbitrary error outer signal and NoError inner signal") {
+				_ = SignalProducer<Int, TestError>.empty
+					.flatMap(.latest) { _ in .init(value: 0) }
+			}
+			
+			it("sould available to use contextual lookup for NoError outer signal and arbitrary error inner signal") {
+				_ = SignalProducer<Int, NoError>.empty
+					.flatMap(.latest) { _ in .init(error: .default) } as SignalProducer<Int, TestError>
 			}
 		}
 

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -645,24 +645,24 @@ class FlattenSpec: QuickSpec {
 					.flatMap(.latest) { _ in Property(value: 0) }
 			}
 
-			it("sould available to use contextual lookup for arbitrary error outer signal and arbitrary error inner signal") {
+			it("sould available to use contextual lookup for flatMap arbitrary error signal to arbitrary error signal") {
 				_ = Signal<Int, TestError>.empty
-					.flatMap(.latest) { _ in .init(error: .default) } as Signal<Int, TestError>
+					.flatMap(.latest) { _ in .init(result: Result<Int, TestError>(error: .default)) }
 			}
 
-			it("sould available to use contextual lookup for NoError outer signal and NoError inner signal") {
+			it("sould available to use contextual lookup for flatMap NoError signal to NoError signal") {
 				_ = Signal<Int, NoError>.empty
 					.flatMap(.latest) { _ in .init(value: 0) }
 			}
 
-			it("sould available to use contextual lookup for arbitrary error outer signal and NoError inner signal") {
+			it("sould available to use contextual lookup for flatMap arbitrary error signal and NoError signal") {
 				_ = Signal<Int, TestError>.empty
 					.flatMap(.latest) { _ in .init(value: 0) }
 			}
 
-			it("sould available to use contextual lookup for NoError outer signal and arbitrary error inner signal") {
+			it("sould available to use contextual lookup for flatMap NoError signal to arbitrary error signal") {
 				_ = Signal<Int, NoError>.empty
-					.flatMap(.latest) { _ in .init(error: .default) } as Signal<Int, TestError>
+					.flatMap(.latest) { _ in .init(result: Result<Int, TestError>(error: .default)) }
 			}
 		}
 

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -644,22 +644,22 @@ class FlattenSpec: QuickSpec {
 				_ = Signal<Int, NoError>.empty
 					.flatMap(.latest) { _ in Property(value: 0) }
 			}
-			
+
 			it("sould available to use contextual lookup for arbitrary error outer signal and arbitrary error inner signal") {
 				_ = Signal<Int, TestError>.empty
 					.flatMap(.latest) { _ in .init(error: .default) } as Signal<Int, TestError>
 			}
-			
+
 			it("sould available to use contextual lookup for NoError outer signal and NoError inner signal") {
 				_ = Signal<Int, NoError>.empty
 					.flatMap(.latest) { _ in .init(value: 0) }
 			}
-			
+
 			it("sould available to use contextual lookup for arbitrary error outer signal and NoError inner signal") {
 				_ = Signal<Int, TestError>.empty
 					.flatMap(.latest) { _ in .init(value: 0) }
 			}
-			
+
 			it("sould available to use contextual lookup for NoError outer signal and arbitrary error inner signal") {
 				_ = Signal<Int, NoError>.empty
 					.flatMap(.latest) { _ in .init(error: .default) } as Signal<Int, TestError>
@@ -834,22 +834,22 @@ class FlattenSpec: QuickSpec {
 				_ = SignalProducer<Int, NoError>.empty
 					.flatMap(.latest) { _ in Property(value: 0) }
 			}
-			
+
 			it("sould available to use contextual lookup for flatMap arbitrary error signal to arbitrary error signal") {
 				_ = SignalProducer<Int, TestError>.empty
 					.flatMap(.latest) { _ in .init(error: .default) } as SignalProducer<Int, TestError>
 			}
-			
+
 			it("sould available to use contextual lookup for flatMap NoError signal to NoError signal") {
 				_ = SignalProducer<Int, NoError>.empty
 					.flatMap(.latest) { _ in .init(value: 0) }
 			}
-			
+
 			it("sould available to use contextual lookup for flatMap arbitrary error signal to NoError signal") {
 				_ = SignalProducer<Int, TestError>.empty
 					.flatMap(.latest) { _ in .init(value: 0) }
 			}
-			
+
 			it("sould available to use contextual lookup for flatMap NoError signal to arbitrary error signal") {
 				_ = SignalProducer<Int, NoError>.empty
 					.flatMap(.latest) { _ in .init(error: .default) } as SignalProducer<Int, TestError>
@@ -1138,7 +1138,7 @@ class FlattenSpec: QuickSpec {
 				observer2.sendCompleted()
 				expect(completed) == true
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, NoError>.empty
 					.merge(with: .init(value: 0))
@@ -1165,47 +1165,47 @@ class FlattenSpec: QuickSpec {
 				observer.send(value: 3)
 				expect(lastValue) == 3
 			}
-			
+
 			it("should emit initial value") {
 				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
-				
+
 				let mergedSignals = signal.prefix(SignalProducer(value: 0))
-				
+
 				var lastValue: Int?
 				mergedSignals.startWithValues { lastValue = $0 }
-				
-				expect(lastValue) == 0
-				
-				observer.send(value: 1)
-				expect(lastValue) == 1
-				
-				observer.send(value: 2)
-				expect(lastValue) == 2
-				
-				observer.send(value: 3)
-				expect(lastValue) == 3
-			}
-			
-			it("should accept SignalProducerConvertible conforming type") {
-				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
-				
-				let mergedSignals = signal.prefix(Property(value: 0))
-				
-				var lastValue: Int?
-				mergedSignals.startWithValues { lastValue = $0 }
-				
+
 				expect(lastValue) == 0
 
 				observer.send(value: 1)
 				expect(lastValue) == 1
-				
+
 				observer.send(value: 2)
 				expect(lastValue) == 2
-				
+
 				observer.send(value: 3)
 				expect(lastValue) == 3
 			}
-			
+
+			it("should accept SignalProducerConvertible conforming type") {
+				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
+
+				let mergedSignals = signal.prefix(Property(value: 0))
+
+				var lastValue: Int?
+				mergedSignals.startWithValues { lastValue = $0 }
+
+				expect(lastValue) == 0
+
+				observer.send(value: 1)
+				expect(lastValue) == 1
+
+				observer.send(value: 2)
+				expect(lastValue) == 2
+
+				observer.send(value: 3)
+				expect(lastValue) == 3
+			}
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, NoError>.empty
 					.prefix(.init(value: 0))
@@ -1233,49 +1233,49 @@ class FlattenSpec: QuickSpec {
 				observer.sendCompleted()
 				expect(lastValue) == 4
 			}
-			
+
 			it("should emit final value") {
 				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
-				
+
 				let mergedSignals = signal.concat(SignalProducer(value: 4))
-				
+
 				var lastValue: Int?
 				mergedSignals.startWithValues { lastValue = $0 }
-				
+
 				observer.send(value: 1)
 				expect(lastValue) == 1
-				
+
 				observer.send(value: 2)
 				expect(lastValue) == 2
-				
+
 				observer.send(value: 3)
 				expect(lastValue) == 3
-				
+
 				observer.sendCompleted()
 				expect(lastValue) == 4
 			}
-			
+
 			it("should accept SignalProducerConvertible conforming type") {
 				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
-				
+
 				let mergedSignals = signal.concat(Property(value: 4))
-				
+
 				var lastValue: Int?
 				mergedSignals.startWithValues { lastValue = $0 }
-				
+
 				observer.send(value: 1)
 				expect(lastValue) == 1
-				
+
 				observer.send(value: 2)
 				expect(lastValue) == 2
-				
+
 				observer.send(value: 3)
 				expect(lastValue) == 3
-				
+
 				observer.sendCompleted()
 				expect(lastValue) == 4
 			}
-			
+
 			it("should emit concatenated error") {
 				let (signal, observer) = SignalProducer<Int, TestError>.pipe()
 
@@ -1309,7 +1309,7 @@ class FlattenSpec: QuickSpec {
 				expect(results).to(haveCount(1))
 				expect(results[0].error) == .error1
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, NoError>.empty
 					.concat(.init(value: 0))

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -1138,6 +1138,11 @@ class FlattenSpec: QuickSpec {
 				observer2.sendCompleted()
 				expect(completed) == true
 			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Int, NoError>.empty
+					.merge(with: .init(value: 0))
+			}
 		}
 
 		describe("SignalProducer.prefix()") {

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -835,22 +835,22 @@ class FlattenSpec: QuickSpec {
 					.flatMap(.latest) { _ in Property(value: 0) }
 			}
 			
-			it("sould available to use contextual lookup for arbitrary error outer signal and arbitrary error inner signal") {
+			it("sould available to use contextual lookup for flatMap arbitrary error signal to arbitrary error signal") {
 				_ = SignalProducer<Int, TestError>.empty
 					.flatMap(.latest) { _ in .init(error: .default) } as SignalProducer<Int, TestError>
 			}
 			
-			it("sould available to use contextual lookup for NoError outer signal and NoError inner signal") {
+			it("sould available to use contextual lookup for flatMap NoError signal to NoError signal") {
 				_ = SignalProducer<Int, NoError>.empty
 					.flatMap(.latest) { _ in .init(value: 0) }
 			}
 			
-			it("sould available to use contextual lookup for arbitrary error outer signal and NoError inner signal") {
+			it("sould available to use contextual lookup for flatMap arbitrary error signal to NoError signal") {
 				_ = SignalProducer<Int, TestError>.empty
 					.flatMap(.latest) { _ in .init(value: 0) }
 			}
 			
-			it("sould available to use contextual lookup for NoError outer signal and arbitrary error inner signal") {
+			it("sould available to use contextual lookup for flatMap NoError signal to arbitrary error signal") {
 				_ = SignalProducer<Int, NoError>.empty
 					.flatMap(.latest) { _ in .init(error: .default) } as SignalProducer<Int, TestError>
 			}

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -661,6 +661,14 @@ class PropertySpec: QuickSpec {
 						propertySignal.observeInterrupted { signalInterrupted = true }
 						expect(signalInterrupted) == true
 					}
+					
+					it("sould available to use contextual lookup") {
+						_ = Property(initial: 0, then: .init(value: 0))
+					}
+					
+					it("sould available to use contextual lookup for optional value") {
+						_ = Property(initial: Optional(0), then: .init(value: 0))
+					}
 				}
 
 				describe("from a value and Signal") {

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -661,11 +661,11 @@ class PropertySpec: QuickSpec {
 						propertySignal.observeInterrupted { signalInterrupted = true }
 						expect(signalInterrupted) == true
 					}
-					
+
 					it("sould available to use contextual lookup") {
 						_ = Property(initial: 0, then: .init(value: 0))
 					}
-					
+
 					it("sould available to use contextual lookup for optional value") {
 						_ = Property(initial: Optional(0), then: .init(value: 0))
 					}

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -722,6 +722,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.send(value: 0)
 				expect(lastValue) == 0
 			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Int, NoError>.empty
+					.skip(until: .init(value: ()))
+			}
 		}
 
 		describe("take") {
@@ -1017,6 +1022,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(completed) == true
 				expect(lastValue).to(beNil())
 			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Int, NoError>.empty
+					.take(until: .init(value: ()))
+			}
 		}
 
 		describe("takeUntilReplacement") {
@@ -1076,6 +1086,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(completed) == false
 				replacementObserver.sendCompleted()
 				expect(completed) == true
+			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Int, NoError>.empty
+					.take(untilReplacement: .init(value: 0))
 			}
 		}
 
@@ -1410,6 +1425,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(valueReceived) == "1a"
 			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Int, NoError>.empty
+					.sample(with: .init(value: 0))
+			}
 		}
 
 		describe("sampleOn") {
@@ -1517,6 +1537,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 					disposable.dispose()
 					expect(payloadFreed) == true
 				}
+			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Int, NoError>.empty
+					.sample(on: .init(value: ()))
 			}
 		}
 
@@ -1650,6 +1675,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				sampleeObserver.sendInterrupted()
 				expect(event).to(beNil())
 			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Int, NoError>.empty
+					.withLatest(from: .init(value: 0))
+			}
 		}
 
 		describe("combineLatestWith") {
@@ -1691,6 +1721,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				otherObserver.sendCompleted()
 				expect(completed) == true
+			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Int, NoError>.empty
+					.combineLatest(with: .init(value: 0))
 			}
 		}
 
@@ -1758,6 +1793,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				rightObserver.send(value: "foo")
 				expect(completed) == true
 				expect(result) == [ "0foo" ]
+			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Int, NoError>.empty
+					.zip(with: .init(value: 0))
 			}
 		}
 

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -722,7 +722,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.send(value: 0)
 				expect(lastValue) == 0
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, NoError>.empty
 					.skip(until: .init(value: ()))
@@ -1022,7 +1022,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(completed) == true
 				expect(lastValue).to(beNil())
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, NoError>.empty
 					.take(until: .init(value: ()))
@@ -1087,7 +1087,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				replacementObserver.sendCompleted()
 				expect(completed) == true
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, NoError>.empty
 					.take(untilReplacement: .init(value: 0))
@@ -1425,7 +1425,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(valueReceived) == "1a"
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, NoError>.empty
 					.sample(with: .init(value: 0))
@@ -1538,7 +1538,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					expect(payloadFreed) == true
 				}
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, NoError>.empty
 					.sample(on: .init(value: ()))
@@ -1675,7 +1675,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				sampleeObserver.sendInterrupted()
 				expect(event).to(beNil())
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, NoError>.empty
 					.withLatest(from: .init(value: 0))
@@ -1722,7 +1722,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				otherObserver.sendCompleted()
 				expect(completed) == true
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, NoError>.empty
 					.combineLatest(with: .init(value: 0))
@@ -1794,7 +1794,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(completed) == true
 				expect(result) == [ "0foo" ]
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, NoError>.empty
 					.zip(with: .init(value: 0))

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -1311,7 +1311,7 @@ class SignalProducerSpec: QuickSpec {
 				expect(disposed) == true
 			}
 			
-			it("sould available to use contextual lookup for") {
+			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, TestError>.empty
 					.flatMapError { _ in .init(value: 0) }
 			}

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -3012,7 +3012,7 @@ class SignalProducerSpec: QuickSpec {
 					.combineLatest(SignalProducer<Int, NoError>.never.promoteError(),
 					               SignalProducer<Double, TestError>.never,
 					               SignalProducer<Float, NoError>.never.promoteError(),
-					               SignalProducer<UInt, POSIXError>.never.flatMapError { _ in .empty })
+					               SignalProducer<UInt, POSIXError>.never.flatMapError { _ in SignalProducer.empty })
 
 				expect(combined is SignalProducer<(Int, Double, Float, UInt), TestError>) == true
 			}

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -1310,6 +1310,11 @@ class SignalProducerSpec: QuickSpec {
 				expect(interrupted) == true
 				expect(disposed) == true
 			}
+			
+			it("sould available to use contextual lookup for") {
+				_ = SignalProducer<Int, TestError>.empty
+					.flatMapError { _ in .init(value: 0) }
+			}
 		}
 
 		describe("flatten") {

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -2855,8 +2855,8 @@ class SignalProducerSpec: QuickSpec {
 			describe("init(values) ambiguity") {
 				it("should not be a SignalProducer<SignalProducer<Int, NoError>, NoError>") {
 
-					let producer1: SignalProducer<Int, NoError> = SignalProducer.empty
-					let producer2: SignalProducer<Int, NoError> = SignalProducer.empty
+					let producer1: SignalProducer<Int, NoError> = .empty
+					let producer2: SignalProducer<Int, NoError> = .empty
 
 					// This expression verifies at compile time that the type is as expected.
 					let _: SignalProducer<Int, NoError> = SignalProducer([producer1, producer2])
@@ -3012,7 +3012,7 @@ class SignalProducerSpec: QuickSpec {
 					.combineLatest(SignalProducer<Int, NoError>.never.promoteError(),
 					               SignalProducer<Double, TestError>.never,
 					               SignalProducer<Float, NoError>.never.promoteError(),
-					               SignalProducer<UInt, POSIXError>.never.flatMapError { _ in SignalProducer.empty })
+					               SignalProducer<UInt, POSIXError>.never.flatMapError { _ in .empty })
 
 				expect(combined is SignalProducer<(Int, Double, Float, UInt), TestError>) == true
 			}

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -2316,6 +2316,36 @@ class SignalProducerSpec: QuickSpec {
 				let h = SignalProducer<Int, TestError>.empty.then(SignalProducer<Double, NoError>.empty)
 				expect(type(of: h)) == SignalProducer<Double, TestError>.self
 			}
+			
+			it("sould available to use contextual lookup for arbitrary error signal then same value same error signal") {
+				_ = SignalProducer<Int, TestError>.empty
+					.then(.init(value: 0))
+			}
+			
+			it("sould available to use contextual lookup for arbitrary error signal then other value same error signal") {
+				_ = SignalProducer<Int, TestError>.empty
+					.then(.init(result: Result<String, TestError>(value: "")))
+			}
+			
+			it("sould available to use contextual lookup for arbitrary error signal then other value NoError signal") {
+				_ = SignalProducer<Int, TestError>.empty
+					.then(.init(value: ""))
+			}
+			
+			it("sould available to use contextual lookup for NoError signal then same value same error signal") {
+				_ = SignalProducer<Int, NoError>.empty
+					.then(.init(value: 0))
+			}
+			
+			it("sould available to use contextual lookup for NoError signal then other value same error signal") {
+				_ = SignalProducer<Int, NoError>.empty
+					.then(.init(value: ""))
+			}
+			
+			it("sould available to use contextual lookup for NoError signal then other value arbitrary error signal") {
+				_ = SignalProducer<Int, NoError>.empty
+					.then(.init(result: Result<String, TestError>(value: "")))
+			}
 		}
 
 		describe("first") {

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -1310,7 +1310,7 @@ class SignalProducerSpec: QuickSpec {
 				expect(interrupted) == true
 				expect(disposed) == true
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Int, TestError>.empty
 					.flatMapError { _ in .init(value: 0) }
@@ -2316,32 +2316,32 @@ class SignalProducerSpec: QuickSpec {
 				let h = SignalProducer<Int, TestError>.empty.then(SignalProducer<Double, NoError>.empty)
 				expect(type(of: h)) == SignalProducer<Double, TestError>.self
 			}
-			
+
 			it("sould available to use contextual lookup for arbitrary error signal then same value same error signal") {
 				_ = SignalProducer<Int, TestError>.empty
 					.then(.init(value: 0))
 			}
-			
+
 			it("sould available to use contextual lookup for arbitrary error signal then other value same error signal") {
 				_ = SignalProducer<Int, TestError>.empty
 					.then(.init(result: Result<String, TestError>(value: "")))
 			}
-			
+
 			it("sould available to use contextual lookup for arbitrary error signal then other value NoError signal") {
 				_ = SignalProducer<Int, TestError>.empty
 					.then(.init(value: ""))
 			}
-			
+
 			it("sould available to use contextual lookup for NoError signal then same value same error signal") {
 				_ = SignalProducer<Int, NoError>.empty
 					.then(.init(value: 0))
 			}
-			
+
 			it("sould available to use contextual lookup for NoError signal then other value same error signal") {
 				_ = SignalProducer<Int, NoError>.empty
 					.then(.init(value: ""))
 			}
-			
+
 			it("sould available to use contextual lookup for NoError signal then other value arbitrary error signal") {
 				_ = SignalProducer<Int, NoError>.empty
 					.then(.init(result: Result<String, TestError>(value: "")))
@@ -2993,7 +2993,7 @@ class SignalProducerSpec: QuickSpec {
 
 				observer2.sendCompleted()
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Bool, NoError>.empty
 					.and(.init(value: true))
@@ -3044,7 +3044,7 @@ class SignalProducerSpec: QuickSpec {
 
 				observer2.sendCompleted()
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = SignalProducer<Bool, NoError>.empty
 					.or(.init(value: true))

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -2890,8 +2890,8 @@ class SignalProducerSpec: QuickSpec {
 			describe("init(values) ambiguity") {
 				it("should not be a SignalProducer<SignalProducer<Int, NoError>, NoError>") {
 
-					let producer1: SignalProducer<Int, NoError> = .empty
-					let producer2: SignalProducer<Int, NoError> = .empty
+					let producer1 = SignalProducer<Int, NoError>.empty
+					let producer2 = SignalProducer<Int, NoError>.empty
 
 					// This expression verifies at compile time that the type is as expected.
 					let _: SignalProducer<Int, NoError> = SignalProducer([producer1, producer2])
@@ -2993,6 +2993,11 @@ class SignalProducerSpec: QuickSpec {
 
 				observer2.sendCompleted()
 			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Bool, NoError>.empty
+					.and(.init(value: true))
+			}
 		}
 
 		describe("or attribute") {
@@ -3038,6 +3043,11 @@ class SignalProducerSpec: QuickSpec {
 				observer2.send(value: true)
 
 				observer2.sendCompleted()
+			}
+			
+			it("sould available to use contextual lookup") {
+				_ = SignalProducer<Bool, NoError>.empty
+					.or(.init(value: true))
 			}
 		}
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -2193,7 +2193,7 @@ class SignalSpec: QuickSpec {
 				sampleeObserver.sendInterrupted()
 				expect(event).to(beNil())
 			}
-			
+
 			it("sould available to use contextual lookup") {
 				_ = Signal<Int, NoError>.empty
 					.withLatest(from: .init(value: 0))

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -3230,7 +3230,7 @@ class SignalSpec: QuickSpec {
 					.combineLatest(Signal<Int, NoError>.never.promoteError(),
 					               Signal<Double, TestError>.never,
 					               Signal<Float, NoError>.never.promoteError(),
-					               Signal<UInt, POSIXError>.never.flatMapError { _ in SignalProducer.empty })
+					               Signal<UInt, POSIXError>.never.flatMapError { _ in .empty })
 
 				expect(combined is Signal<(Int, Double, Float, UInt), TestError>) == true
 			}

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -2193,6 +2193,11 @@ class SignalSpec: QuickSpec {
 				sampleeObserver.sendInterrupted()
 				expect(event).to(beNil())
 			}
+			
+			it("sould available to use contextual lookup") {
+				_ = Signal<Int, NoError>.empty
+					.withLatest(from: .init(value: 0))
+			}
 		}
 
 		describe("combineLatestWith") {

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -3230,7 +3230,7 @@ class SignalSpec: QuickSpec {
 					.combineLatest(Signal<Int, NoError>.never.promoteError(),
 					               Signal<Double, TestError>.never,
 					               Signal<Float, NoError>.never.promoteError(),
-					               Signal<UInt, POSIXError>.never.flatMapError { _ in .empty })
+					               Signal<UInt, POSIXError>.never.flatMapError { _ in SignalProducer.empty })
 
 				expect(combined is Signal<(Int, Double, Float, UInt), TestError>) == true
 			}


### PR DESCRIPTION
Continuation from https://github.com/ReactiveCocoa/ReactiveSwift/pull/610

These operators now accept `SignalProducerConvertible` conforming types.
`SignalProducer.merge(with:)`
`SignalProducer.concat`
`SignalProducer.prefix`
`SignalProducer.then`
`SignalProducer.and`
`SignalProducer.or`
`SignalProducer.zip(with:)`
`SignalProducer.sample(with:)`
`SignalProducer.sample(on:)`
`SignalProducer.take(until:)`
`SignalProducer.take(untilReplacement:)`
`SignalProducer.skip(until:)`
`SignalProducer.flatMap`
`SignalProducer.flatMapError`
`SignalProducer.combineLatest(with:)`
`Signal.flatMap`
`Signal.flatMapError`
`Signal.withLatest(from:)`
`Property.init(initial:then:)`

#### Checklist
- [x] Updated CHANGELOG.md.
