### PR TITLE
Avoid flag override when intergrated with CocoaPods.

### DIFF
--- a/ReactiveSwift.podspec
+++ b/ReactiveSwift.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/*.{swift}"
   s.dependency 'Result', '~> 3.2'
 
-  s.pod_target_xcconfig = {"OTHER_SWIFT_FLAGS[config=Release]" => "-suppress-warnings" }
+  s.pod_target_xcconfig = {"OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
 end


### PR DESCRIPTION
By adding `$(inherited)` to `OTHER_SWIFT_FLAGS[cnnfig=Release]`.

Fixes #628.

#### Checklist
- [ ] Updated CHANGELOG.md.
