### PR TITLE
Fix debounce when started twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 *Please add new entries at the top.*
 
+1. Fixed `SignalProducer.debounce` operator that, when started more than once, would not deliver values on producers started after the first time. (#772, kudos to @gpambrozio)
 1. `FlattenStrategy.throttle` is introduced. (#713, kudos to @inamiy)
 1. Updated `README.md` to reflect Swift 5.1 compatibility and point snippets to 6.1.0 (#763, kudos to @Marcocanc)
 1. Update travis to Xcode 11.1 and Swift 5.1 (#764, kudos @petrpavlik)

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -870,9 +870,8 @@ extension Signal.Event {
 	internal static func debounce(_ interval: TimeInterval, on scheduler: DateScheduler, discardWhenCompleted: Bool) -> Transformation<Value, Error> {
 		precondition(interval >= 0)
 		
-		let state: Atomic<ThrottleState<Value>> = Atomic(ThrottleState(previousDate: scheduler.currentDate, pendingValue: nil))
-
 		return { action, lifetime in
+			let state: Atomic<ThrottleState<Value>> = Atomic(ThrottleState(previousDate: scheduler.currentDate, pendingValue: nil))
 			let d = SerialDisposable()
 
 			lifetime.observeEnded {

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -1254,6 +1254,41 @@ class SignalProducerSpec: QuickSpec {
 				expect(values) == []
 				expect(completed) == true
 			}
+
+			context("starting the producer twice") {
+				it("should deviver the same values") {
+					var values1: [Int] = []
+					var values2: [Int] = []
+					producer.startWithValues { value in
+						values1.append(value)
+					}
+					producer.startWithValues { value in
+						values2.append(value)
+					}
+
+					expect(values1) == []
+					expect(values2) == []
+
+					observer.send(value: 1)
+					observer.send(value: 2)
+
+					scheduler.advance(by: .milliseconds(1500))
+					expect(values1) == [ 2 ]
+					expect(values2) == [ 2 ]
+
+					observer.send(value: 3)
+					scheduler.advance(by: .milliseconds(1500))
+					expect(values1) == [ 2, 3 ]
+					expect(values2) == [ 2, 3 ]
+
+					observer.send(value: 4)
+					observer.sendCompleted()
+					scheduler.run()
+
+					expect(values1) == [ 2, 3 ]
+					expect(values2) == [ 2, 3 ]
+				}
+			}
 		}
 
 		describe("debounce without discarding the latest value when terminated") {
@@ -1363,6 +1398,41 @@ class SignalProducerSpec: QuickSpec {
 				expect(completed) == false
 				scheduler.advance()
 				expect(completed) == true
+			}
+
+			context("starting the producer twice") {
+				it("should deviver the same values") {
+					var values1: [Int] = []
+					var values2: [Int] = []
+					producer.startWithValues { value in
+						values1.append(value)
+					}
+					producer.startWithValues { value in
+						values2.append(value)
+					}
+
+					expect(values1) == []
+					expect(values2) == []
+
+					observer.send(value: 1)
+					observer.send(value: 2)
+
+					scheduler.advance(by: .milliseconds(1500))
+					expect(values1) == [ 2 ]
+					expect(values2) == [ 2 ]
+
+					observer.send(value: 3)
+					scheduler.advance(by: .milliseconds(1500))
+					expect(values1) == [ 2, 3 ]
+					expect(values2) == [ 2, 3 ]
+
+					observer.send(value: 4)
+					observer.sendCompleted()
+					scheduler.run()
+
+					expect(values1) == [ 2, 3, 4 ]
+					expect(values2) == [ 2, 3, 4 ]
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes issue #771. Thanks @andersio for the quick solution on this.

I also added tests that show the solution works. The tests were added at a commit before the change that fixed it so it's easy to verify that tests fail before the change but not after.

#### Checklist
- [x] Updated CHANGELOG.md.
