### PR TITLE
DispatchSourceTimerWrapper uses new hash(into:)

### DIFF
--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -183,9 +183,9 @@ public final class UIScheduler: Scheduler {
 /// be equal.
 private final class DispatchSourceTimerWrapper: Hashable {
 	private let value: DispatchSourceTimer
-	
-	fileprivate var hashValue: Int {
-		return ObjectIdentifier(self).hashValue
+
+	func hash(into hasher: inout Hasher) {
+		hasher.combine(ObjectIdentifier(self))
 	}
 	
 	fileprivate init(_ value: DispatchSourceTimer) {


### PR DESCRIPTION
`var hashValue:` is deprecated in Swift 5.0.

I found this while doing #702.