### PR TITLE
Replace the `NoError` type with `Never` in documentation

### DIFF
--- a/Documentation/APIContracts.md
+++ b/Documentation/APIContracts.md
@@ -107,7 +107,7 @@ Consequently, failures should only be used to represent “abnormal” terminati
 event describing the result might be more appropriate.
 
 If an event stream can _never_ fail, it should be parameterized with the
-special [`NoError`][NoError] type, which statically guarantees that a `failed`
+special `Never` type, which statically guarantees that a `failed`
 event cannot be sent upon the stream.
 
 #### `completion` indicates success
@@ -545,7 +545,6 @@ synchronously retrieve one or more values from a stream, like `single()` or
 [Disposables]: FrameworkOverview.md#disposables
 [Events]: FrameworkOverview.md#events
 [Framework Overview]: FrameworkOverview.md
-[NoError]: ../Sources/Errors.swift
 [Observers]: FrameworkOverview.md#observers
 [Operators]: BasicOperators.md
 [Properties]: FrameworkOverview.md#properties

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -140,7 +140,7 @@ The `map` operator is used to transform the values in an event stream, creating
 a new stream with the results.
 
 ```Swift
-let (signal, observer) = Signal<String, NoError>.pipe()
+let (signal, observer) = Signal<String, Never>.pipe()
 
 signal
     .map { string in string.uppercased() }
@@ -159,7 +159,7 @@ The `filter` operator is used to only include values in an event stream that
 satisfy a predicate.
 
 ```Swift
-let (signal, observer) = Signal<Int, NoError>.pipe()
+let (signal, observer) = Signal<Int, Never>.pipe()
 
 signal
     .filter { number in number % 2 == 0 }
@@ -180,7 +180,7 @@ combined value. Note that the final value is only sent after the input stream
 completes.
 
 ```Swift
-let (signal, observer) = Signal<Int, NoError>.pipe()
+let (signal, observer) = Signal<Int, Never>.pipe()
 
 signal
     .reduce(1) { $0 * $1 }
@@ -197,7 +197,7 @@ a single array value. Note that the final value is only sent after the input
 stream completes.
 
 ```Swift
-let (signal, observer) = Signal<Int, NoError>.pipe()
+let (signal, observer) = Signal<Int, Never>.pipe()
 
 signal
     .collect()
@@ -226,8 +226,8 @@ least one value. After that, new values on any of the inputs will result in
 a new value on the output.
 
 ```Swift
-let (numbersSignal, numbersObserver) = Signal<Int, NoError>.pipe()
-let (lettersSignal, lettersObserver) = Signal<String, NoError>.pipe()
+let (numbersSignal, numbersObserver) = Signal<Int, Never>.pipe()
+let (lettersSignal, lettersObserver) = Signal<String, Never>.pipe()
 
 let signal = Signal.combineLatest(numbersSignal, lettersSignal)
 signal.observeValues { next in print("Next: \(next)") }
@@ -256,8 +256,8 @@ That means the Nth value of the output stream cannot be sent until each input
 has sent at least N values.
 
 ```Swift
-let (numbersSignal, numbersObserver) = Signal<Int, NoError>.pipe()
-let (lettersSignal, lettersObserver) = Signal<String, NoError>.pipe()
+let (numbersSignal, numbersObserver) = Signal<Int, Never>.pipe()
+let (lettersSignal, lettersObserver) = Signal<String, Never>.pipe()
 
 let signal = Signal.zip(numbersSignal, lettersSignal)
 signal.observeValues { next in print("Next: \(next)") }
@@ -309,9 +309,9 @@ Note, how the values interleave and which values are even included in the result
 The `.merge` strategy immediately forwards every value of the inner event streams to the outer event stream. Any failure sent on the outer event stream or any inner event stream is immediately sent on the flattened event stream and terminates it.
 
 ```Swift
-let (lettersSignal, lettersObserver) = Signal<String, NoError>.pipe()
-let (numbersSignal, numbersObserver) = Signal<String, NoError>.pipe()
-let (signal, observer) = Signal<Signal<String, NoError>, NoError>.pipe()
+let (lettersSignal, lettersObserver) = Signal<String, Never>.pipe()
+let (numbersSignal, numbersObserver) = Signal<String, Never>.pipe()
+let (signal, observer) = Signal<Signal<String, Never>, Never>.pipe()
 
 signal.flatten(.merge).observeValues { print($0) }
 
@@ -334,9 +334,9 @@ numbersObserver.send(value: "3")    // prints "3"
 The `.concat` strategy is used to serialize events of the inner event streams. The outer event stream is started observed. Each subsequent event stream is not observed until the preceeding one has completed. Failures are immediately forwarded to the flattened event stream.
 
 ```Swift
