### PR TITLE
Add ExpressibleByNilLiteral constraint to OptionalProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 *Please add new entries at the top.*
+1. Add `ExpressibleByNilLiteral` constraint to `OptionalProtocol` (#805, kudos to @nkristek)
 
 # 6.4.0
 1. Bump min. deployment target to iOS 9 when using swift packages to silence Xcode 12 warnings. Update Quick & Nibmle to the latest version when using swift packages.

--- a/Sources/Optional.swift
+++ b/Sources/Optional.swift
@@ -8,7 +8,7 @@
 
 /// An optional protocol for use in type constraints.
 public protocol OptionalProtocol: ExpressibleByNilLiteral {
-	/// The type contained in the otpional.
+	/// The type contained in the optional.
 	associatedtype Wrapped
 
 	init(reconstructing value: Wrapped?)

--- a/Sources/Optional.swift
+++ b/Sources/Optional.swift
@@ -7,7 +7,7 @@
 //
 
 /// An optional protocol for use in type constraints.
-public protocol OptionalProtocol {
+public protocol OptionalProtocol: ExpressibleByNilLiteral {
 	/// The type contained in the otpional.
 	associatedtype Wrapped
 


### PR DESCRIPTION
Hi, this is just a very small contribution regarding the `OptionalProtocol` and adds the `ExpressibleByNilLiteral` constraint to it. It is already implemented by `Optional<Wrapped>` and requires no further change. This makes it possible to initialise a value of type `OptionalProtocol` with `nil` instead of having to write `.init(reconstructing: nil)`.

There also was a small typo in the documentation of the `associatedType` which I fixed as well.

#### Example
```swift
extension Property where Value: OptionalProtocol {
    func mapNil() -> Property<Value> {
        // now possible to write
        return Property(value: nil)
        // instead of
        return Property(value: .init(reconstructing: nil))
    }
}
```

Extending `OptionalProtocol` with the implementation of `ExpressibleByNilLiteral` is not possible due to a language constraint:
```swift
/// error: Extension of protocol 'OptionalProtocol' cannot have an inheritance clause
extension OptionalProtocol: ExpressibleByNilLiteral {
    
}
```

For now, as a workaround, one needs to append `ExpressibleByNilLiteral` to the generic constraint like so:
```swift
extension Property where Value: OptionalProtocol & ExpressibleByNilLiteral {
    func mapNil() -> Property<Value> {
        return Property(value: nil)
    }
}
```
#### Checklist
- [x] Updated CHANGELOG.md.
