### PR TITLE
Add possibility to use `and` + `or` with collection of signals/properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # master
 *Please add new entries at the top.*
-1. add possibility to use `and` and `or` operators with array of arguments (#735, kudos to @olejnjak)
+1. add possibility to use `all` and `any` operators with array of arguments (#735, kudos to @olejnjak)
    ```swift
-   let property = Property.or([boolProperty1, boolProperty2, boolProperty3])
+   let property = Property.any([boolProperty1, boolProperty2, boolProperty3])
    ```
 2. Fixed Result extensions ambiguity (#733, kudos to @nekrich)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 *Please add new entries at the top.*
+1. add possibility to use `and` and `or` operators with array of arguments (#735, kudos to @olejnjak)
+   ```swift
+   let property = Property.or([boolProperty1, boolProperty2, boolProperty3])
+   ```
 
 # 6.0.0
 1. Dropped support for Swift 4.2 (Xcode 9)

--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -134,19 +134,3 @@ extension DispatchTimeInterval {
 		return result
 	}
 }
-
-extension Collection where Element == Bool {
-	/// Returns logical or over all elements or `false` if `self` is empty.
-	///
-	/// - returns: Logical or over all elements or `false` if `self` is empty
-	internal func or() -> Bool {
-		return reduce(false) { $0 || $1 }
-	}
-	
-	/// Returns logical or over all elements or `false` if `self` is empty.
-	///
-	/// - returns: Logical or over all elements or `false` if `self` is empty
-	internal func and() -> Bool {
-		return reduce(true) { $0 && $1 }
-	}
-}

--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -142,4 +142,11 @@ extension Collection where Element == Bool {
 	internal func or() -> Bool {
 		return reduce(false) { $0 || $1 }
 	}
+	
+	/// Returns logical or over all elements or `false` if `self` is empty.
+	///
+	/// - returns: Logical or over all elements or `false` if `self` is empty
+	internal func and() -> Bool {
+		return reduce(true) { $0 && $1 }
+	}
 }

--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -134,3 +134,12 @@ extension DispatchTimeInterval {
 		return result
 	}
 }
+
+extension Collection where Element == Bool {
+	/// Returns logical or over all elements or `false` if `self` is empty.
+	///
+	/// - returns: Logical or over all elements or `false` if `self` is empty
+	internal func or() -> Bool {
+		return reduce(false) { $0 || $1 }
+	}
+}

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -439,7 +439,7 @@ extension PropertyProtocol where Value == Bool {
 	///   - properties: Collection of properties to be combined.
 	///
 	/// - returns: A property that contains the logial OR results.
-	public static func or<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
+	public static func any<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
 		return Property(initial: properties.map { $0.value }.reduce(false) { $0 || $1 }, then: SignalProducer.or(properties))
 	}
 }

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -422,6 +422,17 @@ extension PropertyProtocol where Value == Bool {
 	public func or<P: PropertyProtocol>(_ property: P) -> Property<Value> where P.Value == Value {
 		return self.lift(SignalProducer.or)(property)
 	}
+	
+	/// Create a property that computes a logical OR between the latest values of `self`
+	/// and `property`.
+	///
+	/// - parameters:
+	///   - property: Property to be combined with `self`.
+	///
+	/// - returns: A property that contains the logial OR results.
+	public static func or<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
+		return Property(initial: properties.map { $0.value }.or(), then: SignalProducer.or(properties))
+	}
 }
 
 /// A read-only property that can be observed for its changes over time. There

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -396,7 +396,7 @@ extension PropertyProtocol {
 extension PropertyProtocol where Value == Bool {
 	/// Create a property that computes a logical NOT in the latest values of `self`.
 	///
-	/// - returns: A property that contains the logial NOT results.
+	/// - returns: A property that contains the logical NOT results.
 	public func negate() -> Property<Value> {
 		return self.lift { $0.negate() }
 	}
@@ -407,7 +407,7 @@ extension PropertyProtocol where Value == Bool {
 	/// - parameters:
 	///   - property: Property to be combined with `self`.
 	///
-	/// - returns: A property that contains the logial AND results.
+	/// - returns: A property that contains the logical AND results.
 	public func and<P: PropertyProtocol>(_ property: P) -> Property<Value> where P.Value == Value {
 		return self.lift(SignalProducer.and)(property)
 	}
@@ -417,7 +417,7 @@ extension PropertyProtocol where Value == Bool {
 	/// - parameters:
 	///   - property: Collection of properties to be combined.
 	///
-	/// - returns: A property that contains the logial AND results.
+	/// - returns: A property that contains the logical AND results.
 	public static func all<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
 		return Property(initial: properties.map { $0.value }.reduce(true) { $0 && $1 }, then: SignalProducer.all(properties))
 	}
@@ -428,7 +428,7 @@ extension PropertyProtocol where Value == Bool {
 	/// - parameters:
 	///   - property: Property to be combined with `self`.
 	///
-	/// - returns: A property that contains the logial OR results.
+	/// - returns: A property that contains the logical OR results.
 	public func or<P: PropertyProtocol>(_ property: P) -> Property<Value> where P.Value == Value {
 		return self.lift(SignalProducer.or)(property)
 	}
@@ -438,7 +438,7 @@ extension PropertyProtocol where Value == Bool {
 	/// - parameters:
 	///   - properties: Collection of properties to be combined.
 	///
-	/// - returns: A property that contains the logial OR results.
+	/// - returns: A property that contains the logical OR results.
 	public static func any<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
 		return Property(initial: properties.map { $0.value }.reduce(false) { $0 || $1 }, then: SignalProducer.any(properties))
 	}

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -418,7 +418,7 @@ extension PropertyProtocol where Value == Bool {
 	///   - property: Collection of properties to be combined.
 	///
 	/// - returns: A property that contains the logial AND results.
-	public static func and<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
+	public static func all<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
 		return Property(initial: properties.map { $0.value }.reduce(true) { $0 && $1 }, then: SignalProducer.and(properties))
 	}
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -419,7 +419,7 @@ extension PropertyProtocol where Value == Bool {
 	///
 	/// - returns: A property that contains the logial AND results.
 	public static func all<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
-		return Property(initial: properties.map { $0.value }.reduce(true) { $0 && $1 }, then: SignalProducer.and(properties))
+		return Property(initial: properties.map { $0.value }.reduce(true) { $0 && $1 }, then: SignalProducer.all(properties))
 	}
 
 	/// Create a property that computes a logical OR between the latest values of `self`

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -440,7 +440,7 @@ extension PropertyProtocol where Value == Bool {
 	///
 	/// - returns: A property that contains the logial OR results.
 	public static func any<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
-		return Property(initial: properties.map { $0.value }.reduce(false) { $0 || $1 }, then: SignalProducer.or(properties))
+		return Property(initial: properties.map { $0.value }.reduce(false) { $0 || $1 }, then: SignalProducer.any(properties))
 	}
 }
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -419,7 +419,7 @@ extension PropertyProtocol where Value == Bool {
 	///
 	/// - returns: A property that contains the logial AND results.
 	public static func and<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
-		return Property(initial: properties.map { $0.value }.and(), then: SignalProducer.and(properties))
+		return Property(initial: properties.map { $0.value }.reduce(true) { $0 && $1 }, then: SignalProducer.and(properties))
 	}
 
 	/// Create a property that computes a logical OR between the latest values of `self`
@@ -440,7 +440,7 @@ extension PropertyProtocol where Value == Bool {
 	///
 	/// - returns: A property that contains the logial OR results.
 	public static func or<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
-		return Property(initial: properties.map { $0.value }.or(), then: SignalProducer.or(properties))
+		return Property(initial: properties.map { $0.value }.reduce(false) { $0 || $1 }, then: SignalProducer.or(properties))
 	}
 }
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -411,6 +411,16 @@ extension PropertyProtocol where Value == Bool {
 	public func and<P: PropertyProtocol>(_ property: P) -> Property<Value> where P.Value == Value {
 		return self.lift(SignalProducer.and)(property)
 	}
+	
+	/// Create a property that computes a logical AND between the latest values of `properties`.
+	///
+	/// - parameters:
+	///   - property: Collection of properties to be combined.
+	///
+	/// - returns: A property that contains the logial AND results.
+	public static func and<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
+		return Property(initial: properties.map { $0.value }.and(), then: SignalProducer.and(properties))
+	}
 
 	/// Create a property that computes a logical OR between the latest values of `self`
 	/// and `property`.
@@ -423,11 +433,10 @@ extension PropertyProtocol where Value == Bool {
 		return self.lift(SignalProducer.or)(property)
 	}
 	
-	/// Create a property that computes a logical OR between the latest values of `self`
-	/// and `property`.
+	/// Create a property that computes a logical OR between the latest values of `properties`.
 	///
 	/// - parameters:
-	///   - property: Property to be combined with `self`.
+	///   - properties: Collection of properties to be combined.
 	///
 	/// - returns: A property that contains the logial OR results.
 	public static func or<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -2169,7 +2169,7 @@ extension Signal where Value == Bool {
 	///
 	/// - returns: A signal that emits the logical AND results.
 	public static func and<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> Signal<Value, Error> where BooleansCollection.Element == Signal<Value, Error> {
-		return combineLatest(booleans).map { $0.and() }
+		return combineLatest(booleans).map { $0.reduce(true) { $0 && $1 } }
 	}
 
 	/// Create a signal that computes a logical OR between the latest values of `self`
@@ -2190,7 +2190,7 @@ extension Signal where Value == Bool {
 	///
 	/// - returns: A signal that emits the logical OR results.
 	public static func or<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> Signal<Value, Error> where BooleansCollection.Element == Signal<Value, Error> {
-		return combineLatest(booleans).map { $0.or() }
+		return combineLatest(booleans).map { $0.reduce(false) { $0 || $1 } }
 	}
 }
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -2180,7 +2180,7 @@ extension Signal where Value == Bool {
 	///
 	/// - returns: A signal that emits the logical OR results.
 	public func or(_ signal: Signal<Value, Error>) -> Signal<Value, Error> {
-		return type(of: self).or([self, signal])
+		return type(of: self).any([self, signal])
 	}
 	
 	/// Create a signal that computes a logical OR between the latest values of `booleans`.
@@ -2189,7 +2189,7 @@ extension Signal where Value == Bool {
 	///   - booleans: A collection of boolean signals to be combined.
 	///
 	/// - returns: A signal that emits the logical OR results.
-	public static func or<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> Signal<Value, Error> where BooleansCollection.Element == Signal<Value, Error> {
+	public static func any<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> Signal<Value, Error> where BooleansCollection.Element == Signal<Value, Error> {
 		return combineLatest(booleans).map { $0.reduce(false) { $0 || $1 } }
 	}
 }

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -2159,7 +2159,7 @@ extension Signal where Value == Bool {
 	///
 	/// - returns: A signal that emits the logical AND results.
 	public func and(_ signal: Signal<Value, Error>) -> Signal<Value, Error> {
-		return type(of: self).and([self, signal])
+		return type(of: self).all([self, signal])
 	}
 	
 	/// Create a signal that computes a logical AND between the latest values of `booleans`.
@@ -2168,7 +2168,7 @@ extension Signal where Value == Bool {
 	///   - booleans: A collection of boolean signals to be combined.
 	///
 	/// - returns: A signal that emits the logical AND results.
-	public static func and<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> Signal<Value, Error> where BooleansCollection.Element == Signal<Value, Error> {
+	public static func all<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> Signal<Value, Error> where BooleansCollection.Element == Signal<Value, Error> {
 		return combineLatest(booleans).map { $0.reduce(true) { $0 && $1 } }
 	}
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -2159,7 +2159,17 @@ extension Signal where Value == Bool {
 	///
 	/// - returns: A signal that emits the logical AND results.
 	public func and(_ signal: Signal<Value, Error>) -> Signal<Value, Error> {
-		return self.combineLatest(with: signal).map { $0.0 && $0.1 }
+		return type(of: self).and([self, signal])
+	}
+	
+	/// Create a signal that computes a logical AND between the latest values of `booleans`.
+	///
+	/// - parameters:
+	///   - booleans: A collection of boolean signals to be combined.
+	///
+	/// - returns: A signal that emits the logical AND results.
+	public static func and<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> Signal<Value, Error> where BooleansCollection.Element == Signal<Value, Error> {
+		return combineLatest(booleans).map { $0.and() }
 	}
 
 	/// Create a signal that computes a logical OR between the latest values of `self`
@@ -2170,7 +2180,17 @@ extension Signal where Value == Bool {
 	///
 	/// - returns: A signal that emits the logical OR results.
 	public func or(_ signal: Signal<Value, Error>) -> Signal<Value, Error> {
-		return self.combineLatest(with: signal).map { $0.0 || $0.1 }
+		return type(of: self).or([self, signal])
+	}
+	
+	/// Create a signal that computes a logical OR between the latest values of `booleans`.
+	///
+	/// - parameters:
+	///   - booleans: A collection of boolean signals to be combined.
+	///
+	/// - returns: A signal that emits the logical OR results.
+	public static func or<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> Signal<Value, Error> where BooleansCollection.Element == Signal<Value, Error> {
+		return combineLatest(booleans).map { $0.or() }
 	}
 }
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2738,6 +2738,16 @@ extension SignalProducer where Value == Bool {
 	public static func or<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
 		return combineLatest(booleans).map { $0.reduce(false) { $0 || $1 } }
 	}
+	
+	/// Create a producer that computes a logical OR between the latest values of `booleans`.
+	///
+	/// - parameters:
+	///   - booleans: A collection of boolean producers to be combined.
+	///
+	/// - returns: A producer that emits the logical OR results.
+	public static func or<Booleans: SignalProducerConvertible, BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error, BooleansCollection.Element == Booleans {
+		return or(booleans.map { $0.producer })
+	}
 }
 
 /// Represents a recoverable error of an observer not being ready for an

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2714,7 +2714,7 @@ extension SignalProducer where Value == Bool {
 	///
 	/// - returns: A producer that emits the logical AND results.
 	public static func and<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
-		return combineLatest(booleans).map { $0.and() }
+		return combineLatest(booleans).map { $0.reduce(true) { $0 && $1 } }
 	}
 	
 	/// Create a producer that computes a logical AND between the latest values of `booleans`.
@@ -2756,7 +2756,7 @@ extension SignalProducer where Value == Bool {
 	///
 	/// - returns: A producer that emits the logical OR results.
 	public static func or<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
-		return combineLatest(booleans).map { $0.or() }
+		return combineLatest(booleans).map { $0.reduce(false) { $0 || $1 } }
 	}
 	
 	/// Create a producer that computes a logical OR between the latest values of `booleans`.

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2735,7 +2735,7 @@ extension SignalProducer where Value == Bool {
 	///
 	/// - returns: A producer that emits the logical OR results.
 	public func or(_ booleans: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
-		return type(of: self).or([self, booleans])
+		return type(of: self).any([self, booleans])
 	}
 
 	/// Create a producer that computes a logical OR between the latest values of `self`
@@ -2755,7 +2755,7 @@ extension SignalProducer where Value == Bool {
 	///   - booleans: A collection of boolean producers to be combined.
 	///
 	/// - returns: A producer that emits the logical OR results.
-	public static func or<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
+	public static func any<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
 		return combineLatest(booleans).map { $0.reduce(false) { $0 || $1 } }
 	}
 	
@@ -2765,8 +2765,8 @@ extension SignalProducer where Value == Bool {
 	///   - booleans: A collection of boolean producers to be combined.
 	///
 	/// - returns: A producer that emits the logical OR results.
-	public static func or<Booleans: SignalProducerConvertible, BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error, BooleansCollection.Element == Booleans {
-		return or(booleans.map { $0.producer })
+	public static func any<Booleans: SignalProducerConvertible, BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error, BooleansCollection.Element == Booleans {
+		return any(booleans.map { $0.producer })
 	}
 }
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2706,6 +2706,26 @@ extension SignalProducer where Value == Bool {
 	public func and<Booleans: SignalProducerConvertible>(_ booleans: Booleans) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error {
 		return and(booleans.producer)
 	}
+	
+	/// Create a producer that computes a logical AND between the latest values of `booleans`.
+	///
+	/// - parameters:
+	///   - booleans: A collection of boolean producers to be combined.
+	///
+	/// - returns: A producer that emits the logical AND results.
+	public static func and<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
+		return combineLatest(booleans).map { $0.and() }
+	}
+	
+	/// Create a producer that computes a logical AND between the latest values of `booleans`.
+	///
+	/// - parameters:
+	///   - booleans: A collection of boolean producers to be combined.
+	///
+	/// - returns: A producer that emits the logical AND results.
+	public static func and<Booleans: SignalProducerConvertible, BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error, BooleansCollection.Element == Booleans {
+		return and(booleans.map { $0.producer })
+	}
 
 	/// Create a producer that computes a logical OR between the latest values of `self`
 	/// and `producer`.
@@ -2736,7 +2756,7 @@ extension SignalProducer where Value == Bool {
 	///
 	/// - returns: A producer that emits the logical OR results.
 	public static func or<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
-		return combineLatest(booleans).map { $0.reduce(false) { $0 || $1 } }
+		return combineLatest(booleans).map { $0.or() }
 	}
 	
 	/// Create a producer that computes a logical OR between the latest values of `booleans`.

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2693,7 +2693,7 @@ extension SignalProducer where Value == Bool {
 	///
 	/// - returns: A producer that emits the logical AND results.
 	public func and(_ booleans: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
-		return combineLatest(with: booleans).map { $0.0 && $0.1 }
+		return type(of: self).and([self, booleans])
 	}
 
 	/// Create a producer that computes a logical AND between the latest values of `self`

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2715,7 +2715,17 @@ extension SignalProducer where Value == Bool {
 	///
 	/// - returns: A producer that emits the logical OR results.
 	public func or(_ booleans: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
-		return combineLatest(with: booleans).map { $0.0 || $0.1 }
+		return type(of: self).or([self, booleans])
+	}
+	
+	/// Create a producer that computes a logical OR between the latest values of `booleans`.
+	///
+	/// - parameters:
+	///   - booleans: An array of boolean producers to be combined.
+	///
+	/// - returns: A producer that emits the logical OR results.
+	public static func or(_ booleans: [SignalProducer<Value, Error>]) -> SignalProducer<Value, Error> {
+		return combineLatest(booleans).map { $0.reduce(false) { $0 || $1 } }
 	}
 
 	/// Create a producer that computes a logical OR between the latest values of `self`

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2717,16 +2717,6 @@ extension SignalProducer where Value == Bool {
 	public func or(_ booleans: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
 		return type(of: self).or([self, booleans])
 	}
-	
-	/// Create a producer that computes a logical OR between the latest values of `booleans`.
-	///
-	/// - parameters:
-	///   - booleans: An array of boolean producers to be combined.
-	///
-	/// - returns: A producer that emits the logical OR results.
-	public static func or(_ booleans: [SignalProducer<Value, Error>]) -> SignalProducer<Value, Error> {
-		return combineLatest(booleans).map { $0.reduce(false) { $0 || $1 } }
-	}
 
 	/// Create a producer that computes a logical OR between the latest values of `self`
 	/// and `producer`.
@@ -2737,6 +2727,16 @@ extension SignalProducer where Value == Bool {
 	/// - returns: A producer that emits the logical OR results.
 	public func or<Booleans: SignalProducerConvertible>(_ booleans: Booleans) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error {
 		return or(booleans.producer)
+	}
+	
+	/// Create a producer that computes a logical OR between the latest values of `booleans`.
+	///
+	/// - parameters:
+	///   - booleans: A collection of boolean producers to be combined.
+	///
+	/// - returns: A producer that emits the logical OR results.
+	public static func or<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
+		return combineLatest(booleans).map { $0.reduce(false) { $0 || $1 } }
 	}
 }
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2693,7 +2693,7 @@ extension SignalProducer where Value == Bool {
 	///
 	/// - returns: A producer that emits the logical AND results.
 	public func and(_ booleans: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
-		return type(of: self).and([self, booleans])
+		return type(of: self).all([self, booleans])
 	}
 
 	/// Create a producer that computes a logical AND between the latest values of `self`
@@ -2713,7 +2713,7 @@ extension SignalProducer where Value == Bool {
 	///   - booleans: A collection of boolean producers to be combined.
 	///
 	/// - returns: A producer that emits the logical AND results.
-	public static func and<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
+	public static func all<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
 		return combineLatest(booleans).map { $0.reduce(true) { $0 && $1 } }
 	}
 	
@@ -2723,8 +2723,8 @@ extension SignalProducer where Value == Bool {
 	///   - booleans: A collection of boolean producers to be combined.
 	///
 	/// - returns: A producer that emits the logical AND results.
-	public static func and<Booleans: SignalProducerConvertible, BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error, BooleansCollection.Element == Booleans {
-		return and(booleans.map { $0.producer })
+	public static func all<Booleans: SignalProducerConvertible, BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error, BooleansCollection.Element == Booleans {
+		return all(booleans.map { $0.producer })
 	}
 
 	/// Create a producer that computes a logical OR between the latest values of `self`

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -1631,11 +1631,29 @@ class PropertySpec: QuickSpec {
 					let property2 = MutableProperty(true)
 					expect(property1.and(property2).value).to(beTrue())
 				}
+				
+				it("should emit true when all properties contain the same value") {
+					let property1 = MutableProperty(true)
+					let property2 = MutableProperty(true)
+					let property3 = MutableProperty(true)
+					expect(Property.and([property1, property2, property3]).value).to(beTrue())
+				}
 
 				it("should emit false when both properties contains opposite values") {
 					let property1 = MutableProperty(true)
 					let property2 = MutableProperty(false)
 					expect(property1.and(property2).value).to(beFalse())
+				}
+				
+				it("should emit false when all properties contain opposite values") {
+					let property1 = MutableProperty(false)
+					let property2 = MutableProperty(true)
+					let property3 = MutableProperty(true)
+					expect(Property.and([property1, property2, property3]).value).to(beFalse())
+				}
+
+				it("should emit true when array of properties is empty") {
+					expect(Property.and([Property<Bool>]()).value).to(beTrue())
 				}
 			}
 

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -1645,11 +1645,29 @@ class PropertySpec: QuickSpec {
 					let property2 = MutableProperty(false)
 					expect(property1.or(property2).value).to(beTrue())
 				}
+				
+				it("should emit true when at least one of the properties in array contains true") {
+					let property1 = MutableProperty(true)
+					let property2 = MutableProperty(false)
+					let property3 = MutableProperty(false)
+					expect(Property.or([property1, property2, property3]).value).to(beTrue())
+				}
 
 				it("should emit false when both properties contains false") {
 					let property1 = MutableProperty(false)
 					let property2 = MutableProperty(false)
 					expect(property1.or(property2).value).to(beFalse())
+				}
+				
+				it("should emit false when all properties in array contain false") {
+					let property1 = MutableProperty(false)
+					let property2 = MutableProperty(false)
+					let property3 = MutableProperty(false)
+					expect(Property.or([property1, property2, property3]).value).to(beFalse())
+				}
+				
+				it("should emit false when array of properties is empty") {
+					expect(Property.or([Property<Bool>]()).value).to(beFalse())
 				}
 			}
 		}

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -1625,6 +1625,20 @@ class PropertySpec: QuickSpec {
 				}
 			}
 
+			describe("and attribute") {
+				it("should emit true when both properties contains the same value") {
+					let property1 = MutableProperty(true)
+					let property2 = MutableProperty(true)
+					expect(property1.and(property2).value).to(beTrue())
+				}
+
+				it("should emit false when both properties contains opposite values") {
+					let property1 = MutableProperty(true)
+					let property2 = MutableProperty(false)
+					expect(property1.and(property2).value).to(beFalse())
+				}
+			}
+
 			describe("all attribute") {
 				it("should emit true when all properties contain the same value") {
 					let property1 = MutableProperty(true)
@@ -1645,17 +1659,17 @@ class PropertySpec: QuickSpec {
 				}
 			}
 
-			describe("and attribute") {
-				it("should emit true when both properties contains the same value") {
-					let property1 = MutableProperty(true)
-					let property2 = MutableProperty(true)
-					expect(property1.and(property2).value).to(beTrue())
-				}
-
-				it("should emit false when both properties contains opposite values") {
+			describe("or attribute") {
+				it("should emit true when at least one of the properties contains true") {
 					let property1 = MutableProperty(true)
 					let property2 = MutableProperty(false)
-					expect(property1.and(property2).value).to(beFalse())
+					expect(property1.or(property2).value).to(beTrue())
+				}
+
+				it("should emit false when both properties contains false") {
+					let property1 = MutableProperty(false)
+					let property2 = MutableProperty(false)
+					expect(property1.or(property2).value).to(beFalse())
 				}
 			}
 
@@ -1676,20 +1690,6 @@ class PropertySpec: QuickSpec {
 
 				it("should emit false when array of properties is empty") {
 					expect(Property.any([Property<Bool>]()).value).to(beFalse())
-				}
-			}
-
-			describe("or attribute") {
-				it("should emit true when at least one of the properties contains true") {
-					let property1 = MutableProperty(true)
-					let property2 = MutableProperty(false)
-					expect(property1.or(property2).value).to(beTrue())
-				}
-
-				it("should emit false when both properties contains false") {
-					let property1 = MutableProperty(false)
-					let property2 = MutableProperty(false)
-					expect(property1.or(property2).value).to(beFalse())
 				}
 			}
 		}

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -1659,35 +1659,37 @@ class PropertySpec: QuickSpec {
 				}
 			}
 
+			describe("any attribute") {
+				it("should emit true when at least one of the properties in array contains true") {
+					let property1 = MutableProperty(true)
+					let property2 = MutableProperty(false)
+					let property3 = MutableProperty(false)
+					expect(Property.any([property1, property2, property3]).value).to(beTrue())
+				}
+
+				it("should emit false when all properties in array contain false") {
+					let property1 = MutableProperty(false)
+					let property2 = MutableProperty(false)
+					let property3 = MutableProperty(false)
+					expect(Property.any([property1, property2, property3]).value).to(beFalse())
+				}
+
+				it("should emit false when array of properties is empty") {
+					expect(Property.any([Property<Bool>]()).value).to(beFalse())
+				}
+			}
+
 			describe("or attribute") {
 				it("should emit true when at least one of the properties contains true") {
 					let property1 = MutableProperty(true)
 					let property2 = MutableProperty(false)
 					expect(property1.or(property2).value).to(beTrue())
 				}
-				
-				it("should emit true when at least one of the properties in array contains true") {
-					let property1 = MutableProperty(true)
-					let property2 = MutableProperty(false)
-					let property3 = MutableProperty(false)
-					expect(Property.or([property1, property2, property3]).value).to(beTrue())
-				}
 
 				it("should emit false when both properties contains false") {
 					let property1 = MutableProperty(false)
 					let property2 = MutableProperty(false)
 					expect(property1.or(property2).value).to(beFalse())
-				}
-				
-				it("should emit false when all properties in array contain false") {
-					let property1 = MutableProperty(false)
-					let property2 = MutableProperty(false)
-					let property3 = MutableProperty(false)
-					expect(Property.or([property1, property2, property3]).value).to(beFalse())
-				}
-				
-				it("should emit false when array of properties is empty") {
-					expect(Property.or([Property<Bool>]()).value).to(beFalse())
 				}
 			}
 		}

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -1625,35 +1625,37 @@ class PropertySpec: QuickSpec {
 				}
 			}
 
+			describe("all attribute") {
+				it("should emit true when all properties contain the same value") {
+					let property1 = MutableProperty(true)
+					let property2 = MutableProperty(true)
+					let property3 = MutableProperty(true)
+					expect(Property.all([property1, property2, property3]).value).to(beTrue())
+				}
+
+				it("should emit false when all properties contain opposite values") {
+					let property1 = MutableProperty(false)
+					let property2 = MutableProperty(true)
+					let property3 = MutableProperty(true)
+					expect(Property.all([property1, property2, property3]).value).to(beFalse())
+				}
+
+				it("should emit true when array of properties is empty") {
+					expect(Property.all([Property<Bool>]()).value).to(beTrue())
+				}
+			}
+
 			describe("and attribute") {
 				it("should emit true when both properties contains the same value") {
 					let property1 = MutableProperty(true)
 					let property2 = MutableProperty(true)
 					expect(property1.and(property2).value).to(beTrue())
 				}
-				
-				it("should emit true when all properties contain the same value") {
-					let property1 = MutableProperty(true)
-					let property2 = MutableProperty(true)
-					let property3 = MutableProperty(true)
-					expect(Property.and([property1, property2, property3]).value).to(beTrue())
-				}
 
 				it("should emit false when both properties contains opposite values") {
 					let property1 = MutableProperty(true)
 					let property2 = MutableProperty(false)
 					expect(property1.and(property2).value).to(beFalse())
-				}
-				
-				it("should emit false when all properties contain opposite values") {
-					let property1 = MutableProperty(false)
-					let property2 = MutableProperty(true)
-					let property3 = MutableProperty(true)
-					expect(Property.and([property1, property2, property3]).value).to(beFalse())
-				}
-
-				it("should emit true when array of properties is empty") {
-					expect(Property.and([Property<Bool>]()).value).to(beTrue())
 				}
 			}
 

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -2958,8 +2958,27 @@ class SignalProducerSpec: QuickSpec {
 					observer.send(value: true)
 					observer.sendCompleted()
 				}
-
+				
 				producer1.and(producer2).startWithValues { value in
+					expect(value).to(beTrue())
+				}
+			}
+			
+			it("should emit true when all producers emit the same value") {
+				let producer1 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+				let producer2 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+				let producer3 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+				
+				SignalProducer.and([producer1, producer2, producer3]).startWithValues { value in
 					expect(value).to(beTrue())
 				}
 			}
@@ -2973,8 +2992,27 @@ class SignalProducerSpec: QuickSpec {
 					observer.send(value: false)
 					observer.sendCompleted()
 				}
-
+				
 				producer1.and(producer2).startWithValues { value in
+					expect(value).to(beFalse())
+				}
+			}
+			
+			it("should emit false when all producers emit opposite values") {
+				let producer1 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+				let producer2 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+				let producer3 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+				
+				SignalProducer.and([producer1, producer2, producer3]).startWithValues { value in
 					expect(value).to(beFalse())
 				}
 			}
@@ -2989,13 +3027,35 @@ class SignalProducerSpec: QuickSpec {
 					expect(value).to(beTrue())
 				}
 				observer2.send(value: true)
-
+				
 				observer2.sendCompleted()
+			}
+			
+			it("should work the same way when using array of signals instead of an array of producers") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				SignalProducer.and([signal1, signal2, signal3]).startWithValues { value in
+					expect(value).to(beTrue())
+				}
+				observer1.send(value: true)
+				observer1.sendCompleted()
+				observer2.send(value: true)
+				observer2.sendCompleted()
+				observer3.send(value: true)
+				observer3.sendCompleted()
+			}
+			
+			it("should return true for empty array of producers") {
+				SignalProducer.and([]).startWithValues { value in
+					expect(value).to(beTrue())
+				}
 			}
 
 			it("should be able to fallback to SignalProducer for contextual lookups") {
 				_ = SignalProducer<Bool, Never>.empty
 					.and(.init(value: true))
+				_ = SignalProducer<Bool, Never>.and(.init(value: true))
 			}
 		}
 
@@ -3108,8 +3168,7 @@ class SignalProducerSpec: QuickSpec {
 			it("should be able to fallback to SignalProducer for contextual lookups") {
 				_ = SignalProducer<Bool, Never>.empty
 					.or(.init(value: true))
-				_ = SignalProducer<Bool, Never>
-					.or(.init(value: true))
+				_ = SignalProducer<Bool, Never>.or(.init(value: true))
 			}
 		}
 

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -3052,6 +3052,63 @@ class SignalProducerSpec: QuickSpec {
 				_ = SignalProducer<Bool, Never>.and(.init(value: true))
 			}
 		}
+        
+        describe("any attribute") {
+            it("should emit true when at least one of the producers in array emits true") {
+                let producer1 = SignalProducer<Bool, Never> { observer, _ in
+                    observer.send(value: true)
+                    observer.sendCompleted()
+                }
+                let producer2 = SignalProducer<Bool, Never> { observer, _ in
+                    observer.send(value: false)
+                    observer.sendCompleted()
+                }
+                let producer3 = SignalProducer<Bool, Never> { observer, _ in
+                    observer.send(value: false)
+                    observer.sendCompleted()
+                }
+
+                SignalProducer.any([producer1, producer2, producer3]).startWithValues { value in
+                    expect(value).to(beTrue())
+                }
+            }
+
+            it("should emit false when all producers in array emit false") {
+                let producer1 = SignalProducer<Bool, Never> { observer, _ in
+                    observer.send(value: false)
+                    observer.sendCompleted()
+                }
+                let producer2 = SignalProducer<Bool, Never> { observer, _ in
+                    observer.send(value: false)
+                    observer.sendCompleted()
+                }
+                let producer3 = SignalProducer<Bool, Never> { observer, _ in
+                    observer.send(value: false)
+                    observer.sendCompleted()
+                }
+
+                SignalProducer.any([producer1, producer2, producer3]).startWithValues { value in
+                    expect(value).to(beFalse())
+                }
+            }
+
+			it("should work the same way when using array of signals instead of an array of producers") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				let arrayOfSignals = [signal1, signal2, signal3]
+
+				SignalProducer.any(arrayOfSignals).startWithValues { value in
+					expect(value).to(beTrue())
+				}
+				observer1.send(value: true)
+				observer1.sendCompleted()
+				observer2.send(value: true)
+				observer2.sendCompleted()
+				observer3.send(value: true)
+				observer3.sendCompleted()
+			}
+        }
 
 		describe("or attribute") {
 			it("should emit true when at least one of the producers emits true") {
@@ -3065,25 +3122,6 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				producer1.or(producer2).startWithValues { value in
-					expect(value).to(beTrue())
-				}
-			}
-			
-			it("should emit true when at least one of the producers in array emits true") {
-				let producer1 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: true)
-					observer.sendCompleted()
-				}
-				let producer2 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: false)
-					observer.sendCompleted()
-				}
-				let producer3 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: false)
-					observer.sendCompleted()
-				}
-				
-				SignalProducer.or([producer1, producer2, producer3]).startWithValues { value in
 					expect(value).to(beTrue())
 				}
 			}
