### PR TITLE
Fix Result extensions ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 *Please add new entries at the top.*
+1. Fixed Result extensions ambiguity (#733, kudos to @nekrich)
+
 
 # 6.0.0
 1. Dropped support for Swift 4.2 (Xcode 9)

--- a/Sources/ResultExtensions.swift
+++ b/Sources/ResultExtensions.swift
@@ -3,14 +3,14 @@ extension Result: SignalProducerConvertible {
 		return .init(result: self)
 	}
 	
-	public var value: Success? {
+	internal var value: Success? {
 		switch self {
 		case let .success(value): return value
 		case .failure: return nil
 		}
 	}
 	
-	public var error: Failure? {
+	internal var error: Failure? {
 		switch self {
 		case .success: return nil
 		case let .failure(error): return error
@@ -19,7 +19,7 @@ extension Result: SignalProducerConvertible {
 }
 
 /// A protocol that can be used to constrain associated types as `Result`.
-public protocol ResultProtocol {
+internal protocol ResultProtocol {
 	associatedtype Success
 	associatedtype Failure: Swift.Error
 	
@@ -30,15 +30,15 @@ public protocol ResultProtocol {
 }
 
 extension Result: ResultProtocol {
-	public init(success: Success) {
+	internal init(success: Success) {
 		self = .success(success)
 	}
 	
-	public init(failure: Failure) {
+	internal init(failure: Failure) {
 		self = .failure(failure)
 	}
 	
-	public var result: Result<Success, Failure> {
+	internal var result: Result<Success, Failure> {
 		return self
 	}
 }

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -903,12 +903,12 @@ extension Signal where Value: EventProtocol, Error == Never {
 	}
 }
 
-extension Signal where Value: ResultProtocol, Error == Never {
+extension Signal where Error == Never {
 	/// Translate a signal of `Result` _values_ into a signal of those events
 	/// themselves.
 	///
 	/// - returns: A signal that sends values carried by `self` events.
-	public func dematerializeResults() -> Signal<Value.Success, Value.Failure> {
+	public func dematerializeResults<Success, Failure>() -> Signal<Success, Failure> where Value == Result<Success, Failure> {
 		return flatMapEvent(Signal.Event.dematerializeResults)
 	}
 }

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1748,12 +1748,12 @@ extension SignalProducer where Value: EventProtocol, Error == Never {
 	}
 }
 
-extension SignalProducer where Value: ResultProtocol, Error == Never {
+extension SignalProducer where Error == Never {
 	/// The inverse of materializeResults(), this will translate a producer of `Result`
 	/// _values_ into a producer of those events themselves.
 	///
 	/// - returns: A producer that sends values carried by `self` results.
-	public func dematerializeResults() -> SignalProducer<Value.Success, Value.Failure> {
+	public func dematerializeResults<Success, Failure>() -> SignalProducer<Success, Failure> where Value == Result<Success, Failure> {
 		return core.flatMapEvent(Signal.Event.dematerializeResults)
 	}
 }

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -10,7 +10,7 @@ import Foundation
 import Dispatch
 import Nimble
 import Quick
-import ReactiveSwift
+@testable import ReactiveSwift
 
 class ActionSpec: QuickSpec {
 	override func spec() {

--- a/Tests/ReactiveSwiftTests/FlattenSpec.swift
+++ b/Tests/ReactiveSwiftTests/FlattenSpec.swift
@@ -8,7 +8,7 @@
 
 import Nimble
 import Quick
-import ReactiveSwift
+@testable import ReactiveSwift
 import Dispatch
 
 private extension Signal {

--- a/Tests/ReactiveSwiftTests/ReactiveExtensionsSpec.swift
+++ b/Tests/ReactiveSwiftTests/ReactiveExtensionsSpec.swift
@@ -1,6 +1,6 @@
 import Nimble
 import Quick
-import ReactiveSwift
+@testable import ReactiveSwift
 
 private final class TestExtensionProvider: ReactiveExtensionsProvider {
 	let instanceProperty = "instance"

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -11,7 +11,7 @@ import Foundation
 
 import Nimble
 import Quick
-import ReactiveSwift
+@testable import ReactiveSwift
 
 class SignalProducerSpec: QuickSpec {
 	override func spec() {


### PR DESCRIPTION
Hi.

`public protocol ResultProtocol `, `public var value: Success?` & `public var error: Failure?` brings ambiguity for those who wrote their own extensions or use [antitypical/Result](https://github.com/antitypical/Result).

This PR attempts to fix this issue.

#### Checklist
- [x] Updated CHANGELOG.md.