### PR TITLE
Add @unknown default to silence a warning

### DIFF
--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -96,6 +96,8 @@ extension DispatchTimeInterval {
 			return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
 		case .never:
 			return .infinity
+		@unknown default:
+			return .infinity
 		}
 	}
 
@@ -112,6 +114,8 @@ extension DispatchTimeInterval {
 		case let .nanoseconds(ns):
 			return .nanoseconds(-ns)
 		case .never:
+			return .never
+		@unknown default:
 			return .never
 		}
 	}


### PR DESCRIPTION
This fixes the following compiler warning:
```
Switch covers known cases, but 'DispatchTimeInterval' may have additional unknown values, possibly added in future versions.
```

Not 100% sure if `.infinity` and `.never` are the best values to return here, but I guess it's also unlikely we'll ever actually have new cases in the enum.