@@ -3102,25 +3140,6 @@ class SignalProducerSpec: QuickSpec {
 					expect(value).to(beFalse())
 				}
 			}
-			
-			it("should emit false when all producers in array emit false") {
-				let producer1 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: false)
-					observer.sendCompleted()
-				}
-				let producer2 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: false)
-					observer.sendCompleted()
-				}
-				let producer3 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: false)
-					observer.sendCompleted()
-				}
-				
-				SignalProducer.or([producer1, producer2, producer3]).startWithValues { value in
-					expect(value).to(beFalse())
-				}
-			}
 
 			it("should work the same way when using signal instead of a producer") {
 				let producer1 = SignalProducer<Bool, Never> { observer, _ in
@@ -3134,23 +3153,6 @@ class SignalProducerSpec: QuickSpec {
 				observer2.send(value: true)
 				
 				observer2.sendCompleted()
-			}
-			
-			it("should work the same way when using array of signals instead of an array of producers") {
-				let (signal1, observer1) = Signal<Bool, Never>.pipe()
-				let (signal2, observer2) = Signal<Bool, Never>.pipe()
-				let (signal3, observer3) = Signal<Bool, Never>.pipe()
-				let arrayOfSignals = [signal1, signal2, signal3]
-				
-				SignalProducer.or(arrayOfSignals).startWithValues { value in
-					expect(value).to(beTrue())
-				}
-				observer1.send(value: true)
-				observer1.sendCompleted()
-				observer2.send(value: true)
-				observer2.sendCompleted()
-				observer3.send(value: true)
-				observer3.sendCompleted()
 			}
 
 			it("should be able to fallback to SignalProducer for contextual lookups") {

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -2947,23 +2947,8 @@ class SignalProducerSpec: QuickSpec {
 				}
 			}
 		}
-
-		describe("and attribute") {
-			it("should emit true when both producers emits the same value") {
-				let producer1 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: true)
-					observer.sendCompleted()
-				}
-				let producer2 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: true)
-					observer.sendCompleted()
-				}
-
-				producer1.and(producer2).startWithValues { value in
-					expect(value).to(beTrue())
-				}
-			}
-			
+		
+		describe("all attribute") {
 			it("should emit true when all producers emit the same value") {
 				let producer1 = SignalProducer<Bool, Never> { observer, _ in
 					observer.send(value: true)
@@ -2977,8 +2962,59 @@ class SignalProducerSpec: QuickSpec {
 					observer.send(value: true)
 					observer.sendCompleted()
 				}
-				
-				SignalProducer.and([producer1, producer2, producer3]).startWithValues { value in
+
+				SignalProducer.all([producer1, producer2, producer3]).startWithValues { value in
+					expect(value).to(beTrue())
+				}
+			}
+
+			it("should emit false when all producers emit opposite values") {
+				let producer1 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+				let producer2 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+				let producer3 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+
+				SignalProducer.all([producer1, producer2, producer3]).startWithValues { value in
+					expect(value).to(beFalse())
+				}
+			}
+
+			it("should work the same way when using array of signals instead of an array of producers") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				SignalProducer.all([signal1, signal2, signal3]).startWithValues { value in
+					expect(value).to(beTrue())
+				}
+				observer1.send(value: true)
+				observer1.sendCompleted()
+				observer2.send(value: true)
+				observer2.sendCompleted()
+				observer3.send(value: true)
+				observer3.sendCompleted()
+			}
+		}
+
+		describe("and attribute") {
+			it("should emit true when both producers emits the same value") {
+				let producer1 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+				let producer2 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+
+				producer1.and(producer2).startWithValues { value in
 					expect(value).to(beTrue())
 				}
 			}
@@ -2997,25 +3033,6 @@ class SignalProducerSpec: QuickSpec {
 					expect(value).to(beFalse())
 				}
 			}
-			
-			it("should emit false when all producers emit opposite values") {
-				let producer1 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: true)
-					observer.sendCompleted()
-				}
-				let producer2 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: false)
-					observer.sendCompleted()
-				}
-				let producer3 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: false)
-					observer.sendCompleted()
-				}
-				
-				SignalProducer.and([producer1, producer2, producer3]).startWithValues { value in
-					expect(value).to(beFalse())
-				}
-			}
 
 			it("should work the same way when using signal instead of a producer") {
 				let producer1 = SignalProducer<Bool, Never> { observer, _ in
@@ -3029,21 +3046,6 @@ class SignalProducerSpec: QuickSpec {
 				observer2.send(value: true)
 
 				observer2.sendCompleted()
-			}
-			
-			it("should work the same way when using array of signals instead of an array of producers") {
-				let (signal1, observer1) = Signal<Bool, Never>.pipe()
-				let (signal2, observer2) = Signal<Bool, Never>.pipe()
-				let (signal3, observer3) = Signal<Bool, Never>.pipe()
-				SignalProducer.and([signal1, signal2, signal3]).startWithValues { value in
-					expect(value).to(beTrue())
-				}
-				observer1.send(value: true)
-				observer1.sendCompleted()
-				observer2.send(value: true)
-				observer2.sendCompleted()
-				observer3.send(value: true)
-				observer3.sendCompleted()
 			}
 
 			it("should be able to fallback to SignalProducer for contextual lookups") {

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -3067,6 +3067,12 @@ class SignalProducerSpec: QuickSpec {
 					expect(value).to(beFalse())
 				}
 			}
+			
+			it("should emit false when array of producers is empty") {
+				SignalProducer.or([]).startWithValues { value in
+					expect(value).to(beFalse())
+				}
+			}
 
 			it("should work the same way when using signal instead of a producer") {
 				let producer1 = SignalProducer<Bool, Never> { observer, _ in

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -2958,7 +2958,7 @@ class SignalProducerSpec: QuickSpec {
 					observer.send(value: true)
 					observer.sendCompleted()
 				}
-				
+
 				producer1.and(producer2).startWithValues { value in
 					expect(value).to(beTrue())
 				}
@@ -2992,7 +2992,7 @@ class SignalProducerSpec: QuickSpec {
 					observer.send(value: false)
 					observer.sendCompleted()
 				}
-				
+
 				producer1.and(producer2).startWithValues { value in
 					expect(value).to(beFalse())
 				}
@@ -3027,7 +3027,7 @@ class SignalProducerSpec: QuickSpec {
 					expect(value).to(beTrue())
 				}
 				observer2.send(value: true)
-				
+
 				observer2.sendCompleted()
 			}
 			

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -3045,12 +3045,6 @@ class SignalProducerSpec: QuickSpec {
 				observer3.send(value: true)
 				observer3.sendCompleted()
 			}
-			
-			it("should return true for empty array of producers") {
-				SignalProducer.and([]).startWithValues { value in
-					expect(value).to(beTrue())
-				}
-			}
 
 			it("should be able to fallback to SignalProducer for contextual lookups") {
 				_ = SignalProducer<Bool, Never>.empty
@@ -3124,12 +3118,6 @@ class SignalProducerSpec: QuickSpec {
 				}
 				
 				SignalProducer.or([producer1, producer2, producer3]).startWithValues { value in
-					expect(value).to(beFalse())
-				}
-			}
-			
-			it("should emit false when array of producers is empty") {
-				SignalProducer.or([]).startWithValues { value in
 					expect(value).to(beFalse())
 				}
 			}

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -2947,7 +2947,59 @@ class SignalProducerSpec: QuickSpec {
 				}
 			}
 		}
-		
+
+		describe("and attribute") {
+			it("should emit true when both producers emits the same value") {
+				let producer1 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+				let producer2 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+
+				producer1.and(producer2).startWithValues { value in
+					expect(value).to(beTrue())
+				}
+			}
+
+			it("should emit false when both producers emits opposite values") {
+				let producer1 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+				let producer2 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+
+				producer1.and(producer2).startWithValues { value in
+					expect(value).to(beFalse())
+				}
+			}
+
+			it("should work the same way when using signal instead of a producer") {
+				let producer1 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				producer1.and(signal2).startWithValues { value in
+					expect(value).to(beTrue())
+				}
+				observer2.send(value: true)
+
+				observer2.sendCompleted()
+			}
+
+			it("should be able to fallback to SignalProducer for contextual lookups") {
+				_ = SignalProducer<Bool, Never>.empty
+					.and(.init(value: true))
+				_ = SignalProducer<Bool, Never>.and(.init(value: true))
+			}
+		}
+
 		describe("all attribute") {
 			it("should emit true when all producers emit the same value") {
 				let producer1 = SignalProducer<Bool, Never> { observer, _ in
@@ -3003,115 +3055,6 @@ class SignalProducerSpec: QuickSpec {
 			}
 		}
 
-		describe("and attribute") {
-			it("should emit true when both producers emits the same value") {
-				let producer1 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: true)
-					observer.sendCompleted()
-				}
-				let producer2 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: true)
-					observer.sendCompleted()
-				}
-
-				producer1.and(producer2).startWithValues { value in
-					expect(value).to(beTrue())
-				}
-			}
-
-			it("should emit false when both producers emits opposite values") {
-				let producer1 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: true)
-					observer.sendCompleted()
-				}
-				let producer2 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: false)
-					observer.sendCompleted()
-				}
-
-				producer1.and(producer2).startWithValues { value in
-					expect(value).to(beFalse())
-				}
-			}
-
-			it("should work the same way when using signal instead of a producer") {
-				let producer1 = SignalProducer<Bool, Never> { observer, _ in
-					observer.send(value: true)
-					observer.sendCompleted()
-				}
-				let (signal2, observer2) = Signal<Bool, Never>.pipe()
-				producer1.and(signal2).startWithValues { value in
-					expect(value).to(beTrue())
-				}
-				observer2.send(value: true)
-
-				observer2.sendCompleted()
-			}
-
-			it("should be able to fallback to SignalProducer for contextual lookups") {
-				_ = SignalProducer<Bool, Never>.empty
-					.and(.init(value: true))
-				_ = SignalProducer<Bool, Never>.and(.init(value: true))
-			}
-		}
-        
-        describe("any attribute") {
-            it("should emit true when at least one of the producers in array emits true") {
-                let producer1 = SignalProducer<Bool, Never> { observer, _ in
-                    observer.send(value: true)
-                    observer.sendCompleted()
-                }
-                let producer2 = SignalProducer<Bool, Never> { observer, _ in
-                    observer.send(value: false)
-                    observer.sendCompleted()
-                }
-                let producer3 = SignalProducer<Bool, Never> { observer, _ in
-                    observer.send(value: false)
-                    observer.sendCompleted()
-                }
-
-                SignalProducer.any([producer1, producer2, producer3]).startWithValues { value in
-                    expect(value).to(beTrue())
-                }
-            }
-
-            it("should emit false when all producers in array emit false") {
-                let producer1 = SignalProducer<Bool, Never> { observer, _ in
-                    observer.send(value: false)
-                    observer.sendCompleted()
-                }
-                let producer2 = SignalProducer<Bool, Never> { observer, _ in
-                    observer.send(value: false)
-                    observer.sendCompleted()
-                }
-                let producer3 = SignalProducer<Bool, Never> { observer, _ in
-                    observer.send(value: false)
-                    observer.sendCompleted()
-                }
-
-                SignalProducer.any([producer1, producer2, producer3]).startWithValues { value in
-                    expect(value).to(beFalse())
-                }
-            }
-
-			it("should work the same way when using array of signals instead of an array of producers") {
-				let (signal1, observer1) = Signal<Bool, Never>.pipe()
-				let (signal2, observer2) = Signal<Bool, Never>.pipe()
-				let (signal3, observer3) = Signal<Bool, Never>.pipe()
-				let arrayOfSignals = [signal1, signal2, signal3]
-
-				SignalProducer.any(arrayOfSignals).startWithValues { value in
-					expect(value).to(beTrue())
-				}
-				observer1.send(value: true)
-				observer1.sendCompleted()
-				observer2.send(value: true)
-				observer2.sendCompleted()
-				observer3.send(value: true)
-				observer3.sendCompleted()
-			}
-        }
-
 		describe("or attribute") {
 			it("should emit true when at least one of the producers emits true") {
 				let producer1 = SignalProducer<Bool, Never> { observer, _ in
@@ -3161,6 +3104,63 @@ class SignalProducerSpec: QuickSpec {
 				_ = SignalProducer<Bool, Never>.empty
 					.or(.init(value: true))
 				_ = SignalProducer<Bool, Never>.or(.init(value: true))
+			}
+		}
+
+		describe("any attribute") {
+			it("should emit true when at least one of the producers in array emits true") {
+				let producer1 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+				let producer2 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+				let producer3 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+
+				SignalProducer.any([producer1, producer2, producer3]).startWithValues { value in
+					expect(value).to(beTrue())
+				}
+			}
+			
+			it("should emit false when all producers in array emit false") {
+				let producer1 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+				let producer2 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+				let producer3 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+
+				SignalProducer.any([producer1, producer2, producer3]).startWithValues { value in
+					expect(value).to(beFalse())
+				}
+			}
+			
+			it("should work the same way when using array of signals instead of an array of producers") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				let arrayOfSignals = [signal1, signal2, signal3]
+
+				SignalProducer.any(arrayOfSignals).startWithValues { value in
+					expect(value).to(beTrue())
+				}
+				observer1.send(value: true)
+				observer1.sendCompleted()
+				observer2.send(value: true)
+				observer2.sendCompleted()
+				observer3.send(value: true)
+				observer3.sendCompleted()
 			}
 		}
 

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -3096,7 +3096,7 @@ class SignalProducerSpec: QuickSpec {
 					expect(value).to(beTrue())
 				}
 				observer2.send(value: true)
-				
+
 				observer2.sendCompleted()
 			}
 

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -3014,6 +3014,25 @@ class SignalProducerSpec: QuickSpec {
 					expect(value).to(beTrue())
 				}
 			}
