### PR TITLE
Add materializeResults operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 *Please add new entries at the top.*
 
+1. New operator `matelializeResults` and `dematerializeResults` (#679, kudos to @ra1028)
 1. New convenience initializer for `Action` that takes a `ValidatingProperty` as its state (#637, kudos to @Marcocanc)
 
 # 4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # master
 *Please add new entries at the top.*
 
-1. New operator `matelializeResults` and `dematerializeResults` (#679, kudos to @ra1028)
+1. New operator `materializeResults` and `dematerializeResults` (#679, kudos to @ra1028)
 1. New convenience initializer for `Action` that takes a `ValidatingProperty` as its state (#637, kudos to @Marcocanc)
 
 # 4.0.0

--- a/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -435,6 +435,25 @@ scopedExample("`materialize`") {
 }
 
 /*:
+ ### `materializeResults`
+
+ Treats all Results from the input producer as plain values, allowing them
+ to be manipulated just like any other value.
+
+ In other words, this brings Results “into the monad.”
+
+ When a Failed event is received, the resulting producer will
+ send the `Result.failure` itself and then complete.
+ */
+scopedExample("`materializeResults`") {
+    SignalProducer<Int, NoError>([ 1, 2, 3, 4 ])
+        .materializeResults()
+        .startWithValues { value in
+            print(value)
+    }
+}
+
+/*:
 ### `sample(on:)`
 Forwards the latest value from `self` whenever `sampler` sends a `value`
 event.

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -311,7 +311,7 @@ extension Signal.Event {
 		}
 	}
 
-	internal static var resultValues: Transformation<Result<Value, Error>, NoError> {
+	internal static var materializeResults: Transformation<Result<Value, Error>, NoError> {
 		return { action, _ in
 			return { event in
 				switch event {

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -311,6 +311,27 @@ extension Signal.Event {
 		}
 	}
 
+	internal static var resultValues: Transformation<Result<Value, Error>, NoError> {
+		return { action, _ in
+			return { event in
+				switch event {
+				case .value(let value):
+					action(.value(Result(value: value)))
+
+				case .failed(let error):
+					action(.value(Result(error: error)))
+					action(.completed)
+
+				case .completed:
+					action(.completed)
+
+				case .interrupted:
+					action(.interrupted)
+				}
+			}
+		}
+	}
+
 	internal static func attemptMap<U>(_ transform: @escaping (Value) -> Result<U, Error>) -> Transformation<U, Error> {
 		return { action, _ in
 			return { event in

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -880,6 +880,15 @@ extension Signal {
 		return flatMapEvent(Signal.Event.materialize)
 	}
 
+	/// Treats all Results from the input producer as plain values, allowing them
+	/// to be manipulated just like any other value.
+	///
+	/// In other words, this brings Results “into the monad.”
+	///
+	/// - note: When a Failed event is received, the resulting producer will
+	///         send the `Result.failure` itself and then complete.
+	///
+	/// - returns: A producer that sends results as its values.
 	public func resultValues() -> Signal<Result<Value, Error>, NoError> {
 		return flatMapEvent(Signal.Event.resultValues)
 	}

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -889,8 +889,8 @@ extension Signal {
 	///         send the `Result.failure` itself and then complete.
 	///
 	/// - returns: A producer that sends results as its values.
-	public func resultValues() -> Signal<Result<Value, Error>, NoError> {
-		return flatMapEvent(Signal.Event.resultValues)
+	public func materializeResults() -> Signal<Result<Value, Error>, NoError> {
+		return flatMapEvent(Signal.Event.materializeResults)
 	}
 }
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -879,6 +879,10 @@ extension Signal {
 	public func materialize() -> Signal<Event, NoError> {
 		return flatMapEvent(Signal.Event.materialize)
 	}
+
+	public func resultValues() -> Signal<Result<Value, Error>, NoError> {
+		return flatMapEvent(Signal.Event.resultValues)
+	}
 }
 
 extension Signal where Value: EventProtocol, Error == NoError {

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -904,6 +904,16 @@ extension Signal where Value: EventProtocol, Error == NoError {
 	}
 }
 
+extension Signal where Value: ResultProtocol, Error == NoError {
+	/// Translate a signal of `Result` _values_ into a signal of those events
+	/// themselves.
+	///
+	/// - returns: A signal that sends values carried by `self` events.
+	public func dematerializeResults() -> Signal<Value.Value, Value.Error> {
+		return flatMapEvent(Signal.Event.dematerializeResults)
+	}
+}
+
 extension Signal {
 	/// Inject side effects to be performed upon the specified signal events.
 	///

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1196,6 +1196,10 @@ extension SignalProducer {
 		return core.flatMapEvent(Signal.Event.materialize)
 	}
 
+	public func resultValues() -> SignalProducer<Result<Value, Error>, NoError> {
+		return core.flatMapEvent(Signal.Event.resultValues)
+	}
+
 	/// Forward the latest value from `self` with the value from `sampler` as a
 	/// tuple, only when `sampler` sends a `value` event.
 	///

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1749,6 +1749,16 @@ extension SignalProducer where Value: EventProtocol, Error == NoError {
 	}
 }
 
+extension SignalProducer where Value: ResultProtocol, Error == NoError {
+	/// The inverse of materializeResults(), this will translate a producer of `Result`
+	/// _values_ into a producer of those events themselves.
+	///
+	/// - returns: A producer that sends values carried by `self` results.
+	public func dematerializeResults() -> SignalProducer<Value.Value, Value.Error> {
+		return core.flatMapEvent(Signal.Event.dematerializeResults)
+	}
+}
+
 extension SignalProducer where Error == NoError {
 	/// Promote a producer that does not generate failures into one that can.
 	///

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1196,6 +1196,15 @@ extension SignalProducer {
 		return core.flatMapEvent(Signal.Event.materialize)
 	}
 
+	/// Treats all Results from the input producer as plain values, allowing them
+	/// to be manipulated just like any other value.
+	///
+	/// In other words, this brings Results “into the monad.”
+	///
+	/// - note: When a Failed event is received, the resulting producer will
+	///         send the `Result.failure` itself and then complete.
+	///
+	/// - returns: A producer that sends results as its values.
 	public func resultValues() -> SignalProducer<Result<Value, Error>, NoError> {
 		return core.flatMapEvent(Signal.Event.resultValues)
 	}

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1205,8 +1205,8 @@ extension SignalProducer {
 	///         send the `Result.failure` itself and then complete.
 	///
 	/// - returns: A producer that sends results as its values.
-	public func resultValues() -> SignalProducer<Result<Value, Error>, NoError> {
-		return core.flatMapEvent(Signal.Event.resultValues)
+	public func materializeResults() -> SignalProducer<Result<Value, Error>, NoError> {
+		return core.flatMapEvent(Signal.Event.materializeResults)
 	}
 
 	/// Forward the latest value from `self` with the value from `sampler` as a

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -1932,7 +1932,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				dematerialized = producer.dematerializeResults()
 			}
 
-			it("should send values for Value events") {
+			it("should send values for Value results") {
 				var result: [Int] = []
 				dematerialized
 					.assumeNoErrors()
@@ -1947,7 +1947,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(result) == [ 2, 4 ]
 			}
 
-			it("should error out for Error events") {
+			it("should error out for Error results") {
 				var errored = false
 				dematerialized.startWithFailed { _ in errored = true }
 

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -1887,12 +1887,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 			}
 		}
 
-		describe("resultValues") {
+		describe("materializeResults") {
 			it("should reify results from the signal") {
 				let (producer, observer) = SignalProducer<Int, TestError>.pipe()
 				var latestResult: Result<Int, TestError>?
 				producer
-					.resultValues()
+					.materializeResults()
 					.startWithValues { latestResult = $0 }
 
 				observer.send(value: 2)

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -1887,6 +1887,40 @@ class SignalProducerLiftingSpec: QuickSpec {
 			}
 		}
 
+		describe("resultValues") {
+			it("should reify results from the signal") {
+				let (producer, observer) = SignalProducer<Int, TestError>.pipe()
+				var latestResult: Result<Int, TestError>?
+				producer
+					.resultValues()
+					.startWithValues { latestResult = $0 }
+
+				observer.send(value: 2)
+
+				expect(latestResult).toNot(beNil())
+				if let latestResult = latestResult {
+					switch latestResult {
+					case .success(let value):
+						expect(value) == 2
+
+					case .failure:
+						fail()
+					}
+				}
+
+				observer.send(error: TestError.default)
+				if let latestResult = latestResult {
+					switch latestResult {
+					case .failure(let error):
+						expect(error) == TestError.default
+
+					case .success:
+						fail()
+					}
+				}
+			}
+		}
+
 		describe("takeLast") {
 			var observer: Signal<Int, TestError>.Observer!
 			var lastThree: SignalProducer<Int, TestError>!

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -2935,12 +2935,12 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
-		describe("resultValues") {
+		describe("materializeResults") {
 			it("should reify results from the signal") {
 				let (signal, observer) = Signal<Int, TestError>.pipe()
 				var latestResult: Result<Int, TestError>?
 				signal
-					.resultValues()
+					.materializeResults()
 					.observeValues { latestResult = $0 }
 
 				observer.send(value: 2)

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -2935,6 +2935,40 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
+		describe("resultValues") {
+			it("should reify results from the signal") {
+				let (signal, observer) = Signal<Int, TestError>.pipe()
+				var latestResult: Result<Int, TestError>?
+				signal
+					.resultValues()
+					.observeValues { latestResult = $0 }
+
+				observer.send(value: 2)
+
+				expect(latestResult).toNot(beNil())
+				if let latestResult = latestResult {
+					switch latestResult {
+					case .success(let value):
+						expect(value) == 2
+
+					case .failure:
+						fail()
+					}
+				}
+
+				observer.send(error: TestError.default)
+				if let latestResult = latestResult {
+					switch latestResult {
+					case .failure(let error):
+						expect(error) == TestError.default
+
+					case .success:
+						fail()
+					}
+				}
+			}
+		}
+
 		describe("takeLast") {
 			var observer: Signal<Int, TestError>.Observer!
 			var lastThree: Signal<Int, TestError>!

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -2980,7 +2980,7 @@ class SignalSpec: QuickSpec {
 				dematerialized = signal.dematerializeResults()
 			}
 
-			it("should send values for Value events") {
+			it("should send values for Value results") {
 				var result: [Int] = []
 				dematerialized
 					.assumeNoErrors()
@@ -2995,7 +2995,7 @@ class SignalSpec: QuickSpec {
 				expect(result) == [ 2, 4 ]
 			}
 
-			it("should error out for Error events") {
+			it("should error out for Error results") {
 				var errored = false
 				dematerialized.observeFailed { _ in errored = true }
 


### PR DESCRIPTION
This operator is useful when we want to handle Result without to complete stream.
It has semantics similar to `dematerialize`.
And `dematerializeResults` which works in inverse is also added.

Use case:
```swift
// This stream doesn't complete even if an error sent.
viewModel.reactive.date.producer
    .take(duringLifetimeOf: self)
    .flatMap(.latest) { date in
        repository.getPrograms(on: date)
            .materializeResults()
    }
    .startWithValues { result in
        switch result {
        case .success(let programs)
            print(programs)

        case .failure(let error)
            print(error)
    }
```

#### Checklist
- [x] Updated CHANGELOG.md.
