### PR TITLE
RFC: Async file reading & run loop based scheduling

### DIFF
--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -18,6 +18,7 @@ import struct Result.AnyError
 
 extension FileHandle: ReactiveExtensionsProvider {}
 
+#if !os(Linux)
 extension Reactive where Base: FileHandle {
 	/// Returns a SignalProducer that reads the contents of this file in the
 	/// background.
@@ -52,6 +53,7 @@ extension Reactive where Base: FileHandle {
 			.flatMap(.latest) { $0.reactive.readToEndOfFile(on: scheduler) }
 	}
 }
+#endif
 
 extension NotificationCenter: ReactiveExtensionsProvider {}
 

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -383,6 +383,7 @@ public final class QueueScheduler: DateScheduler {
 	}
 }
 
+#if !os(Linux)
 /// A scheduler backed by a run loop.
 public final class RunLoopScheduler: DateScheduler {
 	/// A singleton `RunLoopScheduler` that always targets the main run loop.
@@ -470,6 +471,7 @@ public final class RunLoopScheduler: DateScheduler {
 		}
 	}
 }
+#endif
 
 /// A scheduler that implements virtualized time, for use in testing.
 public final class TestScheduler: DateScheduler {


### PR DESCRIPTION
This PR is in two parts: first is a possible new reactive extension for `FileHandle`’s background file reading functionality. I think it would be great for ReactiveSwift to provide first-class support for async file IO.

The second part addresses an awkward problem with wrapping this particular `FileHandle` API: it requires an active run loop in order to work. I couldn’t work out a way to construct a suitable precondition (every thread has access `RunLoop.current`, regardless of whether it’s active and has input sources attached), but similar to our other APIs that require a `DateScheduler` or `QueueScheduler` in order to work, it seemed there was an opportunity for a `RunLoopScheduler` abstraction in the same spirit. This still doesn’t guarantee that the run loop scheduler wraps an active run loop, but having to construct a `RunLoopScheduler` in the first place is a much stronger signal to users of the API. This also provides `RunLoopSchedular.main` for the most common case.

#### Checklist

- [ ] Add tests for `RunLoopScheduler`
- [ ] Add recursive scheduling detection
- [ ] Update CHANGELOG.md.