+			
+			it("should emit true when at least one of the producers in array emits true") {
+				let producer1 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: true)
+					observer.sendCompleted()
+				}
+				let producer2 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+				let producer3 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+				
+				SignalProducer.or([producer1, producer2, producer3]).startWithValues { value in
+					expect(value).to(beTrue())
+				}
+			}
 
 			it("should emit false when both producers emits false") {
 				let producer1 = SignalProducer<Bool, Never> { observer, _ in
@@ -3029,6 +3048,25 @@ class SignalProducerSpec: QuickSpec {
 					expect(value).to(beFalse())
 				}
 			}
+			
+			it("should emit false when all producers in array emit false") {
+				let producer1 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+				let producer2 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+				let producer3 = SignalProducer<Bool, Never> { observer, _ in
+					observer.send(value: false)
+					observer.sendCompleted()
+				}
+				
+				SignalProducer.or([producer1, producer2, producer3]).startWithValues { value in
+					expect(value).to(beFalse())
+				}
+			}
 
 			it("should work the same way when using signal instead of a producer") {
 				let producer1 = SignalProducer<Bool, Never> { observer, _ in
@@ -3040,12 +3078,31 @@ class SignalProducerSpec: QuickSpec {
 					expect(value).to(beTrue())
 				}
 				observer2.send(value: true)
-
+				
 				observer2.sendCompleted()
+			}
+			
+			it("should work the same way when using array of signals instead of an array of producers") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				let arrayOfSignals = [signal1, signal2, signal3]
+				
+				SignalProducer.or(arrayOfSignals).startWithValues { value in
+					expect(value).to(beTrue())
+				}
+				observer1.send(value: true)
+				observer1.sendCompleted()
+				observer2.send(value: true)
+				observer2.sendCompleted()
+				observer3.send(value: true)
+				observer3.sendCompleted()
 			}
 
 			it("should be able to fallback to SignalProducer for contextual lookups") {
 				_ = SignalProducer<Bool, Never>.empty
+					.or(.init(value: true))
+				_ = SignalProducer<Bool, Never>
 					.or(.init(value: true))
 			}
 		}

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -3748,22 +3748,6 @@ class SignalSpec: QuickSpec {
 				observer2.sendCompleted()
 			}
 
