### PR TITLE
Introducing Trigger

### DIFF
--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -83,6 +83,9 @@
 		9ABCB1861D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ABCB1841D2A5B5A00BCA243 /* Deprecations+Removals.swift */; };
 		9ABCB1871D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ABCB1841D2A5B5A00BCA243 /* Deprecations+Removals.swift */; };
 		9ABCB1881D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ABCB1841D2A5B5A00BCA243 /* Deprecations+Removals.swift */; };
+		A9858263207D1A7500E90E8D /* TriggerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D8BA7D207D199F0031733D /* TriggerSpec.swift */; };
+		A9858264207D1A7600E90E8D /* TriggerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D8BA7D207D199F0031733D /* TriggerSpec.swift */; };
+		A9858265207D1A7700E90E8D /* TriggerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D8BA7D207D199F0031733D /* TriggerSpec.swift */; };
 		A9B315BC1B3940810001CB9C /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312BE19EF2A5800984962 /* Disposable.swift */; };
 		A9B315BE1B3940810001CB9C /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08C54B51A69A3DB00AD8286 /* Event.swift */; };
 		A9B315C01B3940810001CB9C /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312C819EF2A5800984962 /* Scheduler.swift */; };
@@ -95,6 +98,10 @@
 		A9B315C81B3940810001CB9C /* FoundationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B4A3C19F4C39A009E02AC /* FoundationExtensions.swift */; };
 		A9B315C91B3940980001CB9C /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; };
 		A9B315CA1B3940AB0001CB9C /* ReactiveSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = D04725EF19E49ED7006002AA /* ReactiveSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A9D8BA79207D16E10031733D /* Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D8BA78207D16E10031733D /* Trigger.swift */; };
+		A9D8BA7A207D16E10031733D /* Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D8BA78207D16E10031733D /* Trigger.swift */; };
+		A9D8BA7B207D16E10031733D /* Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D8BA78207D16E10031733D /* Trigger.swift */; };
+		A9D8BA7C207D16E10031733D /* Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D8BA78207D16E10031733D /* Trigger.swift */; };
 		A9F793341B60D0140026BCBA /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = D871D69E1B3B29A40070F16C /* Optional.swift */; };
 		B696FB811A7640C00075236D /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B696FB801A7640C00075236D /* TestError.swift */; };
 		B696FB821A7640C00075236D /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B696FB801A7640C00075236D /* TestError.swift */; };
@@ -258,6 +265,8 @@
 		A97451351B3A935E00F48E55 /* watchOS-Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Framework.xcconfig"; sourceTree = "<group>"; };
 		A97451361B3A935E00F48E55 /* watchOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
 		A9B315541B3940610001CB9C /* ReactiveSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A9D8BA78207D16E10031733D /* Trigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trigger.swift; sourceTree = "<group>"; };
+		A9D8BA7D207D199F0031733D /* TriggerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSpec.swift; sourceTree = "<group>"; };
 		B696FB801A7640C00075236D /* TestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		BE9CF3941D751B6B003AE479 /* UnidirectionalBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnidirectionalBinding.swift; sourceTree = "<group>"; };
 		BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalProducerNimbleMatchers.swift; sourceTree = "<group>"; };
@@ -416,6 +425,7 @@
 				9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */,
 				D08C54B11A69A2AC00AD8286 /* Signal.swift */,
 				D08C54B21A69A2AC00AD8286 /* SignalProducer.swift */,
+				A9D8BA78207D16E10031733D /* Trigger.swift */,
 				BE9CF3941D751B6B003AE479 /* UnidirectionalBinding.swift */,
 				9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */,
 			);
@@ -506,6 +516,7 @@
 				D0A226071A72E0E900D33B74 /* SignalSpec.swift */,
 				B696FB801A7640C00075236D /* TestError.swift */,
 				C79B64731CD38B2B003F2376 /* TestLogger.swift */,
+				A9D8BA7D207D199F0031733D /* TriggerSpec.swift */,
 				9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */,
 				9A1A4F981E16961C006F3039 /* ValidatingPropertySpec.swift */,
 				9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */,
