### PR TITLE
Cherry-pick fix for Xcode 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # master
 *Please add new entries at the top.*
 
+# 6.0.1
+
+1. Add support for Xcode 11 / Swift 5.1 (#739, kudos to @NachoSoto)
+
+
 # 6.0.0
 1. Dropped support for Swift 4.2 (Xcode 9)
 2. Removed dependency on https://github.com/antitypical/Result (#702, kudos to @NachoSoto and @mdiep)

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -1015,17 +1015,23 @@ extension Signal.Event where Value == Never {
 	internal static func promoteValue<U>(_: U.Type) -> Transformation<U, Error> {
 		return { action, _ in
 			return { event in
-				switch event {
-				case .value:
-					fatalError("Never is impossible to construct")
-				case let .failed(error):
-					action(.failed(error))
-				case .completed:
-					action(.completed)
-				case .interrupted:
-					action(.interrupted)
-				}
+                action(event.promoteValue())
 			}
 		}
 	}
+}
+
+extension Signal.Event where Value == Never {
+	internal func promoteValue<U>() -> Signal<U, Error>.Event {
+        switch event {
+        case .value:
+            fatalError("Never is impossible to construct")
+        case let .failed(error):
+            return .failed(error)
+        case .completed:
+            return .completed
+        case .interrupted:
+            return .interrupted
+        }
+    }
 }

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -1015,7 +1015,7 @@ extension Signal.Event where Value == Never {
 	internal static func promoteValue<U>(_: U.Type) -> Transformation<U, Error> {
 		return { action, _ in
 			return { event in
-                action(event.promoteValue())
+				action(event.promoteValue())
 			}
 		}
 	}

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1848,7 +1848,7 @@ extension Signal {
 			}
 
 			for (index, action) in builder.startHandlers.enumerated() where !lifetime.hasEnded {
-				lifetime += action(index, strategy) { observer.send($0.map { _ in fatalError() }) }
+				lifetime += action(index, strategy) { observer.send($0.promoteValue()) }
 			}
 		}
 	}


### PR DESCRIPTION
This cherry-picks #739 onto a new branch based on 6.0.0. Was thinking it might be nice to release a patch for Swift 5.1 support without including the new features on master.

#### Checklist
- [x] Updated CHANGELOG.md.
