### PR TITLE
Lifecycle

### DIFF
--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -9,6 +9,16 @@
 /* Begin PBXBuildFile section */
 		02D2602A1C1D6DAF003ACC61 /* SignalLifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */; };
 		02D2602B1C1D6DB8003ACC61 /* SignalLifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */; };
+		490B642D2145F9D1008D5D9C /* Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490B642C2145F9D1008D5D9C /* Lifecycle.swift */; };
+		490B642E2145F9D1008D5D9C /* Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490B642C2145F9D1008D5D9C /* Lifecycle.swift */; };
+		490B642F2145F9D1008D5D9C /* Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490B642C2145F9D1008D5D9C /* Lifecycle.swift */; };
+		490B64302145F9D1008D5D9C /* Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490B642C2145F9D1008D5D9C /* Lifecycle.swift */; };
+		490B643221460115008D5D9C /* LifecycleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490B643121460115008D5D9C /* LifecycleSpec.swift */; };
+		490B643321460115008D5D9C /* LifecycleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490B643121460115008D5D9C /* LifecycleSpec.swift */; };
+		490B643421460115008D5D9C /* LifecycleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490B643121460115008D5D9C /* LifecycleSpec.swift */; };
+		490B64362146178F008D5D9C /* MockLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490B64352146178F008D5D9C /* MockLock.swift */; };
+		490B64372146178F008D5D9C /* MockLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490B64352146178F008D5D9C /* MockLock.swift */; };
+		490B64382146178F008D5D9C /* MockLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490B64352146178F008D5D9C /* MockLock.swift */; };
 		4A0AB6721DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0AB6711DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift */; };
 		4A0AB6731DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0AB6711DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift */; };
 		4A0AB6741DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0AB6711DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift */; };
@@ -236,6 +246,9 @@
 
 /* Begin PBXFileReference section */
 		02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalLifetimeSpec.swift; sourceTree = "<group>"; };
+		490B642C2145F9D1008D5D9C /* Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lifecycle.swift; sourceTree = "<group>"; };
+		490B643121460115008D5D9C /* LifecycleSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleSpec.swift; sourceTree = "<group>"; };
+		490B64352146178F008D5D9C /* MockLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLock.swift; sourceTree = "<group>"; };
 		4A0AB6711DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveExtensionsSpec.swift; sourceTree = "<group>"; };
 		4A0E10FE1D2A92720065D310 /* Lifetime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lifetime.swift; sourceTree = "<group>"; };
 		4A0E11031D2A95200065D310 /* LifetimeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifetimeSpec.swift; sourceTree = "<group>"; };
@@ -464,6 +477,7 @@
 				D0C312BC19EF2A5800984962 /* Bag.swift */,
 				D0C312BE19EF2A5800984962 /* Disposable.swift */,
 				D08C54B51A69A3DB00AD8286 /* Event.swift */,
+				490B642C2145F9D1008D5D9C /* Lifecycle.swift */,
 				EBCC7DBB1BBF010C00A2AE92 /* Observer.swift */,
 				D871D69E1B3B29A40070F16C /* Optional.swift */,
 				9A090C131DA0309E00EE97CA /* Reactive.swift */,
@@ -496,6 +510,7 @@
 				D0C312F019EF2A7700984962 /* DisposableSpec.swift */,
 				CA6F284F1C52626B001879D2 /* FlattenSpec.swift */,
 				D8170FC01B100EBC004192AD /* FoundationExtensionsSpec.swift */,
+				490B643121460115008D5D9C /* LifecycleSpec.swift */,
 				4A0E11031D2A95200065D310 /* LifetimeSpec.swift */,
 				D0A2260D1A72F16D00D33B74 /* PropertySpec.swift */,
 				4A0AB6711DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift */,
@@ -521,6 +536,7 @@
 				D05E662419EDD82000904ACA /* Nimble.framework */,
 				D037672B19EDA75D00A782A9 /* Quick.framework */,
 				BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */,
