### PR TITLE
replaced allEvents by allCases

### DIFF
--- a/Sources/EventLogger.swift
+++ b/Sources/EventLogger.swift
@@ -12,10 +12,16 @@ import Foundation
 public enum LoggingEvent {
 	public enum Signal: String, CaseIterable {
 		case value, completed, failed, terminated, disposed, interrupted
+
+		@available(*, deprecated, message:"Use `allCases` instead.")
+		public static var allEvents: Set<Signal> { Set(allCases) }
 	}
 
 	public enum SignalProducer: String, CaseIterable {
 		case starting, started, value, completed, failed, terminated, disposed, interrupted
+
+		@available(*, deprecated, renamed:"Use `allCases` instead.")
+		public static var allEvents: Set<SignalProducer> { Set(allCases) }
 	}
 }
 

--- a/Sources/EventLogger.swift
+++ b/Sources/EventLogger.swift
@@ -10,20 +10,12 @@ import Foundation
 
 /// A namespace for logging event types.
 public enum LoggingEvent {
-	public enum Signal: String {
+	public enum Signal: String, CaseIterable {
 		case value, completed, failed, terminated, disposed, interrupted
-
-		public static let allEvents: Set<Signal> = [
-			.value, .completed, .failed, .terminated, .disposed, .interrupted,
-		]
 	}
 
-	public enum SignalProducer: String {
+	public enum SignalProducer: String, CaseIterable {
 		case starting, started, value, completed, failed, terminated, disposed, interrupted
-
-		public static let allEvents: Set<SignalProducer> = [
-			.starting, .started, .value, .completed, .failed, .terminated, .disposed, .interrupted,
-		]
 	}
 }
 
@@ -82,7 +74,7 @@ extension Signal {
 	///   - logger: Logger that logs the events.
 	///
 	/// - returns: Signal that, when observed, logs the fired events.
-	public func logEvents(identifier: String = "", events: Set<LoggingEvent.Signal> = LoggingEvent.Signal.allEvents, fileName: String = #file, functionName: String = #function, lineNumber: Int = #line, logger: @escaping EventLogger = defaultEventLog) -> Signal<Value, Error> {
+	public func logEvents(identifier: String = "", events: Set<LoggingEvent.Signal> = Set(LoggingEvent.Signal.allCases), fileName: String = #file, functionName: String = #function, lineNumber: Int = #line, logger: @escaping EventLogger = defaultEventLog) -> Signal<Value, Error> {
 		let logContext = LogContext(events: events,
 		                            identifier: identifier,
 		                            fileName: fileName,
@@ -116,7 +108,7 @@ extension SignalProducer {
 	///
 	/// - returns: Signal producer that, when started, logs the fired events.
 	public func logEvents(identifier: String = "",
-	                      events: Set<LoggingEvent.SignalProducer> = LoggingEvent.SignalProducer.allEvents,
+	                      events: Set<LoggingEvent.SignalProducer> = Set(LoggingEvent.SignalProducer.allCases),
 	                      fileName: String = #file,
 	                      functionName: String = #function,
 	                      lineNumber: Int = #line,

--- a/Sources/EventLogger.swift
+++ b/Sources/EventLogger.swift
@@ -20,7 +20,7 @@ public enum LoggingEvent {
 	public enum SignalProducer: String, CaseIterable {
 		case starting, started, value, completed, failed, terminated, disposed, interrupted
 
-		@available(*, deprecated, renamed:"Use `allCases` instead.")
+		@available(*, deprecated, message:"Use `allCases` instead.")
 		public static var allEvents: Set<SignalProducer> { Set(allCases) }
 	}
 }


### PR DESCRIPTION
Replaced manually enumerated `allEvents` to `allCases` from CaseIterable.
#### Checklist
- ~~[ ] Updated CHANGELOG.md~~.