### PR TITLE
Introduce `Lifetime.Token.dispose`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 *Please add new entries at the top.*
 
+1. `Lifetime` may now be manually ended using `Lifetime.Token.dispose()`, in addition to the existing when-token-deinitializes semantic. (#641, kudos to @andersio) 
 1. For Swift 4.1 and above, `BindingSource` conformances are required to have `Error` parameterized as exactly `NoError`. As a result, `Signal` and `SignalProducer` are now conditionally `BindingSource`. (#590, kudos to @NachoSoto and @andersio)
 1. For Swift 4.1 and above, `Signal.Event` and `ActionError` are now conditionally `Equatable`. (#590, kudos to @NachoSoto and @andersio)
 1. New method `collect(every:on:skipEmpty:discardWhenCompleted:)` which delivers all values that occurred during a time interval (#619, kudos to @Qata)

--- a/Sources/Lifetime.swift
+++ b/Sources/Lifetime.swift
@@ -86,7 +86,8 @@ extension Lifetime {
 }
 
 extension Lifetime {
-	/// A token object which completes its signal when it deinitializes.
+	/// A token object which completes its associated `Lifetime` when
+	/// it deinitializes, or when `dispose()` is called.
 	///
 	/// It is generally used in conjuncion with `Lifetime` as a private
 	/// deinitialization trigger.
@@ -97,15 +98,18 @@ extension Lifetime {
 	/// }
 	/// ```
 	public final class Token {
-		/// A signal that sends a Completed event when the lifetime ends.
 		fileprivate let disposables: CompositeDisposable
 
 		public init() {
 			disposables = CompositeDisposable()
 		}
 
-		deinit {
+		public func dispose() {
 			disposables.dispose()
+		}
+
+		deinit {
+			dispose()
 		}
 	}
 }

--- a/Tests/ReactiveSwiftTests/LifetimeSpec.swift
+++ b/Tests/ReactiveSwiftTests/LifetimeSpec.swift
@@ -6,7 +6,7 @@ import Result
 final class LifetimeSpec: QuickSpec {
 	override func spec() {
 		describe("Lifetime") {
-			it("should complete its lifetime ended signal when the it deinitializes") {
+			it("should complete its lifetime ended signal when the token deinitializes") {
 				let object = MutableReference(TestObject())
 
 				var isCompleted = false
@@ -15,6 +15,18 @@ final class LifetimeSpec: QuickSpec {
 				expect(isCompleted) == false
 
 				object.value = nil
+				expect(isCompleted) == true
+			}
+
+			it("should complete its lifetime ended signal when the token is disposed of") {
+				let object = MutableReference(TestObject())
+
+				var isCompleted = false
+
+				object.value!.lifetime.ended.observeCompleted { isCompleted = true }
+				expect(isCompleted) == false
+
+				object.value!.disposeToken()
 				expect(isCompleted) == true
 			}
 
@@ -91,4 +103,8 @@ internal final class MutableReference<Value: AnyObject> {
 internal final class TestObject {
 	private let token = Lifetime.Token()
 	var lifetime: Lifetime { return Lifetime(token) }
+
+	func disposeToken() {
+		token.dispose()
+	}
 }


### PR DESCRIPTION
This hopefully makes attaching lifetime to producer chains more natural.

```swift
let (lifetime, token) = Lifetime.make()

let producer = SignalProducer.combineLatest(conditionA, conditionB, conditionC)
    .filter { $0 && $1 && $2 }

// Before
producer.startWithCompleted { _ = token }

// After
producer.startWithCompleted(token.dispose)
```

#### Checklist
- [x] Updated CHANGELOG.md.