### PR TITLE
add .true and .false signal producers which sends a boolean and compl…

### DIFF
--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -211,6 +211,22 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 			lifetime.observeEnded { _ = observer }
 		}
 	}
+	
+	/// A boolean producer for a Signal that sends one `true` value and completes afterwards.
+	public static var `true`: SignalProducer<Bool, Error> {
+		return SignalProducer<Bool, Error> (GeneratorCore { observer, _ in
+			observer.send(value: true)
+			observer.sendCompleted()
+		})
+	}
+	
+	/// A boolean producer for a Signal that sends one `false` value and completes afterwards.
+	public static var `false`: SignalProducer<Bool, Error> {
+		return SignalProducer<Bool, Error> (GeneratorCore { observer, _ in
+			observer.send(value: false)
+			observer.sendCompleted()
+		})
+	}
 
 	/// Create a `Signal` from `self`, pass it into the given closure, and start the
 	/// associated work on the produced `Signal` as the closure returns.


### PR DESCRIPTION
…etes immediately


#### Checklist
- [ ] Updated CHANGELOG.md.

Useful for **zip** operator for example, when you want to bypass a signal producer in a specific condition.