### PR TITLE
Fix a `SignalProducer.lift` issue which may leak intermediate signals. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 *Please add new entries at the top.*
 1. Add `ExpressibleByNilLiteral` constraint to `OptionalProtocol` (#805, kudos to @nkristek)
+2. Fixed a `SignalProducer.lift` issue which may leak intermediate signals. (#808) 
 
 # 6.4.0
 1. Bump min. deployment target to iOS 9 when using swift packages to silence Xcode 12 warnings. Update Quick & Nibmle to the latest version when using swift packages.

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -666,7 +666,7 @@ extension SignalProducer {
 		return SignalProducer<U, F> { observer, lifetime in
 			self.startWithSignal { signal, interrupter in
 				lifetime += interrupter
-				transform(signal).observe(observer)
+				lifetime += transform(signal).observe(observer)
 			}
 		}
 	}

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -679,7 +679,7 @@ extension SignalProducer {
 	/// - returns: A factory that creates a SignalProducer with the given operator
 	///            applied. `self` would be the LHS, and the factory input would
 	///            be the RHS.
-	fileprivate func liftLeft<U, F, V, G>(_ transform: @escaping (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (SignalProducer<U, F>) -> SignalProducer<V, G> {
+	internal func liftLeft<U, F, V, G>(_ transform: @escaping (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (SignalProducer<U, F>) -> SignalProducer<V, G> {
 		return { right in
 			return SignalProducer<V, G> { observer, lifetime in
 				right.startWithSignal { rightSignal, rightInterrupter in
@@ -687,7 +687,7 @@ extension SignalProducer {
 
 					self.startWithSignal { leftSignal, leftInterrupter in
 						lifetime += leftInterrupter
-						transform(leftSignal)(rightSignal).observe(observer)
+						lifetime += transform(leftSignal)(rightSignal).observe(observer)
 					}
 				}
 			}
@@ -702,7 +702,7 @@ extension SignalProducer {
 	/// - returns: A factory that creates a SignalProducer with the given operator
 	///            applied. `self` would be the LHS, and the factory input would
 	///            be the RHS.
-	fileprivate func liftRight<U, F, V, G>(_ transform: @escaping (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (SignalProducer<U, F>) -> SignalProducer<V, G> {
+	internal func liftRight<U, F, V, G>(_ transform: @escaping (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (SignalProducer<U, F>) -> SignalProducer<V, G> {
 		return { right in
 			return SignalProducer<V, G> { observer, lifetime in
 				self.startWithSignal { leftSignal, leftInterrupter in
@@ -710,7 +710,7 @@ extension SignalProducer {
 
 					right.startWithSignal { rightSignal, rightInterrupter in
 						lifetime += rightInterrupter
-						transform(leftSignal)(rightSignal).observe(observer)
+						lifetime += transform(leftSignal)(rightSignal).observe(observer)
 					}
 				}
 			}

--- a/Tests/ReactiveSwiftTests/SignalLifetimeSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalLifetimeSpec.swift
@@ -24,6 +24,7 @@ class SignalLifetimeSpec: QuickSpec {
 			it("should automatically interrupt if the input observer is not retained") {
 				let disposable = AnyDisposable()
 				var outerSignal: Signal<Never, Never>!
+				_ = outerSignal
 
 				func scope() {
 					let (signal, observer) = Signal<Never, Never>.pipe(disposable: disposable)
@@ -42,6 +43,7 @@ class SignalLifetimeSpec: QuickSpec {
 				let disposable = AnyDisposable()
 				var isInterrupted = false
 				var outerSignal: Signal<Never, Never>!
+				_ = outerSignal
 
 				func scope() {
 					let (signal, observer) = Signal<Never, Never>.pipe(disposable: disposable)

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -849,6 +849,27 @@ class SignalProducerSpec: QuickSpec {
 
 					expect(result?.value) == [1, 4, 9, 16]
 				}
+
+				it("should interrupt all intermediate signals when the upstream is terminated") {
+					let baseProducer = SignalProducer<Int, Never>.empty
+
+					var lastEvent: Signal<Int, Never>.Event?
+
+					var isNeverEndingSignalDisposed = false
+
+					let disposable = baseProducer
+						.lift { _ in Signal.never.on(disposed: { isNeverEndingSignalDisposed = true }) }
+						.start { event in
+							lastEvent = event
+						}
+
+					expect(lastEvent).to(beNil())
+					expect(isNeverEndingSignalDisposed) == false
+
+					disposable.dispose()
+					expect(lastEvent) == .interrupted
+					expect(isNeverEndingSignalDisposed) == true
+				}
 			}
 
 			describe("over binary operators") {

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -873,6 +873,16 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			describe("over binary operators") {
+				var isNeverEndingSignalDisposed = false
+
+				let binaryLiftTransform = { (_: Signal<Int, Never>) -> (Signal<Int, Never>) -> Signal<Int, Never> in
+					{ (_: Signal<Int, Never>) in
+						Signal<Int, Never>.never.on(disposed: { isNeverEndingSignalDisposed = true })
+					}
+				}
+
+				beforeEach { isNeverEndingSignalDisposed = false }
+
 				it("should invoke transformation once per started signal") {
 					let baseProducer = SignalProducer<Int, Never>([1, 2])
 					let otherProducer = SignalProducer<Int, Never>([3, 4])
@@ -909,6 +919,44 @@ class SignalProducerSpec: QuickSpec {
 					let result = producer.collect().single()
 
 					expect(result?.value) == [5, 7, 9]
+				}
+
+				it("[left associative] should interrupt all intermediate signals when the upstream is terminated") {
+					let baseProducer = SignalProducer<Int, Never>.empty
+
+					var lastEvent: Signal<Int, Never>.Event?
+
+					let disposable = baseProducer
+						.liftLeft(binaryLiftTransform)(.empty)
+						.start { event in
+							lastEvent = event
+						}
+
+					expect(lastEvent).to(beNil())
+					expect(isNeverEndingSignalDisposed) == false
+
+					disposable.dispose()
+					expect(lastEvent) == .interrupted
+					expect(isNeverEndingSignalDisposed) == true
+				}
+
+				it("[right associative] should interrupt all intermediate signals when the upstream is terminated") {
+					let baseProducer = SignalProducer<Int, Never>.empty
+
+					var lastEvent: Signal<Int, Never>.Event?
+
+					let disposable = baseProducer
+						.liftRight(binaryLiftTransform)(.empty)
+						.start { event in
+							lastEvent = event
+						}
+
+					expect(lastEvent).to(beNil())
+					expect(isNeverEndingSignalDisposed) == false
+
+					disposable.dispose()
+					expect(lastEvent) == .interrupted
+					expect(isNeverEndingSignalDisposed) == true
 				}
 			}
 


### PR DESCRIPTION
`SignalProducer.lift` might leak intermediate signals, if the upstream has been terminated, way before a downstream interruption is raised.

#### Checklist
- [x] Updated CHANGELOG.md.