-let (lettersSignal, lettersObserver) = Signal<String, NoError>.pipe()
-let (numbersSignal, numbersObserver) = Signal<String, NoError>.pipe()
-let (signal, observer) = Signal<Signal<String, NoError>, NoError>.pipe()
+let (lettersSignal, lettersObserver) = Signal<String, Never>.pipe()
+let (numbersSignal, numbersObserver) = Signal<String, Never>.pipe()
+let (signal, observer) = Signal<Signal<String, Never>, Never>.pipe()
 
 signal.flatten(.concat).observeValues { print($0) }
 
@@ -361,9 +361,9 @@ numbersObserver.sendCompleted()     // nothing printed
 The `.latest` strategy forwards only values or a failure from the latest input event stream.
 
 ```Swift
-let (lettersSignal, lettersObserver) = Signal<String, NoError>.pipe()
-let (numbersSignal, numbersObserver) = Signal<String, NoError>.pipe()
-let (signal, observer) = Signal<Signal<String, NoError>, NoError>.pipe()
+let (lettersSignal, lettersObserver) = Signal<String, Never>.pipe()
+let (numbersSignal, numbersObserver) = Signal<String, Never>.pipe()
+let (signal, observer) = Signal<Signal<String, Never>, Never>.pipe()
 
 signal.flatten(.latest).observeValues { print($0) }
 
@@ -392,7 +392,7 @@ let producer = SignalProducer(signal)
 let error = NSError(domain: "domain", code: 0, userInfo: nil)
 
 producer
-    .flatMapError { _ in SignalProducer<String, NoError>(value: "Default") }
+    .flatMapError { _ in SignalProducer<String, Never>(value: "Default") }
     .startWithValues { print($0) }
 
 
@@ -500,7 +500,7 @@ observer.send(error: NSError(domain: "com.example.foo", code: 42, userInfo: nil)
 The `promoteError` operator promotes an event stream that does not generate failures into one that can.
 
 ```Swift
-let (numbersSignal, numbersObserver) = Signal<Int, NoError>.pipe()
+let (numbersSignal, numbersObserver) = Signal<Int, Never>.pipe()
 let (lettersSignal, lettersObserver) = Signal<String, NSError>.pipe()
 
 numbersSignal

--- a/Documentation/DebuggingTechniques.md
+++ b/Documentation/DebuggingTechniques.md
@@ -14,7 +14,7 @@ In both cases errors are related to incorrect assumptions about type. Such issue
 Below is an example of type-error scenario:
 
 ```swift
-SignalProducer<Int, NoError>(value:42)
+SignalProducer<Int, Never>(value:42)
     .on(value: { answer in
         return _
     })
@@ -26,7 +26,7 @@ SignalProducer<Int, NoError>(value:42)
 The code above will not compile with the following error on the `.startWithCompleted` call `error: cannot convert value of type 'Disposable' to closure result type '()'. To find the actual compile error, the chain needs to be broken apart. Add explicit definitions of closure types on each of the steps:
 
 ```swift
-let initialProducer = SignalProducer<Int, NoError>.init(value:42)
+let initialProducer = SignalProducer<Int, Never>.init(value:42)
 let sideEffectProducer = initialProducer.on(value: { (answer: Int) in
     return _
 })

--- a/Documentation/FrameworkOverview.md
+++ b/Documentation/FrameworkOverview.md
@@ -24,7 +24,7 @@ terminal events:
  * The `failed` event indicates that an error occurred before the signal could
    finish. Events are parameterized by an `ErrorType`, which determines the kind
    of failure that’s permitted to appear in the event. If a failure is not
-   permitted, the event can use type `NoError` to prevent any from being
+   permitted, the event can use type `Never` to prevent any from being
    provided.
  * The `completed` event indicates that the signal finished successfully, and
    that no more values will be sent by the source.

--- a/Documentation/ReactivePrimitives.md
+++ b/Documentation/ReactivePrimitives.md
@@ -13,7 +13,7 @@ The owner of a `Signal` has unilateral control of the event stream. Observers ma
 A `Signal` is like a live TV feed — you can observe and react to the content, but you cannot have a side effect on the live feed or the TV station.
 
 ```swift
-let channel: Signal<Program, NoError> = tvStation.channelOne
+let channel: Signal<Program, Never> = tvStation.channelOne
 channel.observeValues { program in ... }
 ```
 

--- a/Documentation/RxComparison.md
+++ b/Documentation/RxComparison.md
@@ -47,7 +47,7 @@ the kind of error must be specified in the type system. For example,
 `Signal<Int, AnyError>` is a signal of integer values that may fail with an error
 of type `AnyError`.
 
-More importantly, RAC allows the special type `NoError` to be used instead,
+More importantly, RAC allows the special type `Never` to be used instead,
 which _statically guarantees_ that an event stream is not allowed to send a
 failure. **This eliminates many bugs caused by unexpected failure events.**
 


### PR DESCRIPTION
It seems like this was changed [in version 6.0.0](https://github.com/ReactiveCocoa/ReactiveSwift/blob/b772fa0b624926e6e2f21acbb79297736a05c585/CHANGELOG.md#600), and this updates the documentation to reflect that change. :)