### PR TITLE
Add binding operator to Signal.Observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # master
 *Please add new entries at the top.*
 1. Fixed Result extensions ambiguity (#733, kudos to @nekrich)
-
+1. Add `<~` binding operator to `Signal.Observer` (#635, kudos to @Marcocanc)
 
 # 6.0.0
 1. Dropped support for Swift 4.2 (Xcode 9)

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -102,6 +102,37 @@ extension BindingTargetProvider {
 	}
 }
 
+extension Signal.Observer {
+	/// Binds a source to a target, updating the target's value to the latest
+	/// value sent by the source.
+	///
+	/// - note: Only `value` events will be forwarded to the Observer.
+	///         The binding will automatically terminate when the target is
+	///         deinitialized, or when the source sends a `completed` event.
+	///
+	/// - parameters:
+	///   - target: A target to be bond to.
+	///   - source: A source to bind.
+	///
+	/// - returns: A disposable that can be used to terminate binding before the
+	///            deinitialization of the target or the source's `completed`
+	///            event.
+	@discardableResult
+	public static func <~
+		<Source: BindingSource>
+		(observer: Signal<Value, Error>.Observer, source: Source) -> Disposable?
+		where Source.Value == Value
+	{
+		return source.producer.start { [weak observer] in
+			switch $0 {
+			case .value(let val):
+				observer?.send(value: val)
+			default: break
+			}
+		}
+	}
+}
+
 /// A binding target that can be used with the `<~` operator.
 public struct BindingTarget<Value>: BindingTargetProvider {
 	public let lifetime: Lifetime

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -123,12 +123,8 @@ extension Signal.Observer {
 		(observer: Signal<Value, Error>.Observer, source: Source) -> Disposable?
 		where Source.Value == Value
 	{
-		return source.producer.start { [weak observer] in
-			switch $0 {
-			case .value(let val):
-				observer?.send(value: val)
-			default: break
-			}
+		return source.producer.startWithValues { [weak observer] in
+			observer?.send(value: $0)
 		}
 	}
 }

--- a/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
+++ b/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
@@ -102,6 +102,7 @@ class UnidirectionalBindingSpec: QuickSpec {
 					}
 				}
 			}
+
 			describe("key path binding target") {
 				var target: BindingTarget<Int>!
 				var object: Object!
@@ -200,6 +201,7 @@ class UnidirectionalBindingSpec: QuickSpec {
 				expect(value).toEventually(equal(2))
 				expect(mainQueueCounter.value).toEventually(equal(2))
 			}
+
 			describe("observer binding operator") {
 				it("should forward values to observer") {
 					let targetPipe = Signal<Int?, NoError>.pipe()

--- a/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
+++ b/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
@@ -204,8 +204,8 @@ class UnidirectionalBindingSpec: QuickSpec {
 
 			describe("observer binding operator") {
 				it("should forward values to observer") {
-					let targetPipe = Signal<Int?, NoError>.pipe()
-					let sourcePipe = Signal<Int?, NoError>.pipe()
+					let targetPipe = Signal<Int?, Never>.pipe()
+					let sourcePipe = Signal<Int?, Never>.pipe()
 					let targetProperty = Property<Int?>(initial: nil, then: targetPipe.output)
 					targetPipe.input <~ sourcePipe.output
 					expect(targetProperty.value).to(beNil())

--- a/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
+++ b/Tests/ReactiveSwiftTests/UnidirectionalBindingSpec.swift
@@ -102,7 +102,6 @@ class UnidirectionalBindingSpec: QuickSpec {
 					}
 				}
 			}
-
 			describe("key path binding target") {
 				var target: BindingTarget<Int>!
 				var object: Object!
@@ -200,6 +199,17 @@ class UnidirectionalBindingSpec: QuickSpec {
 				property.value = 2
 				expect(value).toEventually(equal(2))
 				expect(mainQueueCounter.value).toEventually(equal(2))
+			}
+			describe("observer binding operator") {
+				it("should forward values to observer") {
+					let targetPipe = Signal<Int?, NoError>.pipe()
+					let sourcePipe = Signal<Int?, NoError>.pipe()
+					let targetProperty = Property<Int?>(initial: nil, then: targetPipe.output)
+					targetPipe.input <~ sourcePipe.output
+					expect(targetProperty.value).to(beNil())
+					sourcePipe.input.send(value: 1)
+					expect(targetProperty.value).to(equal(1))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
~As the title says, I think it would be nice to make `Observer` conform to `BindingTargetProvider`.
Any thoughts on that?~

This PR adds the binding operator to `Signal.Observer`

#### Checklist
- [x] ~Updated CHANGELOG.md.~
