### PR TITLE
Unserialized and Reentrant `Signal`s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ PlaygroundUtility.remap
 # SwiftPM
 .build
 Packages
+.swiftpm
 
 # Carthage
 Carthage/Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # master
 *Please add new entries at the top.*
 
-1. `Signal` now offers a non-serializing variant and a reentrant variant for advanced users. (#797)
+1. `Signal` offers two special variants for advanced users: unserialized and reentrant-unserialized. (#797)
 
-   The input observer of these variants assume that mutual exclusion has already been enforced among its callers.
+   The input observer of these variants assume that mutual exclusion has been enforced by its callers.
 
-   You can create these variants through four `Signal` static methods: `unserialized(_:)`, `unserializedPipe(_:)`, `reentrant(_:)` and `reentrantPipe(_:)`. These would be adopted by ReactiveCocoa UIKit bindings to improve interoperability with Loop, to tackle some legitimate recursive delivery scenarios (e.g. around first responder management), and also to reduce fine-grained locking in ReactiveCocoa.
+   You can create these variants through four `Signal` static methods: `unserialized(_:)`, `unserializedPipe(_:)`, `reentrantUnserialized(_:)` and `reentrantUnserializedPipe(_:)`. These would be adopted by ReactiveCocoa UIKit bindings to improve interoperability with Loop, to tackle some legitimate recursive delivery scenarios (e.g. around first responder management), and also to reduce fine-grained locking in ReactiveCocoa.
 
    Note that the default behavior of `Signal` has not been changed — event serialization remains the default behavior.
 
-1. `SignalProducer` now similarly offers `unserialized(_:)`. (#797)
+1. `SignalProducer` offers an unserialized variant via `SignalProducer.unserialized(_:)`. (#797)
 
 1. `Signal` and Properties now use fewer locks, which should translate into minor performance improvements. (#797)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 1. `Signal` now offers a non-serializing variant and a reentrant variant for advanced users. (#797)
 
-   You can create these variants through four `Signal` static methods: `nonSerializing(_:)`, `nonSerializingPipe(_:)`, `reentrant(_:)` and `reentrantPipe(_:)`. These would be adopted by ReactiveCocoa UIKit bindings to improve interoperability with Loop.
+   You can create these variants through four `Signal` static methods: `nonSerializing(_:)`, `nonSerializingPipe(_:)`, `reentrant(_:)` and `reentrantPipe(_:)`. These would be adopted by ReactiveCocoa UIKit bindings to improve interoperability with Loop, to tackle some legitimate recursive delivery scenarios (e.g. around first responder management), and also to reduce fine-grained locking in ReactiveCocoa.
 
    Note that the default behavior of `Signal` has not been changed — event serialization remains the default behavior.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # master
 *Please add new entries at the top.*
 
+1. `Signal` now offers a non-serializing variant and a reentrant variant for advanced users. (#797)
+
+   You can create these variants through four `Signal` static methods: `nonSerializing(_:)`, `nonSerializingPipe(_:)`, `reentrant(_:)` and `reentrantPipe(_:)`. These would be adopted by ReactiveCocoa UIKit bindings to improve interoperability with Loop.
+
+   Note that the default behavior of `Signal` has not been changed — event serialization remains the default behavior.
+
+1. `Signal` now has reduced fine-grained locking by adopting `nonSerializing(_:)` internally. (#797)
+
 1. Fix a debug assertion in `Lock.try()` that could be raised in earlier OS versions (< iOS 10.0, < macOS 10.12). (#747, #788)
 
    Specifically, ReactiveSwift now recognizes `EDEADLK` as expected error code from `pthread_mutex_trylock` alongside `0`, `EBUSY` and `EAGAIN`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@
 
 1. `Signal` now offers a non-serializing variant and a reentrant variant for advanced users. (#797)
 
+   The input observer of these variants assume that mutual exclusion has already been enforced among its callers.
+
    You can create these variants through four `Signal` static methods: `nonSerializing(_:)`, `nonSerializingPipe(_:)`, `reentrant(_:)` and `reentrantPipe(_:)`. These would be adopted by ReactiveCocoa UIKit bindings to improve interoperability with Loop, to tackle some legitimate recursive delivery scenarios (e.g. around first responder management), and also to reduce fine-grained locking in ReactiveCocoa.
 
    Note that the default behavior of `Signal` has not been changed — event serialization remains the default behavior.
 
-1. `Signal` now has reduced fine-grained locking by adopting `nonSerializing(_:)` internally. (#797)
+1. `SignalProducer` now similarly offers `nonSerializing(_:)`. (#797)
+
+1. `Signal` and Properties now use fewer locks, which should translate into minor performance improvements. (#797)
 
 1. Fix a debug assertion in `Lock.try()` that could be raised in earlier OS versions (< iOS 10.0, < macOS 10.12). (#747, #788)
 

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -213,19 +213,19 @@ internal class Lock: LockProtocol {
 }
 
 internal protocol LockProtocol {
-    static func make() -> Self
-
-    func lock()
-    func unlock()
-    func `try`() -> Bool
+	static func make() -> Self
+	
+	func lock()
+	func unlock()
+	func `try`() -> Bool
 }
 
 internal struct NoLock: LockProtocol {
-    static func make() -> NoLock { NoLock() }
+	static func make() -> NoLock { NoLock() }
 
-    func lock() {}
-    func unlock() {}
-    func `try`() -> Bool { true }
+	func lock() {}
+	func unlock() {}
+	func `try`() -> Bool { true }
 }
 
 /// An atomic variable.

--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -104,7 +104,7 @@ internal struct UnsafeAtomicState<State: RawRepresentable> where State.RawValue 
 
 /// `Lock` exposes `os_unfair_lock` on supported platforms, with pthread mutex as the
 /// fallback.
-internal class Lock {
+internal class Lock: LockProtocol {
 	#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 	@available(iOS 10.0, *)
 	@available(macOS 10.12, *)
@@ -195,14 +195,14 @@ internal class Lock {
 		}
 	}
 
-	static func make() -> Lock {
+	static func make() -> Self {
 		#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 		if #available(*, iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0) {
-			return UnfairLock()
+			return UnfairLock() as! Self
 		}
 		#endif
 
-		return PthreadLock()
+		return PthreadLock() as! Self
 	}
 
 	private init() {}
@@ -210,6 +210,22 @@ internal class Lock {
 	func lock() { fatalError() }
 	func unlock() { fatalError() }
 	func `try`() -> Bool { fatalError() }
+}
+
+internal protocol LockProtocol {
+    static func make() -> Self
+
+    func lock()
+    func unlock()
+    func `try`() -> Bool
+}
+
+internal struct NoLock: LockProtocol {
+    static func make() -> NoLock { NoLock() }
+
+    func lock() {}
+    func unlock() {}
+    func `try`() -> Bool { true }
 }
 
 /// An atomic variable.

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -85,6 +85,11 @@ extension PropertyProtocol {
 		return Property(unsafeProducer: transform(producer))
 	}
 
+	/// Lifts a unary SignalProducer operator to operate upon PropertyProtocol instead.
+	fileprivate func liftNonSerializing<U>(_ transform: @escaping (SignalProducer<Value, Never>) -> SignalProducer<U, Never>) -> Property<U> {
+		return Property(unsafeProducer: transform(producer), nonSerializing: true)
+	}
+
 	/// Lifts a binary SignalProducer operator to operate upon PropertyProtocol instead.
 	fileprivate func lift<P: PropertyProtocol, U>(_ transform: @escaping (SignalProducer<Value, Never>) -> (SignalProducer<P.Value, Never>) -> SignalProducer<U, Never>) -> (P) -> Property<U> {
 		return { other in
@@ -102,7 +107,7 @@ extension PropertyProtocol {
 	///
 	/// - returns: A property that holds a mapped value from `self`.
 	public func map<U>(_ transform: @escaping (Value) -> U) -> Property<U> {
-		return lift { $0.map(transform) }
+		return liftNonSerializing { $0.map(transform) }
 	}
 	
 	/// Map the current value and all susequent values to a new constant property.
@@ -112,7 +117,7 @@ extension PropertyProtocol {
 	///
 	/// - returns: A property that holds a mapped value from `self`.
 	public func map<U>(value: U) -> Property<U> {
-		return lift { $0.map(value: value) }
+		return liftNonSerializing { $0.map(value: value) }
 	}
 
 	/// Maps the current value and all subsequent values to a new property
@@ -123,7 +128,7 @@ extension PropertyProtocol {
 	///
 	/// - returns: A property that holds a mapped value from `self`.
 	public func map<U>(_ keyPath: KeyPath<Value, U>) -> Property<U> {
-		return lift { $0.map(keyPath) }
+		return liftNonSerializing { $0.map(keyPath) }
 	}
 
 	/// Passes only the values of the property that pass the given predicate
@@ -176,7 +181,7 @@ extension PropertyProtocol {
 	/// - returns: A property that holds tuples that contain previous and
 	///            current values of `self`.
 	public func combinePrevious(_ initial: Value) -> Property<(Value, Value)> {
-		return lift { $0.combinePrevious(initial) }
+		return liftNonSerializing { $0.combinePrevious(initial) }
 	}
 
 	/// Forward only values from `self` that are not considered equivalent to its
@@ -189,7 +194,7 @@ extension PropertyProtocol {
 	///
 	/// - returns: A property which conditionally forwards values from `self`.
 	public func skipRepeats(_ isEquivalent: @escaping (Value, Value) -> Bool) -> Property<Value> {
-		return lift { $0.skipRepeats(isEquivalent) }
+		return liftNonSerializing { $0.skipRepeats(isEquivalent) }
 	}
 }
 
@@ -200,7 +205,7 @@ extension PropertyProtocol where Value: Equatable {
 	///
 	/// - returns: A property which conditionally forwards values from `self`.
 	public func skipRepeats() -> Property<Value> {
-		return lift { $0.skipRepeats() }
+		return liftNonSerializing { $0.skipRepeats() }
 	}
 }
 
@@ -243,7 +248,7 @@ extension PropertyProtocol {
 	///
 	/// - returns: A property that sends unique values during its lifetime.
 	public func uniqueValues<Identity: Hashable>(_ transform: @escaping (Value) -> Identity) -> Property<Value> {
-		return lift { $0.uniqueValues(transform) }
+		return liftNonSerializing { $0.uniqueValues(transform) }
 	}
 }
 
@@ -257,7 +262,7 @@ extension PropertyProtocol where Value: Hashable {
 	///
 	/// - returns: A property that sends unique values during its lifetime.
 	public func uniqueValues() -> Property<Value> {
-		return lift { $0.uniqueValues() }
+		return liftNonSerializing { $0.uniqueValues() }
 	}
 }
 
@@ -420,7 +425,7 @@ extension PropertyProtocol where Value == Bool {
 	///
 	/// - returns: A property that contains the logical NOT results.
 	public func negate() -> Property<Value> {
-		return self.lift { $0.negate() }
+		return liftNonSerializing { $0.negate() }
 	}
 
 	/// Create a property that computes a logical AND between the latest values of `self`
@@ -598,7 +603,7 @@ public final class Property<Value>: PropertyProtocol {
 	///
 	/// - parameters:
 	///   - unsafeProducer: The composed producer for creating the property.
-	fileprivate init(unsafeProducer: SignalProducer<Value, Never>) {
+	fileprivate init(unsafeProducer: SignalProducer<Value, Never>, nonSerializing: Bool = false) {
 		// The ownership graph:
 		//
 		// ------------     weak  -----------    strong ------------------
@@ -614,7 +619,9 @@ public final class Property<Value>: PropertyProtocol {
 		// A composed property tracks its active consumers through its relay signal, and
 		// interrupts `unsafeProducer` if the relay signal terminates.
 		let disposable = SerialDisposable()
-		let (relay, observer) = Signal<Value, Never>.pipe(disposable: disposable)
+		let (relay, observer) = nonSerializing
+			? Signal<Value, Never>.nonSerializingPipe(disposable: disposable)
+			: Signal<Value, Never>.pipe(disposable: disposable)
 
 		disposable.inner = unsafeProducer.start { [weak box] event in
 			// `observer` receives `interrupted` only as a result of the termination of
@@ -646,7 +653,7 @@ public final class Property<Value>: PropertyProtocol {
 		_value = { box.value! }
 		signal = relay
 
-		producer = SignalProducer { [box, relay] observer, lifetime in
+		producer = SignalProducer.nonSerializing { [box, relay] observer, lifetime in
 			box.withValue { value in
 				observer.send(value: value!)
 				lifetime += relay.observe(Signal.Observer(mappingInterruptedToCompleted: observer))
@@ -719,7 +726,7 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 	/// followed by all changes over time, then complete when the property has
 	/// deinitialized.
 	public var producer: SignalProducer<Value, Never> {
-		return SignalProducer { [box, signal] observer, lifetime in
+		return SignalProducer.nonSerializing { [box, signal] observer, lifetime in
 			box.withValue { value in
 				observer.send(value: value)
 				lifetime += signal.observe(Signal.Observer(mappingInterruptedToCompleted: observer))
@@ -732,7 +739,7 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 	/// - parameters:
 	///   - initialValue: Starting value for the mutable property.
 	public init(_ initialValue: Value) {
-		(signal, observer) = Signal.pipe()
+		(signal, observer) = Signal.nonSerializingPipe()
 		(lifetime, token) = Lifetime.make()
 
 		/// Need a recursive lock around `value` to allow recursive access to

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -86,8 +86,8 @@ extension PropertyProtocol {
 	}
 
 	/// Lifts a unary SignalProducer operator to operate upon PropertyProtocol instead.
-	fileprivate func liftNonSerializing<U>(_ transform: @escaping (SignalProducer<Value, Never>) -> SignalProducer<U, Never>) -> Property<U> {
-		return Property(unsafeProducer: transform(producer), nonSerializing: true)
+	fileprivate func liftUnserialized<U>(_ transform: @escaping (SignalProducer<Value, Never>) -> SignalProducer<U, Never>) -> Property<U> {
+		return Property(unsafeProducer: transform(producer), unserialized: true)
 	}
 
 	/// Lifts a binary SignalProducer operator to operate upon PropertyProtocol instead.
@@ -107,7 +107,7 @@ extension PropertyProtocol {
 	///
 	/// - returns: A property that holds a mapped value from `self`.
 	public func map<U>(_ transform: @escaping (Value) -> U) -> Property<U> {
-		return liftNonSerializing { $0.map(transform) }
+		return liftUnserialized { $0.map(transform) }
 	}
 	
 	/// Map the current value and all susequent values to a new constant property.
@@ -117,7 +117,7 @@ extension PropertyProtocol {
 	///
 	/// - returns: A property that holds a mapped value from `self`.
 	public func map<U>(value: U) -> Property<U> {
-		return liftNonSerializing { $0.map(value: value) }
+		return liftUnserialized { $0.map(value: value) }
 	}
 
 	/// Maps the current value and all subsequent values to a new property
@@ -128,7 +128,7 @@ extension PropertyProtocol {
 	///
 	/// - returns: A property that holds a mapped value from `self`.
 	public func map<U>(_ keyPath: KeyPath<Value, U>) -> Property<U> {
-		return liftNonSerializing { $0.map(keyPath) }
+		return liftUnserialized { $0.map(keyPath) }
 	}
 
 	/// Passes only the values of the property that pass the given predicate
@@ -181,7 +181,7 @@ extension PropertyProtocol {
 	/// - returns: A property that holds tuples that contain previous and
 	///            current values of `self`.
 	public func combinePrevious(_ initial: Value) -> Property<(Value, Value)> {
-		return liftNonSerializing { $0.combinePrevious(initial) }
+		return liftUnserialized { $0.combinePrevious(initial) }
 	}
 
 	/// Forward only values from `self` that are not considered equivalent to its
@@ -194,7 +194,7 @@ extension PropertyProtocol {
 	///
 	/// - returns: A property which conditionally forwards values from `self`.
 	public func skipRepeats(_ isEquivalent: @escaping (Value, Value) -> Bool) -> Property<Value> {
-		return liftNonSerializing { $0.skipRepeats(isEquivalent) }
+		return liftUnserialized { $0.skipRepeats(isEquivalent) }
 	}
 }
 
@@ -205,7 +205,7 @@ extension PropertyProtocol where Value: Equatable {
 	///
 	/// - returns: A property which conditionally forwards values from `self`.
 	public func skipRepeats() -> Property<Value> {
-		return liftNonSerializing { $0.skipRepeats() }
+		return liftUnserialized { $0.skipRepeats() }
 	}
 }
 
@@ -248,7 +248,7 @@ extension PropertyProtocol {
 	///
 	/// - returns: A property that sends unique values during its lifetime.
 	public func uniqueValues<Identity: Hashable>(_ transform: @escaping (Value) -> Identity) -> Property<Value> {
-		return liftNonSerializing { $0.uniqueValues(transform) }
+		return liftUnserialized { $0.uniqueValues(transform) }
 	}
 }
 
@@ -262,7 +262,7 @@ extension PropertyProtocol where Value: Hashable {
 	///
 	/// - returns: A property that sends unique values during its lifetime.
 	public func uniqueValues() -> Property<Value> {
-		return liftNonSerializing { $0.uniqueValues() }
+		return liftUnserialized { $0.uniqueValues() }
 	}
 }
 
@@ -425,7 +425,7 @@ extension PropertyProtocol where Value == Bool {
 	///
 	/// - returns: A property that contains the logical NOT results.
 	public func negate() -> Property<Value> {
-		return liftNonSerializing { $0.negate() }
+		return liftUnserialized { $0.negate() }
 	}
 
 	/// Create a property that computes a logical AND between the latest values of `self`
@@ -623,7 +623,7 @@ public final class Property<Value>: PropertyProtocol {
 	///
 	/// - parameters:
 	///   - unsafeProducer: The composed producer for creating the property.
-	fileprivate init(unsafeProducer: SignalProducer<Value, Never>, nonSerializing: Bool = false) {
+	fileprivate init(unsafeProducer: SignalProducer<Value, Never>, unserialized: Bool = false) {
 		// The ownership graph:
 		//
 		// ------------     weak  -----------    strong ------------------
@@ -639,8 +639,8 @@ public final class Property<Value>: PropertyProtocol {
 		// A composed property tracks its active consumers through its relay signal, and
 		// interrupts `unsafeProducer` if the relay signal terminates.
 		let disposable = SerialDisposable()
-		let (relay, observer) = nonSerializing
-			? Signal<Value, Never>.nonSerializingPipe(disposable: disposable)
+		let (relay, observer) = unserialized
+			? Signal<Value, Never>.unserializedPipe(disposable: disposable)
 			: Signal<Value, Never>.pipe(disposable: disposable)
 
 		disposable.inner = unsafeProducer.start { [weak box] event in
@@ -673,7 +673,7 @@ public final class Property<Value>: PropertyProtocol {
 		_value = { box.value! }
 		signal = relay
 
-		producer = SignalProducer.nonSerializing { [box, relay] observer, lifetime in
+		producer = SignalProducer.unserialized { [box, relay] observer, lifetime in
 			box.withValue { value in
 				observer.send(value: value!)
 				lifetime += relay.observe(Signal.Observer(mappingInterruptedToCompleted: observer))
@@ -746,7 +746,7 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 	/// followed by all changes over time, then complete when the property has
 	/// deinitialized.
 	public var producer: SignalProducer<Value, Never> {
-		return SignalProducer.nonSerializing { [box, signal] observer, lifetime in
+		return SignalProducer.unserialized { [box, signal] observer, lifetime in
 			box.withValue { value in
 				observer.send(value: value)
 				lifetime += signal.observe(Signal.Observer(mappingInterruptedToCompleted: observer))
@@ -759,7 +759,7 @@ public final class MutableProperty<Value>: ComposableMutablePropertyProtocol {
 	/// - parameters:
 	///   - initialValue: Starting value for the mutable property.
 	public init(_ initialValue: Value) {
-		(signal, observer) = Signal.nonSerializingPipe()
+		(signal, observer) = Signal.unserializedPipe()
 		(lifetime, token) = Lifetime.make()
 
 		/// Need a recursive lock around `value` to allow recursive access to

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -80,6 +80,8 @@ public final class Signal<Value, Error: Swift.Error> {
 			generator(Observer(action: self.send, interruptsOnDeinit: true), Lifetime(disposable))
 		}
 
+		@_specialize(kind: partial, where SendLock == Lock)
+		@_specialize(kind: partial, where SendLock == NoLock)
 		private func send(_ event: Event) {
 			if event.isTerminating {
 				// Recursive events are disallowed for `value` events, but are permitted

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -43,9 +43,14 @@ public final class Signal<Value, Error: Swift.Error> {
 	///            | Other observers |                                 | Other observers |
 	///            -------------------                                 -------------------
 	/// ```
-	private let core: Core
+	private let core: CoreBase
 
-	private final class Core {
+    private class CoreBase {
+        func observe(_ observer: Observer) -> Disposable? { fatalError() }
+        func signalDidDeinitialize() { fatalError() }
+    }
+
+    private final class Core<SendLock: LockProtocol>: CoreBase {
 		/// The disposable associated with the signal.
 		///
 		/// Disposing of `disposable` is assumed to remove the generator
@@ -60,19 +65,24 @@ public final class Signal<Value, Error: Swift.Error> {
 		private let stateLock: Lock
 
 		/// Used to ensure that events are serialized during delivery to observers.
-		private let sendLock: Lock
+		private let sendLock: SendLock
 
-		fileprivate init(_ generator: (Observer, Lifetime) -> Void) {
+        fileprivate init(_ generator: (Observer, Lifetime) -> Void) {
 			state = .alive(Bag(), hasDeinitialized: false)
 
 			stateLock = Lock.make()
-			sendLock = Lock.make()
+			sendLock = SendLock.make()
 			disposable = CompositeDisposable()
+
+            super.init()
 
 			// The generator observer retains the `Signal` core.
 			generator(Observer(action: self.send, interruptsOnDeinit: true), Lifetime(disposable))
 		}
 
+
+        @_specialize(exported: true, kind: partial, where SendLock == Lock)
+        @_specialize(exported: true, kind: partial, where SendLock == NoLock)
 		private func send(_ event: Event) {
 			if event.isTerminating {
 				// Recursive events are disallowed for `value` events, but are permitted
@@ -151,7 +161,7 @@ public final class Signal<Value, Error: Swift.Error> {
 		///
 		/// - returns: A `Disposable` which can be used to disconnect the observer,
 		///            or `nil` if the signal has already terminated.
-		fileprivate func observe(_ observer: Observer) -> Disposable? {
+		fileprivate override func observe(_ observer: Observer) -> Disposable? {
 			var token: Bag<Observer>.Token?
 
 			stateLock.lock()
@@ -268,7 +278,7 @@ public final class Signal<Value, Error: Swift.Error> {
 		}
 
 		/// Acknowledge the deinitialization of the `Signal`.
-		fileprivate func signalDidDeinitialize() {
+		fileprivate override func signalDidDeinitialize() {
 			stateLock.lock()
 
 			// Mark the `Signal` has now deinitialized.
@@ -285,8 +295,15 @@ public final class Signal<Value, Error: Swift.Error> {
 		}
 	}
 
+    private init(_ core: CoreBase) {
+        self.core = core
+    }
+
 	/// Initialize a Signal that will immediately invoke the given generator,
-	/// then forward events sent to the given observer.
+	/// then forward events sent to the given input observer.
+    ///
+    /// The input observer serializes events it received. In other words, it is thread safe, and
+    /// can be called on multiple threads concurrently.
 	///
 	/// - note: The disposable returned from the closure will be automatically
 	///         disposed if a terminating event is sent to the observer. The
@@ -295,9 +312,75 @@ public final class Signal<Value, Error: Swift.Error> {
 	/// - parameters:
 	///   - generator: A closure that accepts an implicitly created observer
 	///                that will act as an event emitter for the signal.
-	public init(_ generator: (Observer, Lifetime) -> Void) {
-		core = Core(generator)
+    public convenience init(_ generator: (Observer, Lifetime) -> Void) {
+        self.init(Core<Lock>(generator))
 	}
+
+    /// Initialize a Signal that will immediately invoke the given generator,
+    /// then forward events sent to the given non-serializing input observer.
+    ///
+    /// Unlike `init(_:)`, the provided input observer does not serialize the events it received, with the assumption
+    /// that it can inherit mutual exclusion from its callers.
+    ///
+    /// Note that the created `Signal` still guarantees thread safe observer manipulation.
+    ///
+    /// - warning: The input observer **is not thread safe**.
+    ///
+    /// - note: The disposable returned from the closure will be automatically
+    ///         disposed if a terminating event is sent to the observer. The
+    ///         Signal itself will remain alive until the observer is released.
+    ///
+    /// - parameters:
+    ///   - generator: A closure that accepts an implicitly created observer
+    ///                that will act as an event emitter for the signal.
+    public static func nonSerializing(_ generator: (Observer, Lifetime) -> Void) -> Signal {
+        self.init(Core<NoLock>(generator))
+    }
+
+    /// Initialize a Signal that will immediately invoke the given generator,
+    /// then forward events sent to the given non-serializing, reentrant input observer.
+    ///
+    /// The provided input observer does not serialize the events it received — akin to `nonSerializing(_:)`. Meanwhile,
+    /// it supports **reentrancy** via a queue drain strategy, which is otherwise unsupported in the default `Signal`
+    /// variant.
+    ///
+    /// Recursively sent events are enqueued, and are drained first-in-first-out after the current event has completed
+    /// calling out to all observers.
+    ///
+    /// Note that the created `Signal` still guarantees thread safe observer manipulation.
+    ///
+    /// - warning: The input observer **is not thread safe**.
+    ///
+    /// - note: The disposable returned from the closure will be automatically
+    ///         disposed if a terminating event is sent to the observer. The
+    ///         Signal itself will remain alive until the observer is released.
+    ///
+    /// - parameters:
+    ///   - generator: A closure that accepts an implicitly created observer
+    ///                that will act as an event emitter for the signal.
+    public static func reentrant(_ generator: (Observer, Lifetime) -> Void) -> Signal {
+        self.init(Core<NoLock> { innerObserver, lifetime in
+            var eventQueue: [Event] = []
+            var isInLoop = false
+
+            let wrappedObserver = Observer { outerEvent in
+                if !isInLoop {
+                    isInLoop = true
+                    innerObserver.send(outerEvent)
+
+                    while !eventQueue.isEmpty {
+                        innerObserver.send(eventQueue.removeLast())
+                    }
+
+                    isInLoop = false
+                } else {
+                    eventQueue.insert(outerEvent, at: 0)
+                }
+            }
+
+            generator(wrappedObserver, lifetime)
+        })
+    }
 
 	/// Observe the Signal by sending any future events to the given observer.
 	///
@@ -392,6 +475,9 @@ extension Signal {
 
 	/// Create a `Signal` that will be controlled by sending events to an
 	/// input observer.
+    ///
+    /// The input observer serializes events it received. In other words, it is thread safe, and
+    /// can be called on multiple threads concurrently.
 	///
 	/// - note: The `Signal` will remain alive until a terminating event is sent
 	///         to the input observer, or until it has no observers and there
@@ -413,6 +499,72 @@ extension Signal {
 
 		return (signal, observer)
 	}
+
+    /// Create a `Signal` that will be controlled by sending events to an
+    /// non-serializing input observer.
+    ///
+    /// Unlike `init(_:)`, the provided input observer does not serialize the events it received, with the assumption
+    /// that it can inherit mutual exclusion from its callers.
+    ///
+    /// Note that the created `Signal` still guarantees thread safe observer manipulation.
+    ///
+    /// - warning: The input observer **is not thread safe**.
+    ///
+    /// - note: The `Signal` will remain alive until a terminating event is sent
+    ///         to the input observer, or until it has no observers and there
+    ///         are no strong references to it.
+    ///
+    /// - parameters:
+    ///   - disposable: An optional disposable to associate with the signal, and
+    ///                 to be disposed of when the signal terminates.
+    ///
+    /// - returns: A 2-tuple of the output end of the pipe as `Signal`, and the input end
+    ///            of the pipe as `Signal.Observer`.
+    public static func nonSerializingPipe(disposable: Disposable? = nil) -> (output: Signal, input: Observer) {
+        var observer: Observer!
+
+        let signal = nonSerializing { innerObserver, lifetime in
+            observer = innerObserver
+            lifetime += disposable
+        }
+
+        return (signal, observer)
+    }
+
+    /// Create a `Signal` that will be controlled by sending events to an
+    /// non-serializing, reentrant input observer.
+    ///
+    /// The provided input observer does not serialize the events it received — akin to `nonSerializing(_:)`. Meanwhile,
+    /// it supports **reentrancy** via a queue drain strategy, which is otherwise unsupported in the default `Signal`
+    /// variant.
+    ///
+    /// Recursively sent events are enqueued, and are drained first-in-first-out after the current event has completed
+    /// calling out to all observers.
+    ///
+    /// Note that the created `Signal` still guarantees thread safe observer manipulation.
+    ///
+    /// - warning: The input observer **is not thread safe**.
+    ///
+    /// - note: The `Signal` will remain alive until a terminating event is sent
+    ///         to the input observer, or until it has no observers and there
+    ///         are no strong references to it.
+    ///
+    /// - parameters:
+    ///   - disposable: An optional disposable to associate with the signal, and
+    ///                 to be disposed of when the signal terminates.
+    ///
+    /// - returns: A 2-tuple of the output end of the pipe as `Signal`, and the input end
+    ///            of the pipe as `Signal.Observer`.
+    public static func reentrantPipe(disposable: Disposable? = nil) -> (output: Signal, input: Observer) {
+        var observer: Observer!
+
+        let signal = reentrant { innerObserver, lifetime in
+            observer = innerObserver
+            lifetime += disposable
+        }
+
+        return (signal, observer)
+    }
 }
 
 public protocol SignalProtocol: class {
@@ -538,7 +690,7 @@ extension Signal {
 	///
 	/// - returns: A signal that forwards events yielded by the action.
 	internal func flatMapEvent<U, E>(_ transform: @escaping Event.Transformation<U, E>) -> Signal<U, E> {
-		return Signal<U, E> { output, lifetime in
+        return Signal<U, E> { output, lifetime in
 			// Create an input sink whose events would go through the given
 			// event transformation, and have the resulting events propagated
 			// to the resulting `Signal`.

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1100,7 +1100,7 @@ extension Signal {
 		disposed: (() -> Void)? = nil,
 		value: ((Value) -> Void)? = nil
 	) -> Signal<Value, Error> {
-		return Signal { observer, lifetime in
+		return Signal.nonSerializing { observer, lifetime in
 			if let action = disposed {
 				lifetime.observeEnded(action)
 			}
@@ -1244,7 +1244,7 @@ extension Signal {
 	///            once `self` has terminated. **`samplee`'s terminated events
 	///            are ignored**.
 	public func withLatest<U>(from samplee: Signal<U, Never>) -> Signal<(Value, U), Error> {
-		return Signal<(Value, U), Error> { observer, lifetime in
+		return Signal<(Value, U), Error>.nonSerializing { observer, lifetime in
 			let state = Atomic<U?>(nil)
 
 			lifetime += samplee.observeValues { value in

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -690,7 +690,7 @@ extension Signal {
 	///
 	/// - returns: A signal that forwards events yielded by the action.
 	internal func flatMapEvent<U, E>(_ transform: @escaping Event.Transformation<U, E>) -> Signal<U, E> {
-        return Signal<U, E> { output, lifetime in
+        return Signal<U, E>.nonSerializing { output, lifetime in
 			// Create an input sink whose events would go through the given
 			// event transformation, and have the resulting events propagated
 			// to the resulting `Signal`.

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -355,7 +355,7 @@ public final class Signal<Value, Error: Swift.Error> {
 	/// - parameters:
 	///   - generator: A closure that accepts an implicitly created observer
 	///                that will act as an event emitter for the signal.
-	public static func reentrant(_ generator: (Observer, Lifetime) -> Void) -> Signal {
+	public static func reentrantUnserialized(_ generator: (Observer, Lifetime) -> Void) -> Signal {
 		self.init(Core<NoLock> { innerObserver, lifetime in
 			var eventQueue: [Event] = []
 			var isInLoop = false
@@ -552,10 +552,10 @@ extension Signal {
 	///
 	/// - returns: A 2-tuple of the output end of the pipe as `Signal`, and the input end
 	///            of the pipe as `Signal.Observer`.
-	public static func reentrantPipe(disposable: Disposable? = nil) -> (output: Signal, input: Observer) {
+	public static func reentrantUnserializedPipe(disposable: Disposable? = nil) -> (output: Signal, input: Observer) {
 		var observer: Observer!
 
-		let signal = reentrant { innerObserver, lifetime in
+		let signal = reentrantUnserialized { innerObserver, lifetime in
 			observer = innerObserver
 			lifetime += disposable
 		}

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -80,9 +80,6 @@ public final class Signal<Value, Error: Swift.Error> {
 			generator(Observer(action: self.send, interruptsOnDeinit: true), Lifetime(disposable))
 		}
 
-
-		@_specialize(exported: true, kind: partial, where SendLock == Lock)
-		@_specialize(exported: true, kind: partial, where SendLock == NoLock)
 		private func send(_ event: Event) {
 			if event.isTerminating {
 				// Recursive events are disallowed for `value` events, but are permitted

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -200,50 +200,50 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
-        describe("reentrant") {
-            #if arch(x86_64) && canImport(Darwin)
-            it("should not crash") {
-                let (signal, observer) = Signal<Int, Never>.reentrantPipe()
-                var values: [Int] = []
+		describe("reentrant") {
+			#if arch(x86_64) && canImport(Darwin)
+			it("should not crash") {
+				let (signal, observer) = Signal<Int, Never>.reentrantPipe()
+				var values: [Int] = []
 
-                signal
-                    .take(first: 5)
-                    .map { $0 + 1 }
-                    .on { values.append($0) }
-                    .observeValues(observer.send(value:))
+				signal
+					.take(first: 5)
+					.map { $0 + 1 }
+					.on { values.append($0) }
+					.observeValues(observer.send(value:))
 
-                expect {
-                    observer.send(value: 1)
-                }.toNot(throwAssertion())
+				expect {
+					observer.send(value: 1)
+				}.toNot(throwAssertion())
 
-                expect(values) == [2, 3, 4, 5, 6]
-            }
-            #endif
+				expect(values) == [2, 3, 4, 5, 6]
+			}
+			#endif
 
-            it("should drain enqueued values in submission order after the observer callout has completed") {
-                let (signal, observer) = Signal<Int, Never>.reentrantPipe()
-                var values: [Int] = []
+			it("should drain enqueued values in submission order after the observer callout has completed") {
+				let (signal, observer) = Signal<Int, Never>.reentrantPipe()
+				var values: [Int] = []
 
-                signal
-                    .take(first: 1)
-                    .observeValues { _ in
-                        observer.send(value: 10)
-                        observer.send(value: 100)
-                    }
+				signal
+					.take(first: 1)
+					.observeValues { _ in
+						observer.send(value: 10)
+						observer.send(value: 100)
+				}
 
-                signal
-                    .take(first: 1)
-                    .observeValues { _ in
-                        observer.send(value: 20)
-                        observer.send(value: 200)
-                    }
+				signal
+					.take(first: 1)
+					.observeValues { _ in
+						observer.send(value: 20)
+						observer.send(value: 200)
+				}
 
-                signal.observeValues { values.append($0) }
+				signal.observeValues { values.append($0) }
 
-                observer.send(value: 0)
-                expect(values) == [0, 10, 100, 20, 200]
-            }
-        }
+				observer.send(value: 0)
+				expect(values) == [0, 10, 100, 20, 200]
+			}
+		}
 
 		describe("Signal.pipe") {
 			it("should forward events to observers") {

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -200,10 +200,10 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
-		describe("reentrant") {
+		describe("reentrantUnserialized") {
 			#if arch(x86_64) && canImport(Darwin)
 			it("should not crash") {
-				let (signal, observer) = Signal<Int, Never>.reentrantPipe()
+				let (signal, observer) = Signal<Int, Never>.reentrantUnserializedPipe()
 				var values: [Int] = []
 
 				signal
@@ -221,7 +221,7 @@ class SignalSpec: QuickSpec {
 			#endif
 
 			it("should drain enqueued values in submission order after the observer callout has completed") {
-				let (signal, observer) = Signal<Int, Never>.reentrantPipe()
+				let (signal, observer) = Signal<Int, Never>.reentrantUnserializedPipe()
 				var values: [Int] = []
 
 				signal

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -200,6 +200,27 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
+        describe("reentrant") {
+            #if arch(x86_64) && canImport(Darwin)
+            it("should not crash") {
+                let (signal, observer) = Signal<Int, Never>.reentrantPipe()
+                var values: [Int] = []
+
+                signal
+                    .take(first: 5)
+                    .map { $0 + 1 }
+                    .on { values.append($0) }
+                    .observeValues(observer.send(value:))
+
+                expect {
+                    observer.send(value: 1)
+                }.toNot(throwAssertion())
+
+                expect(values) == [2, 3, 4, 5, 6]
+            }
+            #endif
+        }
+
 		describe("Signal.pipe") {
 			it("should forward events to observers") {
 				let (signal, observer) = Signal<Int, Never>.pipe()

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -219,6 +219,30 @@ class SignalSpec: QuickSpec {
                 expect(values) == [2, 3, 4, 5, 6]
             }
             #endif
+
+            it("should drain enqueued values in submission order after the observer callout has completed") {
+                let (signal, observer) = Signal<Int, Never>.reentrantPipe()
+                var values: [Int] = []
+
+                signal
+                    .take(first: 1)
+                    .observeValues { _ in
+                        observer.send(value: 10)
+                        observer.send(value: 100)
+                    }
+
+                signal
+                    .take(first: 1)
+                    .observeValues { _ in
+                        observer.send(value: 20)
+                        observer.send(value: 200)
+                    }
+
+                signal.observeValues { values.append($0) }
+
+                observer.send(value: 0)
+                expect(values) == [0, 10, 100, 20, 200]
+            }
         }
 
 		describe("Signal.pipe") {


### PR DESCRIPTION
1. `Signal` now offers an unserialized variant and a reentrant variant for advanced users. (#797)

   These new primitives would be adopted by ReactiveCocoa UIKit bindings to improve interoperability with RAC Loop, to tackle some legitimate recursive delivery scenarios (e.g. around first responder management), and also to reduce fine-grained locking across ReactiveSwift and ReactiveCocoa.

   Note that the default behavior of `Signal` has not been changed — event serialization remains the default behavior. `MutableProperty` is also not gonna be reentrant, because there is no sane reentrancy model that supports access to the current value and multicasting [while being compliant to the Property contract](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Documentation/APIContracts.md#events-must-be-synchronously-emitted-after-the-mutation-is-visible).

1. Fine-grained locking has been scaled down across Signal, SignalProducer and Property. (#797)

    [Observers are naturally inheriting mutual exclusion from upstream, because the upstream has to serialize the events to be compliant to the Event contract](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Documentation/APIContracts.md#events-are-serial). So for most transformations involving only one event stream (Signal/Producer), the locks for serializing events are redundant. This is also the same premise that RAS 2.0 producer optimizations are built upon.

    This similarly applies to Properties — both the read-only and the mutable versions have their own locks for mutual exclusion. So for them, the only value which the default event serialization in `Signal`/`SignalProducer` brings is wasting CPU time.

#### Checklist
- [x] Updated CHANGELOG.md.
