### PR TITLE
Producer constraints (OfMany, OfOne, Completable)

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/EventLogger.swift
+++ b/Sources/EventLogger.swift
@@ -101,7 +101,7 @@ extension Signal {
 	}
 }
 
-extension SignalProducer {
+extension Producer where Constraint: ProducerOfManyConstraint {
 	/// Logs all events that the receiver sends. By default, it will print to 
 	/// the standard output.
 	///

--- a/Sources/EventLogger.swift
+++ b/Sources/EventLogger.swift
@@ -101,7 +101,7 @@ extension Signal {
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint {
+extension Producer where Constraint == OfMany {
 	/// Logs all events that the receiver sends. By default, it will print to 
 	/// the standard output.
 	///

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -1234,7 +1234,7 @@ extension Signal {
 	}
 }
 
-extension SignalProducer {
+extension Producer where Constraint == OfMany {
 	/// Catches any failure that may occur on the input producer, mapping to a
 	/// new producer that starts in its place.
 	///

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -205,7 +205,7 @@ extension Signal where Value: SignalProducerConvertible, Value.Error == Never {
 	}
 }
 
-extension SignalProducer where Value: SignalProducerConvertible, Error == Value.Error {
+extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Value.Error {
 	/// Flattens the inner producers sent upon `producer` (into a single
 	/// producer of values), according to the semantics of the given strategy.
 	///
@@ -234,7 +234,7 @@ extension SignalProducer where Value: SignalProducerConvertible, Error == Value.
 	}
 }
 
-extension SignalProducer where Value: SignalProducerConvertible, Error == Never {
+extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Never {
 	/// Flattens the inner producers sent upon `producer` (into a single
 	/// producer of values), according to the semantics of the given strategy.
 	///
@@ -253,7 +253,7 @@ extension SignalProducer where Value: SignalProducerConvertible, Error == Never 
 	}
 }
 
-extension SignalProducer where Value: SignalProducerConvertible, Error == Never, Value.Error == Never {
+extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Never, Value.Error == Never {
 	/// Flattens the inner producers sent upon `producer` (into a single
 	/// producer of values), according to the semantics of the given strategy.
 	///
@@ -279,7 +279,7 @@ extension SignalProducer where Value: SignalProducerConvertible, Error == Never,
 	}
 }
 
-extension SignalProducer where Value: SignalProducerConvertible, Value.Error == Never {
+extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Value.Error == Never {
 	/// Flattens the inner producers sent upon `signal` (into a single signal of
 	/// values), according to the semantics of the given strategy.
 	///
@@ -303,7 +303,7 @@ extension Signal where Value: Sequence {
 	}
 }
 
-extension SignalProducer where Value: Sequence {
+extension Producer where Constraint: ProducerOfManyConstraint, Value: Sequence {
 	/// Flattens the `sequence` value sent by `signal`.
 	public func flatten() -> SignalProducer<Value.Iterator.Element, Error> {
 		return self.flatMap(.merge, SignalProducer<Value.Iterator.Element, Never>.init)
@@ -386,7 +386,7 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	}
 }
 
-extension SignalProducer where Value: SignalProducerConvertible, Error == Value.Error {
+extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Value.Error {
 	fileprivate func concurrent(limit: UInt) -> SignalProducer<Value.Value, Error> {
 		precondition(limit > 0, "The concurrent limit must be greater than zero.")
 
@@ -400,7 +400,7 @@ extension SignalProducer where Value: SignalProducerConvertible, Error == Value.
 	}
 }
 
-extension SignalProducer {
+extension Producer where Constraint: ProducerOfManyConstraint {
 	/// `concat`s `next` onto `self`.
 	///
 	/// - parameters:
@@ -409,7 +409,7 @@ extension SignalProducer {
 	/// - returns: A producer that will start `self` and then on completion of
 	///            `self` - will start `next`.
 	public func concat(_ next: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
-		return SignalProducer<SignalProducer<Value, Error>, Error>([ self, next ]).flatten(.concat)
+		return SignalProducer<SignalProducer<Value, Error>, Error>([ _self, next ]).flatten(.concat)
 	}
 
 	/// `concat`s `next` onto `self`.
@@ -551,7 +551,7 @@ extension Signal {
 	}
 }
 
-extension SignalProducer {
+extension Producer where Constraint: ProducerOfManyConstraint {
  	/// Merges the given producers into a single `SignalProducer` that will emit
 	/// all values from each of them, and complete when all of them have
 	/// completed.
@@ -699,7 +699,7 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	}
 }
 
-extension SignalProducer where Value: SignalProducerConvertible, Error == Value.Error {
+extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Value.Error {
 	/// - warning: An error sent on `self` or the latest inner producer will be
 	///            sent on the returned producer.
 	///
@@ -820,7 +820,7 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	}
 }
 
-extension SignalProducer where Value: SignalProducerConvertible, Error == Value.Error {
+extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Value.Error {
 	/// Returns a producer that forwards values from the "first input producer to send an event"
 	/// (winning producer) that is sent on `self`, ignoring values sent from other inner producers.
 	///
@@ -925,7 +925,7 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	}
 }
 
-extension SignalProducer where Value: SignalProducerConvertible, Error == Value.Error {
+extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Value.Error {
 	/// Returns a producer that forwards values from the "first inner producer" if not exists,
 	/// ignoring values sent from other inner producers until first inner producer is completed.
 	/// Note that next inner producer after previous completion can become first inner producer again.
@@ -1071,7 +1071,7 @@ extension Signal where Error == Never {
 	}
 }
 
-extension SignalProducer {
+extension Producer where Constraint: ProducerOfManyConstraint {
 	/// Maps each event from `self` to a new producer, then flattens the
 	/// resulting producers (into a producer of values), according to the
 	/// semantics of the given strategy.
@@ -1133,7 +1133,7 @@ extension SignalProducer {
 	}
 }
 
-extension SignalProducer where Error == Never {
+extension Producer where Constraint: ProducerOfManyConstraint, Error == Never {
 	/// Maps each event from `self` to a new producer, then flattens the
 	/// resulting producers (into a producer of values), according to the
 	/// semantics of the given strategy.

--- a/Sources/Flatten.swift
+++ b/Sources/Flatten.swift
@@ -205,7 +205,7 @@ extension Signal where Value: SignalProducerConvertible, Value.Error == Never {
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Value.Error {
+extension Producer where Constraint == OfMany, Value: SignalProducerConvertible, Error == Value.Error {
 	/// Flattens the inner producers sent upon `producer` (into a single
 	/// producer of values), according to the semantics of the given strategy.
 	///
@@ -234,7 +234,7 @@ extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProd
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Never {
+extension Producer where Constraint == OfMany, Value: SignalProducerConvertible, Error == Never {
 	/// Flattens the inner producers sent upon `producer` (into a single
 	/// producer of values), according to the semantics of the given strategy.
 	///
@@ -253,7 +253,7 @@ extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProd
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Never, Value.Error == Never {
+extension Producer where Constraint == OfMany, Value: SignalProducerConvertible, Error == Never, Value.Error == Never {
 	/// Flattens the inner producers sent upon `producer` (into a single
 	/// producer of values), according to the semantics of the given strategy.
 	///
@@ -279,7 +279,7 @@ extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProd
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Value.Error == Never {
+extension Producer where Constraint == OfMany, Value: SignalProducerConvertible, Value.Error == Never {
 	/// Flattens the inner producers sent upon `signal` (into a single signal of
 	/// values), according to the semantics of the given strategy.
 	///
@@ -303,7 +303,7 @@ extension Signal where Value: Sequence {
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint, Value: Sequence {
+extension Producer where Constraint == OfMany, Value: Sequence {
 	/// Flattens the `sequence` value sent by `signal`.
 	public func flatten() -> SignalProducer<Value.Iterator.Element, Error> {
 		return self.flatMap(.merge, SignalProducer<Value.Iterator.Element, Never>.init)
@@ -386,7 +386,7 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Value.Error {
+extension Producer where Constraint == OfMany, Value: SignalProducerConvertible, Error == Value.Error {
 	fileprivate func concurrent(limit: UInt) -> SignalProducer<Value.Value, Error> {
 		precondition(limit > 0, "The concurrent limit must be greater than zero.")
 
@@ -400,7 +400,7 @@ extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProd
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint {
+extension Producer where Constraint == OfMany {
 	/// `concat`s `next` onto `self`.
 	///
 	/// - parameters:
@@ -409,7 +409,7 @@ extension Producer where Constraint: ProducerOfManyConstraint {
 	/// - returns: A producer that will start `self` and then on completion of
 	///            `self` - will start `next`.
 	public func concat(_ next: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
-		return SignalProducer<SignalProducer<Value, Error>, Error>([ _self, next ]).flatten(.concat)
+		return SignalProducer<SignalProducer<Value, Error>, Error>([ self, next ]).flatten(.concat)
 	}
 
 	/// `concat`s `next` onto `self`.
@@ -551,7 +551,7 @@ extension Signal {
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint {
+extension Producer where Constraint == OfMany {
  	/// Merges the given producers into a single `SignalProducer` that will emit
 	/// all values from each of them, and complete when all of them have
 	/// completed.
@@ -699,7 +699,7 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Value.Error {
+extension Producer where Constraint == OfMany, Value: SignalProducerConvertible, Error == Value.Error {
 	/// - warning: An error sent on `self` or the latest inner producer will be
 	///            sent on the returned producer.
 	///
@@ -820,7 +820,7 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Value.Error {
+extension Producer where Constraint == OfMany, Value: SignalProducerConvertible, Error == Value.Error {
 	/// Returns a producer that forwards values from the "first input producer to send an event"
 	/// (winning producer) that is sent on `self`, ignoring values sent from other inner producers.
 	///
@@ -925,7 +925,7 @@ extension Signal where Value: SignalProducerConvertible, Error == Value.Error {
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint, Value: SignalProducerConvertible, Error == Value.Error {
+extension Producer where Constraint == OfMany, Value: SignalProducerConvertible, Error == Value.Error {
 	/// Returns a producer that forwards values from the "first inner producer" if not exists,
 	/// ignoring values sent from other inner producers until first inner producer is completed.
 	/// Note that next inner producer after previous completion can become first inner producer again.
@@ -1071,7 +1071,7 @@ extension Signal where Error == Never {
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint {
+extension Producer where Constraint == OfMany {
 	/// Maps each event from `self` to a new producer, then flattens the
 	/// resulting producers (into a producer of values), according to the
 	/// semantics of the given strategy.
@@ -1133,7 +1133,7 @@ extension Producer where Constraint: ProducerOfManyConstraint {
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint, Error == Never {
+extension Producer where Constraint == OfMany, Error == Never {
 	/// Maps each event from `self` to a new producer, then flattens the
 	/// resulting producers (into a producer of values), according to the
 	/// semantics of the given strategy.

--- a/Sources/Optional.swift
+++ b/Sources/Optional.swift
@@ -34,7 +34,7 @@ extension Signal {
 	}
 }
 
-extension SignalProducer {
+extension Producer where Constraint: ProducerOfManyConstraint {
 	/// Turns each value into an Optional.
 	internal func optionalize() -> SignalProducer<Value?, Error> {
 		return lift { $0.optionalize() }

--- a/Sources/Optional.swift
+++ b/Sources/Optional.swift
@@ -34,7 +34,7 @@ extension Signal {
 	}
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint {
+extension Producer where Constraint == OfMany {
 	/// Turns each value into an Optional.
 	internal func optionalize() -> SignalProducer<Value?, Error> {
 		return lift { $0.optionalize() }

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -309,7 +309,7 @@ private final class GeneratorCore<Value, Error: Swift.Error>: SignalProducerCore
 	}
 }
 
-extension SignalProducer where  Constraint: DeliversValue, Error == Never {
+extension Producer where Constraint: DeliversValue, Error == Never {
 	/// Creates a producer for a `Signal` that will immediately send one value
 	/// then complete.
 	///

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -11,8 +11,21 @@ public struct Multiple<U>: ProducerOfManyConstraint {
 	public typealias Value = U
 }
 
+public protocol ProducerOfOneConstraint: ProducerConstraint {}
+
+public struct One<U>: ProducerOfOneConstraint {
+	public typealias Value = U
+}
+
+public protocol CompletableConstraint: ProducerConstraint {}
+extension Never: CompletableConstraint {
+	public typealias Value = Never
+}
+
 public typealias SignalProducer<Value, Error: Swift.Error> = Producer<Multiple<Value>, Error>
 public typealias ProducerOfMany<Value, Error: Swift.Error> = Producer<Multiple<Value>, Error>
+public typealias ProducerOfOne<Value, Error: Swift.Error> = Producer<One<Value>, Error>
+public typealias Completable<Value, Error: Swift.Error> = Producer<Never, Error>
 
 /// A SignalProducer creates Signals that can produce values of type `Value`
 /// and/or fail with errors of type `Error`. If no failure should be possible,

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -43,6 +43,11 @@ public struct Producer<Constraint: ProducerConstraint, Value, Error: Swift.Error
 	/// - parameters:
 	///   - core: The `SignalProducer` core.
 	internal init(_ core: SignalProducerCore<Value, Error>) {
+		precondition(
+			Constraint.self != NoValue.self || Value.self == Never.self,
+			"A Producer with NoValue constraint should not be instantiable with Value != Never."
+		)
+
 		self.core = core
 	}
 

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -13,7 +13,7 @@ infix operator <~ : BindingPrecedence
 /// Describes a source which can be bound.
 public protocol BindingSource: SignalProducerConvertible where Error == Never {}
 extension Signal: BindingSource where Error == Never {}
-extension SignalProducer: BindingSource where Error == Never {}
+extension Producer: BindingSource where Constraint: ProducerOfManyConstraint, Error == Never {}
 
 /// Describes an entity which be bond towards.
 public protocol BindingTargetProvider {

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -13,7 +13,7 @@ infix operator <~ : BindingPrecedence
 /// Describes a source which can be bound.
 public protocol BindingSource: SignalProducerConvertible where Error == Never {}
 extension Signal: BindingSource where Error == Never {}
-extension Producer: BindingSource where Constraint: ProducerOfManyConstraint, Error == Never {}
+extension Producer: BindingSource where Constraint == OfMany, Error == Never {}
 
 /// Describes an entity which be bond towards.
 public protocol BindingTargetProvider {

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -3682,8 +3682,8 @@ private func == <T>(left: Expectation<T.Type>, right: Any.Type) {
 	}.requireNonNil)
 }
 
-extension SignalProducer {
-	internal static func pipe() -> (SignalProducer, ProducedSignal.Observer) {
+extension Producer where Constraint: ProducerOfManyConstraint {
+	internal static func pipe() -> (SignalProducer<Value, Error>, ProducedSignal.Observer) {
 		let (signal, observer) = ProducedSignal.pipe()
 		let producer = SignalProducer(signal)
 		return (producer, observer)

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -3682,7 +3682,7 @@ private func == <T>(left: Expectation<T.Type>, right: Any.Type) {
 	}.requireNonNil)
 }
 
-extension Producer where Constraint: ProducerOfManyConstraint {
+extension Producer where Constraint == OfMany {
 	internal static func pipe() -> (SignalProducer<Value, Error>, ProducedSignal.Observer) {
 		let (signal, observer) = ProducedSignal.pipe()
 		let producer = SignalProducer(signal)

--- a/Tests/ReactiveSwiftTests/TestError.swift
+++ b/Tests/ReactiveSwiftTests/TestError.swift
@@ -17,7 +17,7 @@ internal enum TestError: Int {
 extension TestError: Error {
 }
 
-internal extension Producer where Constraint: ProducerOfManyConstraint {
+internal extension Producer where Constraint == OfMany {
 	/// Halts if an error is emitted in the receiver signal.
 	/// This is useful in tests to be able to just use `startWithNext`
 	/// in cases where we know that an error won't be emitted.

--- a/Tests/ReactiveSwiftTests/TestError.swift
+++ b/Tests/ReactiveSwiftTests/TestError.swift
@@ -17,12 +17,12 @@ internal enum TestError: Int {
 extension TestError: Error {
 }
 
-internal extension SignalProducer {
+internal extension Producer where Constraint: ProducerOfManyConstraint {
 	/// Halts if an error is emitted in the receiver signal.
 	/// This is useful in tests to be able to just use `startWithNext`
 	/// in cases where we know that an error won't be emitted.
 	func assumeNoErrors() -> SignalProducer<Value, Never> {
-		return self.lift { $0.assumeNoErrors() }
+		return lift { $0.assumeNoErrors() }
 	}
 }
 


### PR DESCRIPTION
Note: **Source breaking** due to type inference now failing for `SignalProducer` w/o parameters specified.

Exploring limitations esp. in type inference and contextual lookup.

This PR introduces `ProducerOfOne<Value, Error>` and `Completable<Error>` into the ReactiveSwift family. The goals are:

1. all of them (incl. `SignalProducer` aka `ProducerOfMany`) share the same underlying implementation and most of the operators by leveraging the Swift generics system.

2. provide API differentiation at compile-time , e.g., strategy-less `flatMap` when it has a OfOne cosntraint, or replacing all compile-time "uninhabited type guards" warnings (that traps at runtime) with true compile-time unavailability.

#### Checklist
- [ ] Updated CHANGELOG.md.
