### PR TITLE
Update Package.swift to match Cartfile

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "22800b0954c89344bb8c87f8ab93378076716fb7",
-          "version": "7.0.3"
+          "revision": "21f4fed2052cea480f5f1d2044d45aa25fdfb988",
+          "version": "7.1.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "0ff81f2c665b4381f526bd656f8708dd52a9ea2f",
-          "version": "1.2.0"
+          "revision": "3e3023569c8d4c4a0d000f58db765df53041117f",
+          "version": "1.3.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": null,
-          "revision": "7477584259bfce2560a19e06ad9f71db441fff11",
-          "version": "3.2.4"
+          "revision": "8fc088dcf72802801efeecba76ea8fb041fb773d",
+          "version": "4.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -7,9 +7,9 @@ let package = Package(
         .library(name: "ReactiveSwift", targets: ["ReactiveSwift"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/antitypical/Result.git", from: "3.2.1"),
-        .package(url: "https://github.com/Quick/Quick.git", from: "1.2.0"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "7.0.3"),
+        .package(url: "https://github.com/antitypical/Result.git", from: "4.0.0"),
+        .package(url: "https://github.com/Quick/Quick.git", from: "1.3.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "7.1.1"),
     ],
     targets: [
         .target(name: "ReactiveSwift", dependencies: ["Result"], path: "Sources"),


### PR DESCRIPTION
I noticed that the `Package.swift` definitions did not match those of the `Cartfile`s while working on a server-side project that imported the latest release of `Result`.