### PR TITLE
[podspec] Update cocoapods_version to `>= 1.7.0` to use `swift_versions` DSL

### DIFF
--- a/ReactiveSwift.podspec
+++ b/ReactiveSwift.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {"OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
 
-  s.cocoapods_version = ">= 1.4.0"
+  s.cocoapods_version = ">= 1.7.0"
   s.swift_versions = ["5.0", "5.1"]
 end


### PR DESCRIPTION
## Checklist
- ~[ ] Updated CHANGELOG.md.~

Refs:
- https://github.com/ReactiveCocoa/ReactiveSwift/pull/743#discussion_r321955557
- http://blog.cocoapods.org/CocoaPods-1.7.0-beta/#support-for-multiple-swift-versions