-			it("should emit true when all signals emit the same value") {
-				let (signal1, observer1) = Signal<Bool, Never>.pipe()
-				let (signal2, observer2) = Signal<Bool, Never>.pipe()
-				let (signal3, observer3) = Signal<Bool, Never>.pipe()
-				Signal.and([signal1, signal2, signal3]).observeValues { value in
-					expect(value).to(beTrue())
-				}
-				observer1.send(value: true)
-				observer2.send(value: true)
-				observer3.send(value: true)
-
-				observer1.sendCompleted()
-				observer2.sendCompleted()
-				observer3.sendCompleted()
-			}
-
 			it("should emit false when both signals emits opposite values") {
 				let (signal1, observer1) = Signal<Bool, Never>.pipe()
 				let (signal2, observer2) = Signal<Bool, Never>.pipe()
@@ -3776,17 +3760,35 @@ class SignalSpec: QuickSpec {
 				observer1.sendCompleted()
 				observer2.sendCompleted()
 			}
-
+		}
+		
+		describe("all attribute") {
 			it("should emit false when any signal emits opposite values") {
 				let (signal1, observer1) = Signal<Bool, Never>.pipe()
 				let (signal2, observer2) = Signal<Bool, Never>.pipe()
 				let (signal3, observer3) = Signal<Bool, Never>.pipe()
-				Signal.and([signal1, signal2, signal3]).observeValues { value in
+				Signal.all([signal1, signal2, signal3]).observeValues { value in
 					expect(value).to(beFalse())
 				}
 				observer1.send(value: false)
 				observer2.send(value: true)
 				observer3.send(value: false)
+
+				observer1.sendCompleted()
+				observer2.sendCompleted()
+				observer3.sendCompleted()
+			}
+
+			it("should emit true when all signals emit the same value") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				Signal.all([signal1, signal2, signal3]).observeValues { value in
+					expect(value).to(beTrue())
+				}
+				observer1.send(value: true)
+				observer2.send(value: true)
+				observer3.send(value: true)
 
 				observer1.sendCompleted()
 				observer2.sendCompleted()

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -3796,40 +3796,6 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
-		describe("any attribute") {
-			it("should emit true when at least one of the signals in array emits true") {
-				let (signal1, observer1) = Signal<Bool, Never>.pipe()
-				let (signal2, observer2) = Signal<Bool, Never>.pipe()
-				let (signal3, observer3) = Signal<Bool, Never>.pipe()
-				Signal.any([signal1, signal2, signal3]).observeValues { value in
-					expect(value).to(beTrue())
-				}
-				observer1.send(value: true)
-				observer2.send(value: false)
-				observer3.send(value: false)
-				
-				observer1.sendCompleted()
-				observer2.sendCompleted()
-				observer3.sendCompleted()
-			}
-
-			it("should emit false when all signals in array emits false") {
-				let (signal1, observer1) = Signal<Bool, Never>.pipe()
-				let (signal2, observer2) = Signal<Bool, Never>.pipe()
-				let (signal3, observer3) = Signal<Bool, Never>.pipe()
-				Signal.any([signal1, signal2, signal3]).observeValues { value in
-					expect(value).to(beFalse())
-				}
-				observer1.send(value: false)
-				observer2.send(value: false)
-				observer3.send(value: false)
-				
-				observer1.sendCompleted()
-				observer2.sendCompleted()
-				observer3.sendCompleted()
-			}
-		}
-
 		describe("or attribute") {
 			it("should emit true when at least one of the signals emits true") {
 				let (signal1, observer1) = Signal<Bool, Never>.pipe()
@@ -3855,6 +3821,40 @@ class SignalSpec: QuickSpec {
 
 				observer1.sendCompleted()
 				observer2.sendCompleted()
+			}
+		}
+
+		describe("any attribute") {
+			it("should emit true when at least one of the signals in array emits true") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				Signal.any([signal1, signal2, signal3]).observeValues { value in
+					expect(value).to(beTrue())
+				}
+				observer1.send(value: true)
+				observer2.send(value: false)
+				observer3.send(value: false)
+
+				observer1.sendCompleted()
+				observer2.sendCompleted()
+				observer3.sendCompleted()
+			}
+			
+			it("should emit false when all signals in array emits false") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				Signal.any([signal1, signal2, signal3]).observeValues { value in
+					expect(value).to(beFalse())
+				}
+				observer1.send(value: false)
+				observer2.send(value: false)
+				observer3.send(value: false)
+
+				observer1.sendCompleted()
+				observer2.sendCompleted()
+				observer3.sendCompleted()
 			}
 		}
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -3748,6 +3748,22 @@ class SignalSpec: QuickSpec {
 				observer2.sendCompleted()
 			}
 
+			it("should emit true when all signals emit the same value") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				Signal.and([signal1, signal2, signal3]).observeValues { value in
+					expect(value).to(beTrue())
+				}
+				observer1.send(value: true)
+				observer2.send(value: true)
+				observer3.send(value: true)
+
+				observer1.sendCompleted()
+				observer2.sendCompleted()
+				observer3.sendCompleted()
+			}
+
 			it("should emit false when both signals emits opposite values") {
 				let (signal1, observer1) = Signal<Bool, Never>.pipe()
 				let (signal2, observer2) = Signal<Bool, Never>.pipe()
@@ -3759,6 +3775,22 @@ class SignalSpec: QuickSpec {
 
 				observer1.sendCompleted()
 				observer2.sendCompleted()
+			}
+
+			it("should emit false when any signal emits opposite values") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				Signal.and([signal1, signal2, signal3]).observeValues { value in
+					expect(value).to(beFalse())
+				}
+				observer1.send(value: false)
+				observer2.send(value: true)
+				observer3.send(value: false)
+
+				observer1.sendCompleted()
+				observer2.sendCompleted()
+				observer3.sendCompleted()
 			}
 		}
 
