### PR TITLE
Skip building testing libraries for SPM users.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ aliases:
     script:
       - swift --version
       - swift build
-      - swift test
+      - TEST=1 swift test
     git:
       submodules: false
     env: JOB=SwiftPM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 *Please add new entries at the top.*
+1. Removed fetching testing libraries for SPM consumers. (#758, kudos to @sunshinejr)
 1. Renamed `filterMap` to `compactMap` and deprecated `filterMap` (#746, kudos to @Marcocanc)
 
 # 6.1.0

--- a/Package.swift
+++ b/Package.swift
@@ -1,18 +1,31 @@
 // swift-tools-version:5.0
 import PackageDescription
+import class Foundation.ProcessInfo
+
+let shouldTest = ProcessInfo.processInfo.environment["TEST"] == "1"
+
+func resolveDependencies() -> [Package.Dependency] {
+    guard shouldTest else { return [] }
+
+    return [
+        .package(url: "https://github.com/Quick/Quick.git", from: "2.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.0"),
+    ]
+}
+
+func resolveTargets() -> [Target] {
+    let baseTarget = Target.target(name: "ReactiveSwift", dependencies: [], path: "Sources")
+    let testTarget = Target.testTarget(name: "ReactiveSwiftTests", dependencies: ["ReactiveSwift", "Quick", "Nimble"])
+
+    return shouldTest ? [baseTarget, testTarget] : [baseTarget]
+}
 
 let package = Package(
     name: "ReactiveSwift",
     products: [
         .library(name: "ReactiveSwift", targets: ["ReactiveSwift"]),
     ],
-    dependencies: [
-        .package(url: "https://github.com/Quick/Quick.git", from: "2.0.0"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.0"),
-    ],
-    targets: [
-        .target(name: "ReactiveSwift", dependencies: [], path: "Sources"),
-        .testTarget(name: "ReactiveSwiftTests", dependencies: ["ReactiveSwift", "Quick", "Nimble"]),
-    ],
+    dependencies: resolveDependencies(),
+    targets: resolveTargets(),
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
Hey all! In this PR I'm removing testing libraries for SPM users. This is because currently SPM will both fetch & build your libraries even though they are in a target that you don't use. Because of that (and the current integration of SPM in Xcode), Xcode will build your testing dependencies (either in Xcode Preview or for normal builds) and complain (in Preview you won't ever get your UI to show and in your projects you will get runtime crash for missing XCTest etc.).

With this fix we are still able to test ReactiveSwift (using additional env variable) and skip downloading the testing libraries for normal usage.

Let me know what you think about it.

#### Checklist
- [x] Updated CHANGELOG.md.
