### PR TITLE
Add `_modify` accessor to `Atomic.value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 *Please add new entries at the top.*
+1. Add `_modify` accessor to `Atomic.value` (#731, kudos to @p4checo)
 
 # 6.0.0
 1. Dropped support for Swift 4.2 (Xcode 9)

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -226,6 +226,13 @@ public final class Atomic<Value> {
 		set(newValue) {
 			swap(newValue)
 		}
+
+		_modify {
+			lock.lock()
+			defer { lock.unlock() }
+
+			yield &_value
+		}
 	}
 
 	/// Initialize the variable with the given initial value.

--- a/Tests/ReactiveSwiftTests/AtomicSpec.swift
+++ b/Tests/ReactiveSwiftTests/AtomicSpec.swift
@@ -18,11 +18,14 @@ class AtomicSpec: QuickSpec {
 			atomic = Atomic(1)
 		}
 
-		it("should read and write the value directly") {
+		it("should read, write and modify the value directly") {
 			expect(atomic.value) == 1
 
 			atomic.value = 2
 			expect(atomic.value) == 2
+
+			atomic.value += 1
+			expect(atomic.value) == 3
 		}
 
 		it("should swap the value atomically") {


### PR DESCRIPTION
## Motivation

With Swift 5.0 the new `_modify` accessor became available, which allows a more efficient access to underlying storage when an in place mutation is made (i.e. via `inout`, like `value += 1`), by `yield`ing
a reference to the storage itself, instead of performing a copy (`get`) followed by a write (`set`).

This is particularly useful in containers where memory operations can become expensive (like collections), but also in containers wrapping expensive operations (like locking/unlocking locks).

Such is the case of `Atomic`, where besides optimizing memory access to the underlying storage, it can save a lock/unlock when the `.value` is modified in place (i.e. via `inout`). In this particular case, one can even claim that it’s more correct, because the whole mutation is truly made in a single atomic operation instead of two (as is already the case in the `modify(_:)` API).

## Changes

- Add `_modify` accessor to `Atomic.value`


#### Checklist
- [x] Updated CHANGELOG.md.
