### PR TITLE
SignalProducer: avoid recursive start of a sequence of producers

### DIFF
--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2169,25 +2169,22 @@ extension SignalProducer {
 		return start(producers, Signal.zip)
 	}
 
-	private static func start<S: Sequence>(_ producers: S, _ transform: @escaping ([Signal<Value, Error>]) -> Signal<[Value], Error>) -> SignalProducer<[Value], Error> where S.Iterator.Element: SignalProducerConvertible, S.Iterator.Element.Value == Value, S.Iterator.Element.Error == Error {
+	private static func start<S: Sequence>(_ producers: S, _ transform: @escaping (AnySequence<Signal<Value, Error>>) -> Signal<[Value], Error>) -> SignalProducer<[Value], Error> where S.Iterator.Element: SignalProducerConvertible, S.Iterator.Element.Value == Value, S.Iterator.Element.Error == Error
+	{
 		return SignalProducer<[Value], Error> { observer, lifetime in
-			let producers = Array(producers)
-			var pipes = [(Signal<Value, Error>, Signal<Value, Error>.Observer)]()
+			let setup = producers.map {
+				(producer: $0, pipe: Signal<Value, Error>.pipe())
+			}
 			
-			guard !producers.isEmpty else {
+			guard !setup.isEmpty else {
 				observer.sendCompleted()
 				return
 			}
-			
-			pipes.reserveCapacity(producers.count)
-			for _ in (0..<producers.count) {
-				pipes.append(Signal<Value, Error>.pipe())
-			}
 
-			lifetime += transform(pipes.map { $0.0 }).observe(observer)
+			lifetime += transform(AnySequence(setup.lazy.map { $0.pipe.output })).observe(observer)
 			
-			for (producer, (_, observer)) in Swift.zip(producers, pipes) {
-				lifetime += producer.producer.start(observer)
+			for (producer, pipe) in setup {
+				lifetime += producer.producer.start(pipe.input)
 			}
 		}
 	}

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2173,7 +2173,7 @@ extension SignalProducer {
 	{
 		return SignalProducer<[Value], Error> { observer, lifetime in
 			let setup = producers.map {
-				(producer: $0, pipe: Signal<Value, Error>.pipe())
+				(producer: $0.producer, pipe: Signal<Value, Error>.pipe())
 			}
 			
 			guard !setup.isEmpty else {
@@ -2184,7 +2184,7 @@ extension SignalProducer {
 			lifetime += transform(AnySequence(setup.lazy.map { $0.pipe.output })).observe(observer)
 			
 			for (producer, pipe) in setup {
-				lifetime += producer.producer.start(pipe.input)
+				lifetime += producer.start(pipe.input)
 			}
 		}
 	}

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -995,6 +995,23 @@ class SignalProducerSpec: QuickSpec {
 				expect(ids) == [1, 2]
 				expect(values._bridgeToObjectiveC()) == [[1, 2]]._bridgeToObjectiveC()
 			}
+			
+			it("can deal with hundreds of producers") {
+				let scheduler = QueueScheduler(qos: .default, name: "RACScheduler", targeting: nil)
+				
+				let producers = (0..<700).map { _ -> SignalProducer<Void, Never> in
+					return SignalProducer(value: ())
+				}
+				
+				waitUntil { done in
+					SignalProducer
+						.combineLatest(producers)
+						.start(on: scheduler)
+						.startWithCompleted {
+							done()
+					}
+				}
+			}
 		}
 
 		describe("zip") {
@@ -1031,6 +1048,23 @@ class SignalProducerSpec: QuickSpec {
 
 				expect(ids) == [1, 2]
 				expect(values._bridgeToObjectiveC()) == [[1, 2]]._bridgeToObjectiveC()
+			}
+			
+			it("can deal with hundreds of producers") {
+				let scheduler = QueueScheduler(qos: .default, name: "RACScheduler", targeting: nil)
+				
+				let producers = (0..<700).map { _ -> SignalProducer<Void, Never> in
+					return SignalProducer(value: ())
+				}
+				
+				waitUntil { done in
+					SignalProducer
+						.zip(producers)
+						.start(on: scheduler)
+						.startWithCompleted {
+							done()
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Instead, generate an array of pipes which can be fed to the transformation method
and then start all producers in a loop, connecting each to the corresponding pipe

This fixes #729 

I suspect that with significantly more effort one could refactor the Signal aggregate strategy to avoid creating the set of pipes by allowing for dynamic aggregation.
However, it may happen that eventually, such refactor will result in a comparable overhead down the line.


