### PR TITLE
Add attempt and attemptMap overloads for ErrorConvertible

### DIFF
--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -347,7 +347,22 @@ extension Signal.Event where Error == AnyError {
 
 	internal static func attemptMap<U>(_ transform: @escaping (Value) throws -> U) -> Transformation<U, AnyError> {
 		return attemptMap { value in
-			ReactiveSwift.materialize { try transform(value) }
+			Result { try transform(value) }
+		}
+	}
+}
+
+extension Signal.Event where Error: ErrorConvertible {
+	internal static func attemptMap<U>(_ transform: @escaping (Value) throws -> U) -> Transformation<U, Error> {
+		return attemptMap { value in
+			Result { try transform(value) }
+		}
+	}
+
+	internal static func attempt(_ action: @escaping (Value) throws -> Void) -> Transformation<Value, Error> {
+		return attemptMap { value in
+			try action(value)
+			return value
 		}
 	}
 }

--- a/Sources/ResultExtensions.swift
+++ b/Sources/ResultExtensions.swift
@@ -1,17 +1,5 @@
 import Result
 
-/// Private alias of the free `materialize()` from `Result`.
-///
-/// This exists because within a `Signal` or `SignalProducer` operator,
-/// `materialize()` refers to the operator with that name.
-/// Namespacing as `Result.materialize()` doesn't work either,
-/// because it tries to resolve a static member on the _type_
-/// `Result`, rather than the free function in the _module_
-/// of the same name.
-internal func materialize<T>(_ f: () throws -> T) -> Result<T, AnyError> {
-	return materialize(try f())
-}
-
 extension Result: SignalProducerConvertible {
 	public var producer: SignalProducer<Value, Error> {
 		return .init(result: self)

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -2148,6 +2148,20 @@ extension Signal where Error == NoError {
 			.attempt(action)
 	}
 
+	/// Apply a throwable action to every value from `self`, and forward the values
+	/// if the action succeeds. If the action throws an error, the returned `Signal`
+	/// would propagate the failure and terminate.
+	///
+	/// - parameters:
+	///   - action: A throwable closure to perform an arbitrary action on the value.
+	///
+	/// - returns: A signal which forwards the successful values of the given action.
+	public func attempt<NewError: ErrorConvertible>(_ action: @escaping (Value) throws -> Void) -> Signal<Value, NewError> {
+		return self
+			.promoteError(NewError.self)
+			.attempt(action)
+	}
+
 	/// Apply a throwable transform to every value from `self`, and forward the results
 	/// if the action succeeds. If the transform throws an error, the returned `Signal`
 	/// would propagate the failure and terminate.
@@ -2159,6 +2173,20 @@ extension Signal where Error == NoError {
 	public func attemptMap<U>(_ transform: @escaping (Value) throws -> U) -> Signal<U, AnyError> {
 		return self
 			.promoteError(AnyError.self)
+			.attemptMap(transform)
+	}
+
+	/// Apply a throwable transform to every value from `self`, and forward the results
+	/// if the action succeeds. If the transform throws an error, the returned `Signal`
+	/// would propagate the failure and terminate.
+	///
+	/// - parameters:
+	///   - transform: A throwable transform.
+	///
+	/// - returns: A signal which forwards the successfully transformed values.
+	public func attemptMap<U, NewError: ErrorConvertible>(_ transform: @escaping (Value) throws -> U) -> Signal<U, NewError> {
+		return self
+			.promoteError(NewError.self)
 			.attemptMap(transform)
 	}
 }
@@ -2185,6 +2213,32 @@ extension Signal where Error == AnyError {
 	///
 	/// - returns: A signal which forwards the successfully transformed values.
 	public func attemptMap<U>(_ transform: @escaping (Value) throws -> U) -> Signal<U, AnyError> {
+		return flatMapEvent(Signal.Event.attemptMap(transform))
+	}
+}
+
+extension Signal where Error: ErrorConvertible {
+	/// Apply a throwable action to every value from `self`, and forward the values
+	/// if the action succeeds. If the action throws an error, the returned `Signal`
+	/// would propagate the failure and terminate.
+	///
+	/// - parameters:
+	///   - action: A throwable closure to perform an arbitrary action on the value.
+	///
+	/// - returns: A signal which forwards the successful values of the given action.
+	public func attempt(_ action: @escaping (Value) throws -> Void) -> Signal<Value, Error> {
+		return flatMapEvent(Signal.Event.attempt(action))
+	}
+
+	/// Apply a throwable transform to every value from `self`, and forward the results
+	/// if the action succeeds. If the transform throws an error, the returned `Signal`
+	/// would propagate the failure and terminate.
+	///
+	/// - parameters:
+	///   - transform: A throwable transform.
+	///
+	/// - returns: A signal which forwards the successfully transformed values.
+	public func attemptMap<U>(_ transform: @escaping (Value) throws -> U) -> Signal<U, Error> {
 		return flatMapEvent(Signal.Event.attemptMap(transform))
 	}
 }


### PR DESCRIPTION
This allows consumers to use throwable closures with their own custom `ErrorConvertible` types, not just with `AnyError`.

- [ ] Add tests for various type inference scenarios https://github.com/ReactiveCocoa/ReactiveSwift/pull/626#pullrequestreview-108491025
- [ ] Updated CHANGELOG.md.