+				490B64352146178F008D5D9C /* MockLock.swift */,
 				D04725FB19E49ED7006002AA /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -885,6 +901,7 @@
 				57A4D1B81BA13D7A00F7D4B1 /* Scheduler.swift in Sources */,
 				9A9100E21E0E6E680093E346 /* ValidatingProperty.swift in Sources */,
 				57A4D1B91BA13D7A00F7D4B1 /* Action.swift in Sources */,
+				490B64302145F9D1008D5D9C /* Lifecycle.swift in Sources */,
 				57A4D1BA1BA13D7A00F7D4B1 /* Property.swift in Sources */,
 				9A090C171DA0309E00EE97CA /* Reactive.swift in Sources */,
 				57A4D1BB1BA13D7A00F7D4B1 /* Signal.swift in Sources */,
@@ -907,6 +924,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				490B64382146178F008D5D9C /* MockLock.swift in Sources */,
 				7DFBED221CDB8DE300EE435B /* ActionSpec.swift in Sources */,
 				7DFBED231CDB8DE300EE435B /* AtomicSpec.swift in Sources */,
 				7DFBED241CDB8DE300EE435B /* BagSpec.swift in Sources */,
@@ -917,6 +935,7 @@
 				7DFBED2A1CDB8DE300EE435B /* SignalLifetimeSpec.swift in Sources */,
 				7DFBED2B1CDB8DE300EE435B /* SignalProducerSpec.swift in Sources */,
 				9A681AA01E5A241B00B097CF /* DeprecationSpec.swift in Sources */,
+				490B643421460115008D5D9C /* LifecycleSpec.swift in Sources */,
 				7DFBED2C1CDB8DE300EE435B /* SignalProducerLiftingSpec.swift in Sources */,
 				7DFBED2D1CDB8DE300EE435B /* SignalSpec.swift in Sources */,
 				7DFBED2E1CDB8DE300EE435B /* FlattenSpec.swift in Sources */,
@@ -940,6 +959,7 @@
 				A9B315C01B3940810001CB9C /* Scheduler.swift in Sources */,
 				9A9100E11E0E6E680093E346 /* ValidatingProperty.swift in Sources */,
 				A9B315C11B3940810001CB9C /* Action.swift in Sources */,
+				490B642F2145F9D1008D5D9C /* Lifecycle.swift in Sources */,
 				A9B315C21B3940810001CB9C /* Property.swift in Sources */,
 				9A090C161DA0309E00EE97CA /* Reactive.swift in Sources */,
 				A9B315C31B3940810001CB9C /* Signal.swift in Sources */,
@@ -968,6 +988,7 @@
 				9A9100DF1E0E6E620093E346 /* ValidatingProperty.swift in Sources */,
 				EBCC7DBC1BBF010C00A2AE92 /* Observer.swift in Sources */,
 				D03B4A3D19F4C39A009E02AC /* FoundationExtensions.swift in Sources */,
+				490B642D2145F9D1008D5D9C /* Lifecycle.swift in Sources */,
 				9A090C141DA0309E00EE97CA /* Reactive.swift in Sources */,
 				D08C54B31A69A2AE00AD8286 /* Signal.swift in Sources */,
 				D85C652A1C0D84C7005A77AD /* Flatten.swift in Sources */,
@@ -990,6 +1011,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				490B64362146178F008D5D9C /* MockLock.swift in Sources */,
 				D0A2260E1A72F16D00D33B74 /* PropertySpec.swift in Sources */,
 				B696FB811A7640C00075236D /* TestError.swift in Sources */,
 				D021671D1A6CD50500987861 /* ActionSpec.swift in Sources */,
@@ -1000,6 +1022,7 @@
 				CA6F28501C52626B001879D2 /* FlattenSpec.swift in Sources */,
 				4A0E11041D2A95200065D310 /* LifetimeSpec.swift in Sources */,
 				9A681A9E1E5A241B00B097CF /* DeprecationSpec.swift in Sources */,
