### PR TITLE
Implement the new hash method in Hashable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 *Please add new entries at the top.*
 
+1. Migrated from `hashValue` to `hash(into:)`, fixing deprecation warning in Swift 5 (#707, kudos to @ChristopherRogers)
 1. New operator `materializeResults` and `dematerializeResults` (#679, kudos to @ra1028)
 1. New convenience initializer for `Action` that takes a `ValidatingProperty` as its state (#637, kudos to @Marcocanc)
 1. Fix legacy date implementation. (#683, kudos to @shoheiyokoyama)

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -184,9 +184,15 @@ public final class UIScheduler: Scheduler {
 private final class DispatchSourceTimerWrapper: Hashable {
 	private let value: DispatchSourceTimer
 	
+	#if swift(>=4.1.50)
+	fileprivate func hash(into hasher: inout Hasher) {
+		hasher.combine(ObjectIdentifier(self))
+	}
+	#else
 	fileprivate var hashValue: Int {
 		return ObjectIdentifier(self).hashValue
 	}
+	#endif
 	
 	fileprivate init(_ value: DispatchSourceTimer) {
 		self.value = value


### PR DESCRIPTION
This also fixes the deprecation error in Swift 5.

#### Checklist
- [x] Updated CHANGELOG.md.
