### PR TITLE
Add variadic sugar for boolean static methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 *Please add new entries at the top.*
 
+1. Add variadic sugar for boolean static methods such as `Property.any(boolProperty1, boolProperty2, boolProperty3)` (#801, kudos to @fortmarek)
 1. Fix a debug assertion in `Lock.try()` that could be raised in earlier OS versions (< iOS 10.0, < macOS 10.12). (#747, #788)
 
    Specifically, ReactiveSwift now recognizes `EDEADLK` as expected error code from `pthread_mutex_trylock` alongside `0`, `EBUSY` and `EAGAIN`.

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -443,6 +443,16 @@ extension PropertyProtocol where Value == Bool {
 	public static func all<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
 		return Property(initial: properties.map { $0.value }.reduce(true) { $0 && $1 }, then: SignalProducer.all(properties))
 	}
+    
+    /// Create a property that computes a logical AND between the latest values of `properties`.
+    ///
+    /// - parameters:
+    ///   - property: Properties to be combined.
+    ///
+    /// - returns: A property that contains the logical AND results.
+    public static func all<P: PropertyProtocol>(_ properties: P...) -> Property<Value> where P.Value == Value {
+        return .all(properties)
+    }
 
 	/// Create a property that computes a logical OR between the latest values of `self`
 	/// and `property`.
@@ -464,6 +474,16 @@ extension PropertyProtocol where Value == Bool {
 	public static func any<P: PropertyProtocol, Properties: Collection>(_ properties: Properties) -> Property<Value> where P.Value == Value, Properties.Element == P {
 		return Property(initial: properties.map { $0.value }.reduce(false) { $0 || $1 }, then: SignalProducer.any(properties))
 	}
+    
+    /// Create a property that computes a logical OR between the latest values of `properties`.
+    ///
+    /// - parameters:
+    ///   - properties: Properties to be combined.
+    ///
+    /// - returns: A property that contains the logical OR results.
+    public static func any<P: PropertyProtocol>(_ properties: P...) -> Property<Value> where P.Value == Value {
+        return Property.any(properties)
+    }
 }
 
 /// A read-only property that can be observed for its changes over time. There

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -482,7 +482,7 @@ extension PropertyProtocol where Value == Bool {
     ///
     /// - returns: A property that contains the logical OR results.
     public static func any<P: PropertyProtocol>(_ properties: P...) -> Property<Value> where P.Value == Value {
-        return Property.any(properties)
+        return .any(properties)
     }
 }
 

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -2210,6 +2210,16 @@ extension Signal where Value == Bool {
 	public static func all<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> Signal<Value, Error> where BooleansCollection.Element == Signal<Value, Error> {
 		return combineLatest(booleans).map { $0.reduce(true) { $0 && $1 } }
 	}
+    
+    /// Create a signal that computes a logical AND between the latest values of `booleans`.
+    ///
+    /// - parameters:
+    ///   - booleans: Boolean signals to be combined.
+    ///
+    /// - returns: A signal that emits the logical AND results.
+    public static func all(_ booleans: Signal<Value, Error>...) -> Signal<Value, Error> {
+        return .all(booleans)
+    }
 
 	/// Create a signal that computes a logical OR between the latest values of `self`
 	/// and `signal`.
@@ -2230,7 +2240,17 @@ extension Signal where Value == Bool {
 	/// - returns: A signal that emits the logical OR results.
 	public static func any<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> Signal<Value, Error> where BooleansCollection.Element == Signal<Value, Error> {
 		return combineLatest(booleans).map { $0.reduce(false) { $0 || $1 } }
-	}
+    }
+    
+    /// Create a signal that computes a logical OR between the latest values of `booleans`.
+    ///
+    /// - parameters:
+    ///   - booleans: Boolean signals to be combined.
+    ///
+    /// - returns: A signal that emits the logical OR results.
+    public static func any(_ booleans: Signal<Value, Error>...) -> Signal<Value, Error> {
+        return .any(booleans)
+    }
 }
 
 extension Signal {

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2770,6 +2770,18 @@ extension SignalProducer where Value == Bool {
 	public static func all<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
 		return combineLatest(booleans, emptySentinel: []).map { $0.reduce(true) { $0 && $1 } }
 	}
+    
+    /// Create a producer that computes a logical AND between the latest values of `booleans`.
+    ///
+    /// If no producer is given in `booleans`, the resulting producer constantly emits `true`.
+    ///
+    /// - parameters:
+    ///   - booleans: Boolean producers to be combined.
+    ///
+    /// - returns: A producer that emits the logical AND results.
+    public static func all(_ booleans: SignalProducer<Value, Error>...) -> SignalProducer<Value, Error> {
+        return .all(booleans)
+    }
 	
 	/// Create a producer that computes a logical AND between the latest values of `booleans`.
     ///
@@ -2816,6 +2828,18 @@ extension SignalProducer where Value == Bool {
 	public static func any<BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where BooleansCollection.Element == SignalProducer<Value, Error> {
 		return combineLatest(booleans, emptySentinel: []).map { $0.reduce(false) { $0 || $1 } }
 	}
+    
+    /// Create a producer that computes a logical OR between the latest values of `booleans`.
+    ///
+    /// If no producer is given in `booleans`, the resulting producer constantly emits `false`.
+    ///
+    /// - parameters:
+    ///   - booleans: Boolean producers to be combined.
+    ///
+    /// - returns: A producer that emits the logical OR results.
+    public static func any(_ booleans: SignalProducer<Value, Error>...) -> SignalProducer<Value, Error> {
+        return .any(booleans)
+    }
 	
 	/// Create a producer that computes a logical OR between the latest values of `booleans`.
 	///
@@ -2825,7 +2849,7 @@ extension SignalProducer where Value == Bool {
 	///   - booleans: A collection of boolean producers to be combined.
 	///
 	/// - returns: A producer that emits the logical OR results.
-	public static func any<Booleans: SignalProducerConvertible, BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error, BooleansCollection.Element == Booleans {
+	public static func  sBooleans: SignalProducerConvertible, BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error, BooleansCollection.Element == Booleans {
 		return any(booleans.map { $0.producer })
 	}
 }

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2849,7 +2849,7 @@ extension SignalProducer where Value == Bool {
 	///   - booleans: A collection of boolean producers to be combined.
 	///
 	/// - returns: A producer that emits the logical OR results.
-	public static func  sBooleans: SignalProducerConvertible, BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error, BooleansCollection.Element == Booleans {
+	public static func any<Booleans: SignalProducerConvertible, BooleansCollection: Collection>(_ booleans: BooleansCollection) -> SignalProducer<Value, Error> where Booleans.Value == Value, Booleans.Error == Error, BooleansCollection.Element == Booleans {
 		return any(booleans.map { $0.producer })
 	}
 }

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -1789,11 +1789,11 @@ class PropertySpec: QuickSpec {
 					expect(Property.any([property1, property2, property3]).value).to(beTrue())
 				}
 
-				it("should emit false when all properties in array contain false") {
+				it("should emit false when all properties contain false") {
 					let property1 = MutableProperty(false)
 					let property2 = MutableProperty(false)
 					let property3 = MutableProperty(false)
-					expect(Property.any([property1, property2, property3]).value).to(beFalse())
+					expect(Property.any(property1, property2, property3).value).to(beFalse())
 				}
 
 				it("should emit false when array of properties is empty") {

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -3623,7 +3623,7 @@ class SignalProducerSpec: QuickSpec {
 				}
 			}
 			
-			it("should emit false when all producers in array emit false") {
+			it("should emit false when all producers emit false") {
 				let producer1 = SignalProducer<Bool, Never> { observer, _ in
 					observer.send(value: false)
 					observer.sendCompleted()
@@ -3637,7 +3637,7 @@ class SignalProducerSpec: QuickSpec {
 					observer.sendCompleted()
 				}
 
-				SignalProducer.any([producer1, producer2, producer3]).startWithValues { value in
+				SignalProducer.any(producer1, producer2, producer3).startWithValues { value in
 					expect(value).to(beFalse())
 				}
 			}

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -3896,11 +3896,11 @@ class SignalSpec: QuickSpec {
 				observer3.sendCompleted()
 			}
 			
-			it("should emit false when all signals in array emits false") {
+			it("should emit false when all signals emits false") {
 				let (signal1, observer1) = Signal<Bool, Never>.pipe()
 				let (signal2, observer2) = Signal<Bool, Never>.pipe()
 				let (signal3, observer3) = Signal<Bool, Never>.pipe()
-				Signal.any([signal1, signal2, signal3]).observeValues { value in
+				Signal.any(signal1, signal2, signal3).observeValues { value in
 					expect(value).to(beFalse())
 				}
 				observer1.send(value: false)


### PR DESCRIPTION
Hi 👋 

This is my first contribution, albeit a small one.

What I'd like to add is variadic argument support for static intializers of `Signal`s, `SignalProducer`s and `Properties` where `Value == Boolean`.
So, similar to how we write `SignalProducer.combineLatest(producer1, producer2)` we could write `SignalProducer.any(producer1, producer2)` - right now we have to do `SignalProducer.any([producer1, producer2])` which seems unnecessarily verbose.

I have also change a few test cases to leverage this new feature

#### Checklist
- [x] Updated CHANGELOG.md.