+				490B643221460115008D5D9C /* LifecycleSpec.swift in Sources */,
 				CDCD247A1C277EEC00710AEE /* AtomicSpec.swift in Sources */,
 				579504331BB8A34200A5E482 /* BagSpec.swift in Sources */,
 				D0A226081A72E0E900D33B74 /* SignalSpec.swift in Sources */,
@@ -1023,6 +1046,7 @@
 				D08C54B91A69A9D100AD8286 /* SignalProducer.swift in Sources */,
 				9A9100E01E0E6E670093E346 /* ValidatingProperty.swift in Sources */,
 				9ABCB1861D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */,
+				490B642E2145F9D1008D5D9C /* Lifecycle.swift in Sources */,
 				EBCC7DBD1BBF01E100A2AE92 /* Observer.swift in Sources */,
 				9A090C151DA0309E00EE97CA /* Reactive.swift in Sources */,
 				D85C652B1C0E70E3005A77AD /* Flatten.swift in Sources */,
@@ -1045,6 +1069,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				490B64372146178F008D5D9C /* MockLock.swift in Sources */,
 				D0A2260C1A72E6C500D33B74 /* SignalProducerSpec.swift in Sources */,
 				D0A2260F1A72F16D00D33B74 /* PropertySpec.swift in Sources */,
 				D0A226091A72E0E900D33B74 /* SignalSpec.swift in Sources */,
@@ -1055,6 +1080,7 @@
 				B696FB821A7640C00075236D /* TestError.swift in Sources */,
 				D8170FC21B100EBC004192AD /* FoundationExtensionsSpec.swift in Sources */,
 				9A681A9F1E5A241B00B097CF /* DeprecationSpec.swift in Sources */,
+				490B643321460115008D5D9C /* LifecycleSpec.swift in Sources */,
 				D0C3131419EF2B2000984962 /* SchedulerSpec.swift in Sources */,
 				C79B64751CD38B2B003F2376 /* TestLogger.swift in Sources */,
 				D0C3131219EF2B2000984962 /* DisposableSpec.swift in Sources */,

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -102,9 +102,23 @@ internal struct UnsafeAtomicState<State: RawRepresentable> where State.RawValue 
 #endif
 }
 
+internal protocol LockProtocol {
+	func lock()
+	func unlock()
+	func `try`() -> Bool
+}
+
+extension LockProtocol {
+	func perform(action: () -> Void) {
+		lock()
+		action()
+		unlock()
+	}
+}
+
 /// `Lock` exposes `os_unfair_lock` on supported platforms, with pthread mutex as the
 // fallback.