@@ -3819,12 +3851,6 @@ class SignalSpec: QuickSpec {
 				observer1.sendCompleted()
 				observer2.sendCompleted()
 				observer3.sendCompleted()
-			}
-
-			it("should emit false when collection of signals is empty") {
-				Signal.or([]).observeValues { value in
-					expect(value).to(beFalse())
-				}
 			}
 		}
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -3794,6 +3794,40 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
+		describe("any attribute") {
+			it("should emit true when at least one of the signals in array emits true") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				Signal.any([signal1, signal2, signal3]).observeValues { value in
+					expect(value).to(beTrue())
+				}
+				observer1.send(value: true)
+				observer2.send(value: false)
+				observer3.send(value: false)
+				
+				observer1.sendCompleted()
+				observer2.sendCompleted()
+				observer3.sendCompleted()
+			}
+
+			it("should emit false when all signals in array emits false") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				Signal.any([signal1, signal2, signal3]).observeValues { value in
+					expect(value).to(beFalse())
+				}
+				observer1.send(value: false)
+				observer2.send(value: false)
+				observer3.send(value: false)
+				
+				observer1.sendCompleted()
+				observer2.sendCompleted()
+				observer3.sendCompleted()
+			}
+		}
+
 		describe("or attribute") {
 			it("should emit true when at least one of the signals emits true") {
 				let (signal1, observer1) = Signal<Bool, Never>.pipe()
@@ -3808,22 +3842,6 @@ class SignalSpec: QuickSpec {
 				observer2.sendCompleted()
 			}
 
-			it("should emit true when at least one of the signals in array emits true") {
-				let (signal1, observer1) = Signal<Bool, Never>.pipe()
-				let (signal2, observer2) = Signal<Bool, Never>.pipe()
-				let (signal3, observer3) = Signal<Bool, Never>.pipe()
-				Signal.or([signal1, signal2, signal3]).observeValues { value in
-					expect(value).to(beTrue())
-				}
-				observer1.send(value: true)
-				observer2.send(value: false)
-				observer3.send(value: false)
-
-				observer1.sendCompleted()
-				observer2.sendCompleted()
-				observer3.sendCompleted()
-			}
-
 			it("should emit false when both signals emits false") {
 				let (signal1, observer1) = Signal<Bool, Never>.pipe()
 				let (signal2, observer2) = Signal<Bool, Never>.pipe()
@@ -3835,22 +3853,6 @@ class SignalSpec: QuickSpec {
 
 				observer1.sendCompleted()
 				observer2.sendCompleted()
-			}
-
-			it("should emit false when all signals in array emits false") {
-				let (signal1, observer1) = Signal<Bool, Never>.pipe()
-				let (signal2, observer2) = Signal<Bool, Never>.pipe()
-				let (signal3, observer3) = Signal<Bool, Never>.pipe()
-				Signal.or([signal1, signal2, signal3]).observeValues { value in
-					expect(value).to(beFalse())
-				}
-				observer1.send(value: false)
-				observer2.send(value: false)
-				observer3.send(value: false)
-
-				observer1.sendCompleted()
-				observer2.sendCompleted()
-				observer3.sendCompleted()
 			}
 		}
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -3776,6 +3776,22 @@ class SignalSpec: QuickSpec {
 				observer2.sendCompleted()
 			}
 
+			it("should emit true when at least one of the signals in array emits true") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				Signal.or([signal1, signal2, signal3]).observeValues { value in
+					expect(value).to(beTrue())
+				}
+				observer1.send(value: true)
+				observer2.send(value: false)
+				observer3.send(value: false)
+
+				observer1.sendCompleted()
+				observer2.sendCompleted()
+				observer3.sendCompleted()
+			}
+
 			it("should emit false when both signals emits false") {
 				let (signal1, observer1) = Signal<Bool, Never>.pipe()
 				let (signal2, observer2) = Signal<Bool, Never>.pipe()
@@ -3787,6 +3803,28 @@ class SignalSpec: QuickSpec {
 
 				observer1.sendCompleted()
 				observer2.sendCompleted()
+			}
+
+			it("should emit false when all signals in array emits false") {
+				let (signal1, observer1) = Signal<Bool, Never>.pipe()
+				let (signal2, observer2) = Signal<Bool, Never>.pipe()
+				let (signal3, observer3) = Signal<Bool, Never>.pipe()
+				Signal.or([signal1, signal2, signal3]).observeValues { value in
+					expect(value).to(beFalse())
+				}
+				observer1.send(value: false)
+				observer2.send(value: false)
+				observer3.send(value: false)
+
+				observer1.sendCompleted()
+				observer2.sendCompleted()
+				observer3.sendCompleted()
+			}
+
+			it("should emit false when collection of signals is empty") {
+				Signal.or([]).observeValues { value in
+					expect(value).to(beFalse())
+				}
 			}
 		}
 


### PR DESCRIPTION
Usually on my projects I do use more properties to determine state of some `Property`, e.g. `isLoading` property usually depends on more properties which later on ends like this
```
action1.isExecuting.or(action2.isExecuting)...or(actionX.isExecuting)
```
Then I end up with extensions which simplify such code and I think it might be useful for more people than just me.

This PR adds static function `and` and `or` to `SignalProducer`, `PropertyProtocol` with appropriate attributes which solves such case elegantly.

#### Checklist
- [x] Updated CHANGELOG.md.
