### PR TITLE
Bump the version to 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # master
 *Please add new entries at the top.*
 
+# 5.0.0
+
+1. Support Swift 5.0 (Xcode 10.2) (#711, kudos to @ikesyo)
+1. Dropped support for Swift 4.1 (Xcode 9)
 1. Migrated from `hashValue` to `hash(into:)`, fixing deprecation warning in Swift 5 (#707, kudos to @ChristopherRogers)
 1. New operator `materializeResults` and `dematerializeResults` (#679, kudos to @ra1028)
 1. New convenience initializer for `Action` that takes a `ValidatingProperty` as its state (#637, kudos to @Marcocanc)

--- a/ReactiveSwift.podspec
+++ b/ReactiveSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "ReactiveSwift"
   # Version goes here and will be used to access the git tag later on, once we have a first release.
-  s.version      = "4.0.0"
+  s.version      = "5.0.0"
   s.summary      = "Streams of values over time"
   s.description  = <<-DESC
                    ReactiveSwift is a Swift framework inspired by Functional Reactive Programming. It provides APIs for composing and transforming streams of values over time.

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0</string>
+	<string>5.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/ReactiveSwiftTests/Info.plist
+++ b/Tests/ReactiveSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0</string>
+	<string>5.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
I'd like to release our changes for Xcode 10.2. Since we dropped Swift 4.1, this needs to be a breaking release.

I don't think we need to do a beta release for this, but I'm open to other opinions. 🙂

@ReactiveCocoa/reactiveswift 