-internal class Lock {
+internal class Lock: LockProtocol {
 	#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 	@available(iOS 10.0, *)
 	@available(macOS 10.12, *)

--- a/Sources/Lifecycle.swift
+++ b/Sources/Lifecycle.swift
@@ -8,7 +8,14 @@
 
 import Foundation
 
-public class Lifecycle {
+public protocol LifecycleProtocol {
+	var lifetime: Property<Lifetime> { get }
+	func update()
+	func updateIfValid()
+	func invalidate()
+}
+
+public class Lifecycle: LifecycleProtocol {
 
 	/// Hook that can be used to get the current lifetime.
 	///

--- a/Sources/Lifecycle.swift
+++ b/Sources/Lifecycle.swift
@@ -10,17 +10,22 @@ import Foundation
 
 public class Lifecycle {
 
-	/// Hook that can be used to get the current lifetime
+	/// Hook that can be used to get the current lifetime.
 	/// - note: The consumer of lifecycle is responsible for checking
-	///         whether or not the lifetime is valid
+	///         whether or not the lifetime is valid.
 	public let lifetime: Property<Lifetime>
 	private let lock: LockProtocol
 	private var token: Lifetime.Token?
 	private let mutableLifetime: MutableProperty<Lifetime>
 
-	public init() {
+	/// Initializes a new Lifecycle
+	///
+	/// - parameters:
+	///   - invalidate: A flag used to determine whether the current
+	///                 lifetime is invalidated.
+	public init(invalidate: Bool = false) {
 		let (lifetime, token) = Lifetime.make()
-		self.token = token
+		self.token = (!invalidate) ? token : nil
 		mutableLifetime = MutableProperty(lifetime)
 		self.lifetime = Property(mutableLifetime)
 		lock = Lock.PthreadLock(recursive: true)
@@ -34,7 +39,7 @@ public class Lifecycle {
 		self.lock = lock
 	}
 
-	/// Updates lifetime property and invalidates current lifetime
+	/// Updates lifetime property and invalidates current lifetime.
 	public func update() {
 		lock.perform { [weak self] in
 			self?.unsafeUpdate()
@@ -42,9 +47,9 @@ public class Lifecycle {
 	}
 
 	/// Updates lifetime property and invalidates cuurent lifetime
-	/// if current lifetime is valid
+	/// if current lifetime is valid.
 	///
-	/// - note: If the current lifetime is invalid nothing happens
+	/// - note: If the current lifetime is invalid nothing happens.
 	public func updateIfValid() {
 		lock.perform { [weak self] in
 			if self?.token != nil {
@@ -53,9 +58,9 @@ public class Lifecycle {
 		}
 	}
 
-	/// Invalidates lifetime property
+	/// Invalidates lifetime property.
 	///
-	/// - note: If the current lifetime is invalid nothing happens
+	/// - note: If the current lifetime is invalid nothing happens.
 	public func invalidate() {
 		lock.perform { [weak self] in
 			self?.token = nil

--- a/Sources/Lifecycle.swift
+++ b/Sources/Lifecycle.swift
@@ -35,7 +35,7 @@ public class Lifecycle {
 	/// Initializer used for testing purposes
 	///
 	/// - parameters:
-	///   - lock: A lock that can be used to reproduce race conditions reliably
+	///   - lock: A lock that can be used to reproduce race conditions reliably.
 	internal init(lock: LockProtocol) {
 		let (lifetime, token) = Lifetime.make()
 		self.token = token

--- a/Sources/Lifecycle.swift
+++ b/Sources/Lifecycle.swift
@@ -11,14 +11,15 @@ import Foundation
 public class Lifecycle {
 
 	/// Hook that can be used to get the current lifetime.
-	/// - note: The consumer of lifecycle is responsible for checking
+	///
+	/// - note: The consumer of `Lifecycle` is responsible for checking
 	///         whether or not the lifetime is valid.
 	public let lifetime: Property<Lifetime>
 	private let lock: LockProtocol
 	private var token: Lifetime.Token?
 	private let mutableLifetime: MutableProperty<Lifetime>
 
-	/// Initializes a new Lifecycle
+	/// Initializes a new `Lifecycle`
 	///
 	/// - parameters:
 	///   - invalidate: A flag used to determine whether the current

--- a/Sources/Lifecycle.swift
+++ b/Sources/Lifecycle.swift
@@ -31,6 +31,10 @@ public class Lifecycle {
 		lock = Lock.PthreadLock(recursive: true)
 	}
 
+	/// Initializer used for testing purposes
+	///
+	/// - parameters:
+	///   - lock: A lock that can be used to reproduce race conditions reliably
 	internal init(lock: LockProtocol) {
 		let (lifetime, token) = Lifetime.make()
 		self.token = token

--- a/Sources/Lifecycle.swift
+++ b/Sources/Lifecycle.swift
@@ -10,6 +10,9 @@ import Foundation
 
 public class Lifecycle {
 
+	/// Hook that can be used to get the current lifetime
+	/// - note: The consumer of lifecycle is responsible for checking
+	///         whether or not the lifetime is valid
 	public let lifetime: Property<Lifetime>
 	private let lock: LockProtocol
 	private var token: Lifetime.Token?
@@ -31,12 +34,17 @@ public class Lifecycle {
 		self.lock = lock
 	}
 
+	/// Updates lifetime property and invalidates current lifetime
 	public func update() {
 		lock.perform { [weak self] in
 			self?.unsafeUpdate()
 		}
 	}
 
+	/// Updates lifetime property and invalidates cuurent lifetime
+	/// if current lifetime is valid
+	///
+	/// - note: If the current lifetime is invalid nothing happens
 	public func updateIfValid() {
 		lock.perform { [weak self] in
 			if self?.token != nil {
@@ -45,6 +53,9 @@ public class Lifecycle {
 		}
 	}
 
+	/// Invalidates lifetime property
+	///
+	/// - note: If the current lifetime is invalid nothing happens
 	public func invalidate() {
 		lock.perform { [weak self] in
 			self?.token = nil

--- a/Sources/Lifecycle.swift
+++ b/Sources/Lifecycle.swift
@@ -1,0 +1,60 @@
+//
+//  Lifecycle.swift
+//  ReactiveSwift
+//
+//  Created by Andrew Arnopoulos on 9/9/18.
+//  Copyright © 2018 GitHub. All rights reserved.
+//
+
+import Foundation
+
+public class Lifecycle {
+
+	public let lifetime: Property<Lifetime>
+	private let lock: LockProtocol
+	private var token: Lifetime.Token?
+	private let mutableLifetime: MutableProperty<Lifetime>
+
+	public init() {
+		let (lifetime, token) = Lifetime.make()
+		self.token = token
+		mutableLifetime = MutableProperty(lifetime)
+		self.lifetime = Property(mutableLifetime)
+		lock = Lock.PthreadLock(recursive: true)
+	}
+
+	internal init(lock: LockProtocol) {
+		let (lifetime, token) = Lifetime.make()
+		self.token = token
+		mutableLifetime = MutableProperty(lifetime)
+		self.lifetime = Property(mutableLifetime)
+		self.lock = lock
+	}
+
+	public func update() {
+		lock.perform { [weak self] in
+			self?.unsafeUpdate()
+		}
+	}
+
+	public func updateIfValid() {
+		lock.perform { [weak self] in
+			if self?.token != nil {
+				self?.unsafeUpdate()
+			}
+		}
+	}
+
+	public func invalidate() {
+		lock.perform { [weak self] in
+			self?.token = nil
+		}
+	}
+
+	private func unsafeUpdate() {
+		let (lifetime, token) = Lifetime.make()
+		self.token = token
+		mutableLifetime.value = lifetime
+	}
+
+}

--- a/Tests/ReactiveSwiftTests/LifecycleSpec.swift
+++ b/Tests/ReactiveSwiftTests/LifecycleSpec.swift
@@ -1,0 +1,81 @@
+//
+//  LifecycleSpec.swift
+//  ReactiveSwift
+//
+//  Created by Andrew Arnopoulos on 9/9/18.
+//  Copyright © 2018 GitHub. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import ReactiveSwift
+
+final class LifecycleSpec: QuickSpec {
+	override func spec() {
+		describe("Lifecycle") {
+			it("should invalidate lifetime when invalidate is called") {
+				let cycle = Lifecycle()
+				let lifetime = cycle.lifetime.value
+				cycle.invalidate()
+				expect(lifetime.hasEnded) == true
+			}
+
+			it("should update lifetime when update is called") {
+				let cycle = Lifecycle()
+				let lifetime = cycle.lifetime.value
+				cycle.update()
+				expect(cycle.lifetime.value).toNot(be(lifetime))
+				expect(lifetime.hasEnded) == true
+			}
+
+			it("should guarantee mutual exclusion when calling update") {
+				let lock = MockLock()
+				let cycle = Lifecycle(lock: lock)
+				cycle.update()
+				expect(lock.lockCount) == 1
+				expect(lock.unlockCount) == 1
+			}
+
+			it("should guarantee mutual exclusion when calling invalidate") {
+				let lock = MockLock()
+				let cycle = Lifecycle(lock: lock)
+				cycle.invalidate()
+				expect(lock.lockCount) == 1
+				expect(lock.unlockCount) == 1
+			}
+
+			it("should guarantee mutual exclusion when calling mutually exclusive functions") {
+				let lock = MockLock()
+				let cycle = Lifecycle(lock: lock)
+				cycle.update()
+				cycle.updateIfValid()
+				cycle.invalidate()
+				expect(lock.lockCount) == 3
+				expect(lock.unlockCount) == 3
+			}
+
+			it("should not deadlock when updateIfValid is called") {
+				let lock = MockLock()
+				let cycle = Lifecycle(lock: lock)
+				cycle.updateIfValid()
+				expect(lock.deadlock) == false
+			}
+
+			it("should update if lifetime is valid when updateIfValid is called") {
+				let cycle = Lifecycle()
+				let lifetime = cycle.lifetime.value
+				cycle.updateIfValid()
+				expect(cycle.lifetime.value).notTo(be(lifetime))
+			}
+
+			it("should not update if lifetime is invalid when updateIfValid is called") {
+				let cycle = Lifecycle()
+				let lifetime = cycle.lifetime.value
+				cycle.invalidate()
+				cycle.updateIfValid()
+				expect(cycle.lifetime.value).to(be(lifetime))
+			}
+		}
+	}
+}

--- a/Tests/ReactiveSwiftTests/LifecycleSpec.swift
+++ b/Tests/ReactiveSwiftTests/LifecycleSpec.swift
@@ -14,6 +14,21 @@ import Nimble
 final class LifecycleSpec: QuickSpec {
 	override func spec() {
 		describe("Lifecycle") {
+			it("should have a valid lifetime after initialization by default") {
+				let lifecycle = Lifecycle(invalidate: false)
+				expect(lifecycle.lifetime.value.hasEnded) == false
+			}
+
+			it("should have a valid lifetime after initialization if invalidate is false") {
+				let lifecycle = Lifecycle(invalidate: false)
+				expect(lifecycle.lifetime.value.hasEnded) == false
+			}
+
+			it("should have a invalid lifetime after initialization if invalidate is true") {
+				let lifecycle = Lifecycle(invalidate: true)
+				expect(lifecycle.lifetime.value.hasEnded) == true
+			}
+
 			it("should invalidate lifetime when invalidate is called") {
 				let cycle = Lifecycle()
 				let lifetime = cycle.lifetime.value

--- a/Tests/ReactiveSwiftTests/MockLock.swift
+++ b/Tests/ReactiveSwiftTests/MockLock.swift
@@ -1,0 +1,30 @@
+//
+//  MockLock.swift
+//  ReactiveSwift
+//
+//  Created by Andrew Arnopoulos on 9/9/18.
+//  Copyright © 2018 GitHub. All rights reserved.
+//
+
+import Foundation
+@testable import ReactiveSwift
+
+class MockLock: LockProtocol {
+	var lockCount = 0
+	var unlockCount = 0
+	var deadlock = false
+	func lock() {
+		lockCount += 1
+		if lockCount - unlockCount > 1 {
+			deadlock = true
+		}
+	}
+
+	func unlock() {
+		unlockCount += 1
+	}
+
+	func `try`() -> Bool {
+		fatalError("Not yet implemented")
+	}
+}

--- a/Tests/ReactiveSwiftTests/MockLock.swift
+++ b/Tests/ReactiveSwiftTests/MockLock.swift
@@ -13,7 +13,14 @@ class MockLock: LockProtocol {
 	var lockCount = 0
 	var unlockCount = 0
 	var deadlock = false
+	private var initializationThread: Thread
+
+	init() {
+		initializationThread = Thread.current
+	}
+
 	func lock() {
+		precondition(initializationThread == Thread.current)
 		lockCount += 1
 		if lockCount - unlockCount > 1 {
 			deadlock = true
@@ -21,6 +28,7 @@ class MockLock: LockProtocol {
 	}
 
 	func unlock() {
+		precondition(initializationThread == Thread.current)
 		unlockCount += 1
 	}
 


### PR DESCRIPTION
This adds the ability for a consumer of ReactiveSwift to have a custom life cycle without having to manually create the scaffolding for the `Lifetime`. In addition this has the added benefit of making `Lifetime.Token`s implicit mutual exclusion rule and makes it explicit.

#### Checklist
- [ ] Updated CHANGELOG.md.