@@ -885,6 +896,7 @@
 				57A4D1B81BA13D7A00F7D4B1 /* Scheduler.swift in Sources */,
 				4AC73ECE1DF273570004EC4F /* ResultExtensions.swift in Sources */,
 				9A9100E21E0E6E680093E346 /* ValidatingProperty.swift in Sources */,
+				A9D8BA7C207D16E10031733D /* Trigger.swift in Sources */,
 				57A4D1B91BA13D7A00F7D4B1 /* Action.swift in Sources */,
 				57A4D1BA1BA13D7A00F7D4B1 /* Property.swift in Sources */,
 				9A090C171DA0309E00EE97CA /* Reactive.swift in Sources */,
@@ -907,6 +919,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9858265207D1A7700E90E8D /* TriggerSpec.swift in Sources */,
 				7DFBED221CDB8DE300EE435B /* ActionSpec.swift in Sources */,
 				7DFBED231CDB8DE300EE435B /* AtomicSpec.swift in Sources */,
 				7DFBED241CDB8DE300EE435B /* BagSpec.swift in Sources */,
@@ -940,6 +953,7 @@
 				A9B315C01B3940810001CB9C /* Scheduler.swift in Sources */,
 				4AC73ECD1DF273570004EC4F /* ResultExtensions.swift in Sources */,
 				9A9100E11E0E6E680093E346 /* ValidatingProperty.swift in Sources */,
+				A9D8BA7B207D16E10031733D /* Trigger.swift in Sources */,
 				A9B315C11B3940810001CB9C /* Action.swift in Sources */,
 				A9B315C21B3940810001CB9C /* Property.swift in Sources */,
 				9A090C161DA0309E00EE97CA /* Reactive.swift in Sources */,
@@ -968,6 +982,7 @@
 				4AC73ECB1DF273570004EC4F /* ResultExtensions.swift in Sources */,
 				9A9100DF1E0E6E620093E346 /* ValidatingProperty.swift in Sources */,
 				EBCC7DBC1BBF010C00A2AE92 /* Observer.swift in Sources */,
+				A9D8BA79207D16E10031733D /* Trigger.swift in Sources */,
 				D03B4A3D19F4C39A009E02AC /* FoundationExtensions.swift in Sources */,
 				9A090C141DA0309E00EE97CA /* Reactive.swift in Sources */,
 				D08C54B31A69A2AE00AD8286 /* Signal.swift in Sources */,
@@ -990,6 +1005,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9858263207D1A7500E90E8D /* TriggerSpec.swift in Sources */,
 				D0A2260E1A72F16D00D33B74 /* PropertySpec.swift in Sources */,
 				B696FB811A7640C00075236D /* TestError.swift in Sources */,
 				D021671D1A6CD50500987861 /* ActionSpec.swift in Sources */,
@@ -1023,6 +1039,7 @@
 				D08C54B91A69A9D100AD8286 /* SignalProducer.swift in Sources */,
 				4AC73ECC1DF273570004EC4F /* ResultExtensions.swift in Sources */,
 				9A9100E01E0E6E670093E346 /* ValidatingProperty.swift in Sources */,
+				A9D8BA7A207D16E10031733D /* Trigger.swift in Sources */,
 				9ABCB1861D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */,
 				EBCC7DBD1BBF01E100A2AE92 /* Observer.swift in Sources */,
 				9A090C151DA0309E00EE97CA /* Reactive.swift in Sources */,
@@ -1045,6 +1062,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9858264207D1A7600E90E8D /* TriggerSpec.swift in Sources */,
 				D0A2260C1A72E6C500D33B74 /* SignalProducerSpec.swift in Sources */,
 				D0A2260F1A72F16D00D33B74 /* PropertySpec.swift in Sources */,
 				D0A226091A72E0E900D33B74 /* SignalSpec.swift in Sources */,

