### PR TITLE
Add a short upgrade guide for 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 1. Dropped support for Swift 4.2 (Xcode 9)
 2. Removed dependency on https://github.com/antitypical/Result (#702, kudos to @NachoSoto and @mdiep)
 
+**Upgrade to 6.0.0**
+
+* If you have used `Result` only as dependency of `ReactiveSwift`, remove all instances of `import Result`, `import enum Result.NoError` or `import struct Result.AnyError` and remove the `Result` Framework from your project.
+* Replace all cases where `NoError` was used in a `Signal` or `SignalProducer` with `Never`
+* Replace all cases where `AnyError` was used in a `Signal` or `SignalProducer` with `Swift.Error`
+
+
 # 5.0.1
 1. Fix warnings in Xcode 10.2
 


### PR DESCRIPTION
As proposed in https://github.com/ReactiveCocoa/ReactiveSwift/pull/724

#### Checklist
- [x] Updated CHANGELOG.md.