### PR TITLE
Rename filterMap to compactMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master
 *Please add new entries at the top.*
-1. Renamed `filterMap` to `compactMap` and deperacated `filterMap` (#746, kudos to @Marcocanc)
+1. Renamed `filterMap` to `compactMap` and deprecated `filterMap` (#746, kudos to @Marcocanc)
 
 # 6.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 *Please add new entries at the top.*
+1. Renamed `filterMap` to `compactMap` and deperacated `filterMap` (#746, kudos to @Marcocanc)
 
 # 6.1.0
 

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -102,9 +102,9 @@ public final class Action<Input, Output, Error: Swift.Error> {
 		(events, eventsObserver) = Signal<Signal<Output, Error>.Event, Never>.pipe()
 		(disabledErrors, disabledErrorsObserver) = Signal<(), Never>.pipe()
 
-		values = events.filterMap { $0.value }
-		errors = events.filterMap { $0.error }
-		completed = events.filterMap { $0.isCompleted ? () : nil }
+		values = events.compactMap { $0.value }
+		errors = events.compactMap { $0.error }
+		completed = events.compactMap { $0.isCompleted ? () : nil }
 
 		let actionState = MutableProperty(ActionState<State.Value>(isUserEnabled: true, isExecuting: false, value: state.value))
 

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -229,7 +229,7 @@ extension Signal.Event {
 		}
 	}
 
-	internal static func filterMap<U>(_ transform: @escaping (Value) -> U?) -> Transformation<U, Error> {
+	internal static func compactMap<U>(_ transform: @escaping (Value) -> U?) -> Transformation<U, Error> {
 		return { action, _ in
 			return { event in
 				switch event {
@@ -527,7 +527,7 @@ extension Signal.Event where Value: ResultProtocol, Error == Never {
 
 extension Signal.Event where Value: OptionalProtocol {
 	internal static var skipNil: Transformation<Value.Wrapped, Error> {
-		return filterMap { $0.optional }
+		return compactMap { $0.optional }
 	}
 }
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -628,7 +628,7 @@ extension Signal {
 	public func compactMap<U>(_ transform: @escaping (Value) -> U?) -> Signal<U, Error> {
 		return flatMapEvent(Signal.Event.compactMap(transform))
 	}
-	
+
 	/// Applies `transform` to values from `signal` and forwards values with non `nil` results unwrapped.
 	/// - parameters:
 	///   - transform: A closure that accepts a value from the `value` event and

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -625,8 +625,19 @@ extension Signal {
 	///                returns a new optional value.
 	///
 	/// - returns: A signal that will send new values, that are non `nil` after the transformation.
+	public func compactMap<U>(_ transform: @escaping (Value) -> U?) -> Signal<U, Error> {
+		return flatMapEvent(Signal.Event.compactMap(transform))
+	}
+	
+	/// Applies `transform` to values from `signal` and forwards values with non `nil` results unwrapped.
+	/// - parameters:
+	///   - transform: A closure that accepts a value from the `value` event and
+	///                returns a new optional value.
+	///
+	/// - returns: A signal that will send new values, that are non `nil` after the transformation.
+	@available(*, deprecated, renamed: "compactMap")
 	public func filterMap<U>(_ transform: @escaping (Value) -> U?) -> Signal<U, Error> {
-		return flatMapEvent(Signal.Event.filterMap(transform))
+		return flatMapEvent(Signal.Event.compactMap(transform))
 	}
 }
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -929,7 +929,7 @@ extension SignalProducer {
 	public func compactMap<U>(_ transform: @escaping (Value) -> U?) -> SignalProducer<U, Error> {
 		return core.flatMapEvent(Signal.Event.compactMap(transform))
 	}
-	
+
 	/// Applies `transform` to values from the producer and forwards values with non `nil` results unwrapped.
 	/// - parameters:
 	///   - transform: A closure that accepts a value from the `value` event and
@@ -940,7 +940,7 @@ extension SignalProducer {
 	public func filterMap<U>(_ transform: @escaping (Value) -> U?) -> SignalProducer<U, Error> {
 		return core.flatMapEvent(Signal.Event.compactMap(transform))
 	}
-	
+
 	/// Yield the first `count` values from the input producer.
 	///
 	/// - precondition: `count` must be non-negative number.

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -310,7 +310,7 @@ private final class SignalCore<Value, Error: Swift.Error>: SignalProducerCore<Va
 /// example, when we do:
 ///
 /// ```
-/// upstream.map(transform).filterMap(filteringTransform).start()
+/// upstream.map(transform).compactMap(filteringTransform).start()
 /// ```
 ///
 /// It is contractually guaranteed that these operators would always end up producing a
@@ -875,7 +875,7 @@ extension SignalProducer {
 	///
 	/// - returns: A producer that will send new values.
 	public func map<U>(_ keyPath: KeyPath<Value, U>) -> SignalProducer<U, Error> {
-		return core.flatMapEvent(Signal.Event.filterMap { $0[keyPath: keyPath] })
+		return core.flatMapEvent(Signal.Event.compactMap { $0[keyPath: keyPath] })
 	}
 
 	/// Map errors in the producer to a new error.
@@ -926,10 +926,21 @@ extension SignalProducer {
 	///                returns a new optional value.
 	///
 	/// - returns: A producer that will send new values, that are non `nil` after the transformation.
-	public func filterMap<U>(_ transform: @escaping (Value) -> U?) -> SignalProducer<U, Error> {
-		return core.flatMapEvent(Signal.Event.filterMap(transform))
+	public func compactMap<U>(_ transform: @escaping (Value) -> U?) -> SignalProducer<U, Error> {
+		return core.flatMapEvent(Signal.Event.compactMap(transform))
 	}
-
+	
+	/// Applies `transform` to values from the producer and forwards values with non `nil` results unwrapped.
+	/// - parameters:
+	///   - transform: A closure that accepts a value from the `value` event and
+	///                returns a new optional value.
+	///
+	/// - returns: A producer that will send new values, that are non `nil` after the transformation.
+	@available(*, deprecated, renamed: "compactMap")
+	public func filterMap<U>(_ transform: @escaping (Value) -> U?) -> SignalProducer<U, Error> {
+		return core.flatMapEvent(Signal.Event.compactMap(transform))
+	}
+	
 	/// Yield the first `count` values from the input producer.
 	///
 	/// - precondition: `count` must be non-negative number.

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -138,7 +138,7 @@ class ActionSpec: QuickSpec {
 				var isFirstResponder = false
 
 				action.isEnabled.producer
-					.filterMap { isActionEnabled in !isActionEnabled && isFirstResponder ? () : nil }
+					.compactMap { isActionEnabled in !isActionEnabled && isFirstResponder ? () : nil }
 					.startWithValues { _ in enabled.value = false }
 
 				enabled.value = true

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -678,10 +678,10 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
-		describe("filterMap") {
+		describe("compactMap") {
 			it("should omit values from the signal that are nil after the transformation") {
 				let (signal, observer) = Signal<String, Never>.pipe()
-				let mappedSignal: Signal<Int, Never> = signal.filterMap { Int.init($0) }
+				let mappedSignal: Signal<Int, Never> = signal.compactMap { Int.init($0) }
 
 				var lastValue: Int?
 
@@ -701,7 +701,7 @@ class SignalSpec: QuickSpec {
 
 			it("should stop emiting values after an error") {
 				let (signal, observer) = Signal<String, TestError>.pipe()
-				let mappedSignal: Signal<Int, TestError> = signal.filterMap { Int.init($0) }
+				let mappedSignal: Signal<Int, TestError> = signal.compactMap { Int.init($0) }
 
 				var lastValue: Int?
 
@@ -724,7 +724,7 @@ class SignalSpec: QuickSpec {
 
 			it("should stop emiting values after a complete") {
 				let (signal, observer) = Signal<String, Never>.pipe()
-				let mappedSignal: Signal<Int, Never> = signal.filterMap { Int.init($0) }
+				let mappedSignal: Signal<Int, Never> = signal.compactMap { Int.init($0) }
 
 				var lastValue: Int?
 
@@ -743,7 +743,7 @@ class SignalSpec: QuickSpec {
 
 			it("should send completed") {
 				let (signal, observer) = Signal<String, Never>.pipe()
-				let mappedSignal: Signal<Int, Never> = signal.filterMap { Int.init($0) }
+				let mappedSignal: Signal<Int, Never> = signal.compactMap { Int.init($0) }
 
 				var completed: Bool = false
 
@@ -755,7 +755,7 @@ class SignalSpec: QuickSpec {
 
 			it("should send failure") {
 				let (signal, observer) = Signal<String, TestError>.pipe()
-				let mappedSignal: Signal<Int, TestError> = signal.filterMap { Int.init($0) }
+				let mappedSignal: Signal<Int, TestError> = signal.compactMap { Int.init($0) }
 
 				var failure: TestError?
 

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -681,7 +681,7 @@ class SignalSpec: QuickSpec {
 		describe("compactMap") {
 			it("should omit values from the signal that are nil after the transformation") {
 				let (signal, observer) = Signal<String, Never>.pipe()
-				let mappedSignal: Signal<Int, Never> = signal.compactMap { Int.init($0) }
+				let mappedSignal: Signal<Int, Never> = signal.compactMap(Int.init)
 
 				var lastValue: Int?
 
@@ -701,7 +701,7 @@ class SignalSpec: QuickSpec {
 
 			it("should stop emiting values after an error") {
 				let (signal, observer) = Signal<String, TestError>.pipe()
-				let mappedSignal: Signal<Int, TestError> = signal.compactMap { Int.init($0) }
+				let mappedSignal: Signal<Int, TestError> = signal.compactMap(Int.init)
 
 				var lastValue: Int?
 
@@ -724,7 +724,7 @@ class SignalSpec: QuickSpec {
 
 			it("should stop emiting values after a complete") {
 				let (signal, observer) = Signal<String, Never>.pipe()
-				let mappedSignal: Signal<Int, Never> = signal.compactMap { Int.init($0) }
+				let mappedSignal: Signal<Int, Never> = signal.compactMap(Int.init)
 
 				var lastValue: Int?
 
@@ -743,7 +743,7 @@ class SignalSpec: QuickSpec {
 
 			it("should send completed") {
 				let (signal, observer) = Signal<String, Never>.pipe()
-				let mappedSignal: Signal<Int, Never> = signal.compactMap { Int.init($0) }
+				let mappedSignal: Signal<Int, Never> = signal.compactMap(Int.init)
 
 				var completed: Bool = false
 
@@ -755,7 +755,7 @@ class SignalSpec: QuickSpec {
 
 			it("should send failure") {
 				let (signal, observer) = Signal<String, TestError>.pipe()
-				let mappedSignal: Signal<Int, TestError> = signal.compactMap { Int.init($0) }
+				let mappedSignal: Signal<Int, TestError> = signal.compactMap(Int.init)
 
 				var failure: TestError?
 


### PR DESCRIPTION
I've renamed `filterMap` to `compactMap` so that it would be more in line with the Swift [compactMap](https://developer.apple.com/documentation/swift/sequence/2950916-compactmap) and the Combine [CompactMap Publisher](https://developer.apple.com/documentation/combine/publishers/compactmap). 