### PR TITLE
Explicitly warning that cannot observe with ignoring the errors.

### DIFF
--- a/Sources/UninhabitedTypeGuards.swift
+++ b/Sources/UninhabitedTypeGuards.swift
@@ -118,6 +118,9 @@ private func observingUninhabitedTypeError() -> Never {
 
 /*
 func test() {
+	SignalProducer<Any, AnyError>.never.startWithValues { _ in }
+	Signal<Any, AnyError>.never.observeValues { _ in }
+
 	SignalProducer<Never, AnyError>.never.startWithResult { _ in }
 	SignalProducer<Never, NoError>.never.startWithResult { _ in }
 	SignalProducer<Any, NoError>.never.startWithFailed { _ in }

--- a/Sources/UninhabitedTypeGuards.swift
+++ b/Sources/UninhabitedTypeGuards.swift
@@ -1,6 +1,18 @@
 import Result
 
 // Observation
+extension SignalProducer {
+	@available(*, unavailable, message:"Use `startWithResult` instead - cannot ignore errors that may occur")
+	@discardableResult
+	public func startWithValues(_ action: @escaping (Value) -> Void) -> Disposable { observingUninhabitedTypeError() }
+}
+
+extension Signal {
+	@available(*, unavailable, message:"Use `observeResult` instead - cannot ignore errors that may occur")
+	@discardableResult
+	public func observeValues(_ action: @escaping (Value) -> Void) -> Disposable { observingUninhabitedTypeError() }
+}
+
 extension SignalProducer where Value == Never {
 	@discardableResult
 	@available(*, deprecated, message:"`Result.success` is never delivered - value type `Never` is uninstantiable (Use at runtime would trap)")

--- a/Sources/UninhabitedTypeGuards.swift
+++ b/Sources/UninhabitedTypeGuards.swift
@@ -1,6 +1,7 @@
 import Result
 
 // Observation
+
 extension SignalProducer {
 	@available(*, unavailable, message:"Use `startWithResult` instead - cannot ignore errors that may occur")
 	@discardableResult
@@ -10,7 +11,7 @@ extension SignalProducer {
 extension Signal {
 	@available(*, unavailable, message:"Use `observeResult` instead - cannot ignore errors that may occur")
 	@discardableResult
-	public func observeValues(_ action: @escaping (Value) -> Void) -> Disposable { observingUninhabitedTypeError() }
+	public func observeValues(_ action: @escaping (Value) -> Void) -> Disposable? { observingUninhabitedTypeError() }
 }
 
 extension SignalProducer where Value == Never {

--- a/Sources/UninhabitedTypeGuards.swift
+++ b/Sources/UninhabitedTypeGuards.swift
@@ -3,13 +3,13 @@ import Result
 // Observation
 
 extension SignalProducer {
-	@available(*, unavailable, message:"Use `startWithResult` instead - cannot ignore errors that may occur")
+	@available(*, unavailable, message:"Transform the error to `NoError` beforehand, or use `startWithResult` instead")
 	@discardableResult
 	public func startWithValues(_ action: @escaping (Value) -> Void) -> Disposable { observingUninhabitedTypeError() }
 }
 
 extension Signal {
-	@available(*, unavailable, message:"Use `observeResult` instead - cannot ignore errors that may occur")
+	@available(*, unavailable, message:"Transform the error to `NoError` beforehand, or use `observeResult` instead")
 	@discardableResult
 	public func observeValues(_ action: @escaping (Value) -> Void) -> Disposable? { observingUninhabitedTypeError() }
 }


### PR DESCRIPTION
Currently, compiler warns `Ambiguous reference to observeValues` when use `observeValues` of `Signal` that with an error type which is not `NoError`.
This is a confusing API.
I think it should better warn to use observeResult.
relevant issue: https://github.com/ReactiveCocoa/ReactiveSwift/issues/598

<img width="600" alt="screen shot 2018-03-03 at 11 40 10" src="https://user-images.githubusercontent.com/7347118/36929674-ae3a295e-1ed7-11e8-9251-b85ac769b060.png">
<img width="600" alt="screen shot 2018-03-03 at 11 39 54" src="https://user-images.githubusercontent.com/7347118/36929677-afd0428a-1ed7-11e8-9341-2490790b807a.png">


#### Checklist
~- [ ] Updated CHANGELOG.md.~