--- a/Sources/Trigger.swift
+++ b/Sources/Trigger.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Result
+
+/// A Trigger is a simple mechanism that can be used to when no explicit value is needed.
+public final class Trigger: BindingSource, BindingTargetProvider {
+	public typealias Value = ()
+	public typealias Error = NoError
+	
+	let (lifetime, token) = Lifetime.make()
+	let observer: Signal<Value, Error>.Observer
+	/// A signal that sends `Void` whenever the trigger is fired.
+	public var signal: Signal<Value, Error>
+	
+	public init() {
+		(self.signal, self.observer) = Signal<Value, Error>.pipe()
+	}
+	
+	public convenience init(capturing signal: Signal<Value, Error>) {
+		self.init()
+		signal.observe(observer)
+	}
+	
+	public convenience init<P: PropertyProtocol>(capturing property: P) where P.Value == Value {
+		self.init(capturing: property.signal)
+	}
+	
+	/// Fires the trigger.
+	public func fire() {
+		observer.send(value: ())
+	}
+	
+	// MARK: BindingSource
+	public var producer: SignalProducer<Value, Error> {
+		return SignalProducer(signal)
+	}
+	// MARK: BindingTargetProvider
+	public var bindingTarget: BindingTarget<Value> {
+		return BindingTarget(lifetime: lifetime) { [weak self] in self?.fire() }
+	}
+}

--- a/Sources/Trigger.swift
+++ b/Sources/Trigger.swift
@@ -17,7 +17,7 @@ public final class Trigger: BindingSource, BindingTargetProvider {
 	
 	public convenience init(capturing signal: Signal<Value, Error>) {
 		self.init()
-		signal.observe(observer)
+		lifetime += signal.observeValues(observer.send)
 	}
 	
 	public convenience init<P: PropertyProtocol>(capturing property: P) where P.Value == Value {

--- a/Tests/ReactiveSwiftTests/TriggerSpec.swift
+++ b/Tests/ReactiveSwiftTests/TriggerSpec.swift
@@ -1,0 +1,57 @@
+//
+//  TriggerSpec.swift
+//  ReactiveSwift
+//
+//  Created by Marco Cancellieri on 10.04.18.
+//  Copyright © 2018 GitHub. All rights reserved.
+//
+
+import Nimble
+import Quick
+import ReactiveSwift
+
+class TriggerSpec: QuickSpec {
+	override func spec() {
+		describe("Trigger") {
+			it("should send void if triggered") {
+				let trigger = Trigger()
+				var lastValue: ()?
+				trigger.signal.observeValues { lastValue = $0 }
+				expect(lastValue).to(beNil())
+				trigger.fire()
+				expect(lastValue).toNot(beNil())
+			}
+			it("should provide a BindingTarget") {
+				let trigger = Trigger()
+				var lastValue: ()?
+				trigger.signal.observeValues { lastValue = $0 }
+				expect(lastValue).to(beNil())
+				trigger <~ SignalProducer(value: ())
+				expect(lastValue).toNot(beNil())
+			}
+			it("should work as a BindingSource") {
+				let trigger = Trigger()
+				let lastValue = MutableProperty<()?>(nil)
+				lastValue <~ trigger
+				expect(lastValue.value).to(beNil())
+				trigger.fire()
+				expect(lastValue.value).toNot(beNil())
+			}
+			it("should capture an external Property") {
+				let propertyToCapture = MutableProperty<()>(())
+				let trigger = Trigger(capturing: propertyToCapture)
+				
+				let lastValue = MutableProperty<()?>(nil)
+				lastValue <~ trigger
+				
+				expect(lastValue.value).to(beNil())
+				propertyToCapture.value = ()
+				expect(lastValue.value).toNot(beNil())
+				lastValue.value = nil
+				expect(lastValue.value).to(beNil())
+				trigger.fire()
+				expect(lastValue.value).toNot(beNil())
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

`Trigger` provides a simple wrapper for Signals that are used to *trigger* something through `Void`.
It conforms to `BindingSource` and `BindingTargetProvider`.

## Motivation

I find myself using `MutableProperty<()>` way too often, especially for my ViewModel inputs.

## Todo

- I'm not entirely sure which verb is the most adequate for the use-case. I've used `fire` for now.
- Proper documentation
- Maybe a Playground example?