### PR TITLE
Mark Property and MutableProperty as property wrappers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # master
 *Please add new entries at the top.*
 
+1. `Property` and `MutableProperty` can now be used as property wrapper. Note that they remain a reference type container, so it may not be appropriate to use them in types requiring value semantics. (#781)
+   ```swift
+   class ViewModel {
+     @MutableProperty var count: Int = 0
+
+     func subscribe() {
+       self.$count.producer.startWithValues {
+         print("`count` has changed to \(count)")
+       }
+     }
+
+     func increment() {
+       print("count prior to increment: \(count)")
+       self.$count.modify { $0 += 1 }
+     }
+   }
+   ```
+
 # 6.2.1
 1. Improved performance of joining signals by a factor of around 5. This enables joining of 1000 and more signals in a reasonable amount of time.
 1. Fixed `SignalProducer.debounce` operator that, when started more than once, would not deliver values on producers started after the first time. (#772, kudos to @gpambrozio)

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -470,12 +470,23 @@ extension PropertyProtocol where Value == Bool {
 /// deinitializing.
 ///
 /// Note that composed properties do not retain any of its sources.
+@propertyWrapper
 public final class Property<Value>: PropertyProtocol {
 	private let _value: () -> Value
 
 	/// The current value of the property.
 	public var value: Value {
 		return _value()
+	}
+
+	@inlinable
+	public var wrappedValue: Value {
+		return value
+	}
+
+	@inlinable
+	public var projectedValue: Property<Value> {
+		return self
 	}
 
 	/// A producer for Signals that will send the property's current
@@ -649,6 +660,7 @@ extension Property where Value: OptionalProtocol {
 /// A mutable property of type `Value` that allows observation of its changes.
 ///
 /// Instances of this class are thread-safe.
+@propertyWrapper
 public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 	private let token: Lifetime.Token
 	private let observer: Signal<Value, Never>.Observer
@@ -661,6 +673,17 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 	public var value: Value {
 		get { return box.value }
 		set { modify { $0 = newValue } }
+	}
+
+	@inlinable
+	public var wrappedValue: Value {
+		get { value }
+		set { value = newValue }
+	}
+
+	@inlinable
+	public var projectedValue: MutableProperty<Value> {
+		return self
 	}
 
 	/// The lifetime of the property.
@@ -694,6 +717,14 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 		/// `value`. Note that recursive sets will still deadlock because the
 		/// underlying producer prevents sending recursive events.
 		box = PropertyBox(initialValue)
+	}
+
+	/// Initializes a mutable property that first takes on `initialValue`
+	///
+	/// - parameters:
+	///   - initialValue: Starting value for the mutable property.
+	public convenience init(wrappedValue: Value) {
+		self.init(wrappedValue)
 	}
 
 	/// Atomically replaces the contents of the variable.

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -310,9 +310,40 @@ class PropertySpec: QuickSpec {
 					}
 				}
 			}
+
+			it("can be used as property wrapper") {
+				struct Container {
+					@MutableProperty var counter = 0
+				}
+
+				let container = Container()
+				expect(container.counter) == 0
+
+				container.counter += 1
+				expect(container.counter) == 1
+
+				container.$counter.modify { $0 += 2 }
+				expect(container.counter) == 3
+			}
 		}
 
 		describe("Property") {
+			it("can be used as property wrapper") {
+				struct Container {
+					@Property var counter: Int
+				}
+
+				let mutableCounter = MutableProperty(0)
+				let container = Container(counter: Property(capturing: mutableCounter))
+				expect(container.counter) == 0
+
+				mutableCounter.value = 1
+				expect(container.counter) == 1
+
+				mutableCounter.modify { $0 += 2 }
+				expect(container.counter) == 3
+			}
+
 			describe("constant property") {
 				it("should have the value given at initialization") {
 					let constantProperty = Property(value: initialPropertyValue)


### PR DESCRIPTION
Relevant context: https://github.com/ReactiveCocoa/ReactiveSwift/pull/762#issuecomment-632793302

These types would not go away even if we continue to evolve #762, and marking them as property wrapper is a reasonable transitional solution to improve QoL until that happens.

`Property` and `MutableProperty` can be used as property wrappers without controversy IMO — they will continue to be reference type containers, so there is no surprise awaiting new RAS users.

#### Checklist
- [x] Updated CHANGELOG.md.
