### PR TITLE
Fix caption `Combine` to `ReactiveSwift`

### DIFF
--- a/Documentation/RxCheatsheet.md
+++ b/Documentation/RxCheatsheet.md
@@ -45,7 +45,7 @@ Inspired by the [RxSwift to Combine cheatsheet](https://github.com/CombineCommun
 
 ## Operators
 
-| RxSwift               | Combine                                  | Notes                                                                                                    |
+| RxSwift               | ReactiveSwift                                  | Notes                                                                                                    |
 |-----------------------|------------------------------------------|----------------------------------------------------------------------------------------------------------|
 | amb()                 | flatten(.race)                           |
 | asObservable()        | ❌                                       | Not required in ReactiveSwift, although `Property.producer` and `Property.signal` are similar


### PR DESCRIPTION
Is the `Combine` caption in the Operators table correct?
I think the correct caption is `ReactiveSwift`.

#### Checklist
- [ ] ~~Updated CHANGELOG.md.~~
