### PR TITLE
Delete an unnecessary setup for playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ We also provide a great Playground, so you can get used to ReactiveCocoa's opera
      - `git submodule update --init --recursive` **OR**, if you have [Carthage][] installed    
      - `carthage checkout`
  1. Open `ReactiveSwift.xcworkspace`
- 1. Build `Result-Mac` scheme
  1. Build `ReactiveSwift-macOS` scheme
  1. Finally open the `ReactiveSwift.playground`
  1. Choose `View > Show Debug Area`

--- a/ReactiveSwift.playground/Pages/Property.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Property.xcplaygroundpage/Contents.swift
@@ -6,7 +6,6 @@
  **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
     - `carthage checkout`
  1. Open `ReactiveSwift.xcworkspace`
- 1. Build `Result-Mac` scheme
  1. Build `ReactiveSwift-macOS` scheme
  1. Finally open the `ReactiveSwift.playground`
  1. Choose `View > Show Debug Area`

--- a/ReactiveSwift.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
@@ -6,7 +6,6 @@
  **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
     - `carthage checkout`
  1. Open `ReactiveSwift.xcworkspace`
- 1. Build `Result-Mac` scheme
  1. Build `ReactiveSwift-macOS` scheme
  1. Finally open the `ReactiveSwift.playground`
  1. Choose `View > Show Debug Area`

--- a/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/Signal.xcplaygroundpage/Contents.swift
@@ -6,7 +6,6 @@
  **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
     - `carthage checkout`
 1. Open `ReactiveSwift.xcworkspace`
-1. Build `Result-Mac` scheme
 1. Build `ReactiveSwift-macOS` scheme
 1. Finally open the `ReactiveSwift.playground`
 1. Choose `View > Show Debug Area`

--- a/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -6,7 +6,6 @@
  **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
     - `carthage checkout`
 1. Open `ReactiveSwift.xcworkspace`
-1. Build `Result-Mac` scheme
 1. Build `ReactiveSwift-macOS` scheme
 1. Finally open the `ReactiveSwift.playground`
 1. Choose `View > Show Debug Area`


### PR DESCRIPTION
#### Checklist

- [x] Delete an unnecessary setup for playground since it doesn't depend on `antitypical/Result` anymore.
