### PR TITLE
Move CI to Xcode 11.4 and update the tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: osx
 language: objective-c
-osx_image: xcode11.1
+osx_image: xcode11.4
 before_install: true
 install: true
 branches:

--- a/ReactiveSwift.xcodeproj/xcshareddata/xcschemes/ReactiveSwift-macOS.xcscheme
+++ b/ReactiveSwift.xcodeproj/xcshareddata/xcschemes/ReactiveSwift-macOS.xcscheme
@@ -68,8 +68,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -83,8 +83,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -105,8 +103,6 @@
             ReferencedContainer = "container:ReactiveSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Profile"

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -364,7 +364,6 @@ class PropertySpec: QuickSpec {
 						let property = Property(capturing: constantProperty)
 
 						var sentValue: String?
-						var signalSentValue: String?
 						var producerCompleted = false
 						var signalInterrupted = false
 						var hasUnexpectedEventsEmitted = false
@@ -390,7 +389,6 @@ class PropertySpec: QuickSpec {
 						}
 
 						expect(sentValue) == initialPropertyValue
-						expect(signalSentValue).to(beNil())
 						expect(producerCompleted) == true
 						expect(signalInterrupted) == true
 						expect(hasUnexpectedEventsEmitted) == false
@@ -400,6 +398,7 @@ class PropertySpec: QuickSpec {
 						var property = Optional(MutableProperty(1))
 						weak var weakProperty = property
 						var existential = Optional(Property(capturing: property!))
+						_ = existential
 
 						expect(weakProperty).toNot(beNil())
 
@@ -419,7 +418,6 @@ class PropertySpec: QuickSpec {
 						let property = Property(constantProperty)
 
 						var sentValue: String?
-						var signalSentValue: String?
 						var producerCompleted = false
 						var signalInterrupted = false
 						var hasUnexpectedEventsEmitted = false
@@ -445,7 +443,6 @@ class PropertySpec: QuickSpec {
 						}
 
 						expect(sentValue) == initialPropertyValue
-						expect(signalSentValue).to(beNil())
 						expect(producerCompleted) == true
 						expect(signalInterrupted) == true
 						expect(hasUnexpectedEventsEmitted) == false
@@ -914,10 +911,12 @@ class PropertySpec: QuickSpec {
 					}
 
 					expect(getAnotherValue()) == 10203
+					expect(secondResult) == 10203
 
 					A.value = 4
 					expect(getValue()) == 204
 					expect(getAnotherValue()) == 10204
+					expect(secondResult) == 10204
 				}
 			}
 
@@ -1044,6 +1043,7 @@ class PropertySpec: QuickSpec {
 					///
 					/// https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3042
 					expect(getAnotherValue()) == 10202
+					expect(secondResult) == 10202
 				}
 
 				it("should be consistent between combined and nested zipped properties") {
@@ -1092,6 +1092,7 @@ class PropertySpec: QuickSpec {
 					expect(firstResult) == 202
 
 					expect(getAnotherValue()) == 10202
+					expect(secondResult) == 10202
 
 					/// Zip `D` with `anotherZipped`.
 					let yetAnotherZipped = anotherZipped.zip(with: D)
@@ -1117,7 +1118,7 @@ class PropertySpec: QuickSpec {
 					var zippedProperty = Optional(property.zip(with: otherProperty))
 					zippedProperty!.producer.start { event in
 						switch event {
-						case let .value(left, right):
+						case let .value((left, right)):
 							result.append("\(left)\(right)")
 						case .completed:
 							completed = true

--- a/Tests/ReactiveSwiftTests/SchedulerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SchedulerSpec.swift
@@ -219,9 +219,7 @@ class SchedulerSpec: QuickSpec {
 					expect{count}.toEventually(equal(timesToRun))
 				}
 				
-				it("should repeatedly run actions after a given date when the disposable is not retained") {
-					let disposable = SerialDisposable()
-					
+				it("should repeatedly run actions after a given date when the disposable is not retained") {				
 					var count = 0
 					let timesToIncrement = 3
 					

--- a/Tests/ReactiveSwiftTests/SignalLifetimeSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalLifetimeSpec.swift
@@ -91,6 +91,8 @@ class SignalLifetimeSpec: QuickSpec {
 					expect(isDisposed) == false
 
 					var reference = signal
+					_ = reference
+
 					signal = nil
 					expect(weakSignal).toNot(beNil())
 					expect(isDisposed) == false
@@ -118,10 +120,12 @@ class SignalLifetimeSpec: QuickSpec {
 			}
 
 			it("should be disposed of when the generator observer has deinitialized even if it has an observer") {
-				var isDisposed = false
 				var inputObserver: Signal<AnyObject, Never>.Observer?
-
 				var disposable: Disposable? = nil
+				_ = (inputObserver, disposable)
+
+				var isDisposed = false
+
 				weak var signal: Signal<AnyObject, Never>? = {
 					let signal = Signal<AnyObject, Never> { observer, lifetime in
 						inputObserver = observer
@@ -330,6 +334,8 @@ class SignalLifetimeSpec: QuickSpec {
 			it("should be disposed of if it is not explicitly retained and its generator observer is not retained") {
 				var disposable: Disposable? = nil
 				var inputObserver: Signal<AnyObject, Never>.Observer?
+				_ = (disposable, inputObserver)
+
 				var isDisposed = false
 
 				weak var signal: Signal<AnyObject, Never>? = {

--- a/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerLiftingSpec.swift
@@ -1781,7 +1781,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				zipped.start { event in
 					switch event {
-					case let .value(left, right):
+					case let .value((left, right)):
 						result.append("\(left)\(right)")
 					case .completed:
 						completed = true

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -32,6 +32,7 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should not release signal observers when given disposable is disposed") {
 				var lifetime: Lifetime!
+				_ = lifetime
 
 				let producer = SignalProducer<Int, Never> { observer, innerLifetime in
 					lifetime = innerLifetime

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -3286,10 +3286,16 @@ class SignalProducerSpec: QuickSpec {
 						.start()
 
 					disposable.dispose()
-					expect(deinitValues) == 0
+
+					withExtendedLifetime(producer) {
+						expect(deinitValues) == 0
+					}
 
 					producer = nil
-					expect(deinitValues) == 0
+
+					withExtendedLifetime(replayedProducer) {
+						expect(deinitValues) == 0
+					}
 
 					replayedProducer = nil
 					expect(deinitValues) == 1

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -145,7 +145,9 @@ class SignalSpec: QuickSpec {
 					lifetime += disposable
 				}
 
-				expect(disposable.isDisposed) == true
+				withExtendedLifetime(signal) {
+					expect(disposable.isDisposed) == true
+				}
 			}
 
 			it("should dispose of the returned disposable if the signal has completed in the generator") {
@@ -157,7 +159,9 @@ class SignalSpec: QuickSpec {
 					lifetime += disposable
 				}
 
-				expect(disposable.isDisposed) == true
+				withExtendedLifetime(signal) {
+					expect(disposable.isDisposed) == true
+				}
 			}
 
 			it("should dispose of the returned disposable if the signal has failed in the generator") {
@@ -169,7 +173,9 @@ class SignalSpec: QuickSpec {
 					lifetime += disposable
 				}
 
-				expect(disposable.isDisposed) == true
+				withExtendedLifetime(signal) {
+					expect(disposable.isDisposed) == true
+				}
 			}
 		}
 
@@ -230,10 +236,12 @@ class SignalSpec: QuickSpec {
 				let disposable = AnyDisposable()
 				let (signal, observer) = Signal<(), Never>.pipe(disposable: disposable)
 
-				expect(disposable.isDisposed) == false
+				withExtendedLifetime(signal) {
+					expect(disposable.isDisposed) == false
 
-				observer.sendCompleted()
-				expect(disposable.isDisposed) == true
+					observer.sendCompleted()
+					expect(disposable.isDisposed) == true
+				}
 			}
 
 			context("memory") {
@@ -262,7 +270,6 @@ class SignalSpec: QuickSpec {
 		describe("interruption") {
 			it("should not send events after sending an interrupted event") {
 				let queue: DispatchQueue
-				let counter = Atomic<Int>(0)
 
 				if #available(macOS 10.10, *) {
 					queue = DispatchQueue.global(qos: .userInitiated)
@@ -327,7 +334,6 @@ class SignalSpec: QuickSpec {
 					DispatchQueue.concurrentPerform(iterations: iterations) { _ in
 						let (signal, observer) = Signal<(), Never>.pipe()
 
-						var isInterrupted = false
 						signal.observeInterrupted { counter.modify { $0 += 1 } }
 
 						// Used to synchronize the `value` sender and the `interrupt`
@@ -2777,7 +2783,7 @@ class SignalSpec: QuickSpec {
 
 				zipped.observe { event in
 					switch event {
-					case let .value(left, right):
+					case let .value((left, right)):
 						result.append("\(left)\(right)")
 					case .completed:
 						completed = true
@@ -2804,7 +2810,7 @@ class SignalSpec: QuickSpec {
 
 				zipped.observe { event in
 					switch event {
-					case let .value(left, right):
+					case let .value((left, right)):
 						result.append("\(left)\(right)")
 					case .completed:
 						completed = true
@@ -2830,7 +2836,7 @@ class SignalSpec: QuickSpec {
 
 				zipped.observe { event in
 					switch event {
-					case let .value(left, right):
+					case let .value((left, right)):
 						result.append("\(left)\(right)")
 					case .completed:
 						completed = true


### PR DESCRIPTION
Swift 5.2 in Xcode 11.4 seems to be preempting deinitialization of objects to be as earliest as possible, when optimization mode is on (`-O -Owholemodule`). That breaks a few test cases, which have the deinitialization reordered before the pre-deinit assertions. These are fixed by applying `withExtendedLifetime` as appropriate.

#### Checklist
- ~~Updated CHANGELOG.md.~~
