### PR TITLE
Migrate six operators to the new abstraction.

### DIFF
--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -69,6 +69,22 @@
 		9A1D067D1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */; };
 		9A1D067E1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */; };
 		9A1D067F1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */; };
+		9A2D5C4F259F7B21005682ED /* MapError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C4E259F7B21005682ED /* MapError.swift */; };
+		9A2D5C50259F7B21005682ED /* MapError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C4E259F7B21005682ED /* MapError.swift */; };
+		9A2D5C51259F7B21005682ED /* MapError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C4E259F7B21005682ED /* MapError.swift */; };
+		9A2D5C52259F7B21005682ED /* MapError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C4E259F7B21005682ED /* MapError.swift */; };
+		9A2D5C59259F7B31005682ED /* Materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C58259F7B31005682ED /* Materialize.swift */; };
+		9A2D5C5A259F7B31005682ED /* Materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C58259F7B31005682ED /* Materialize.swift */; };
+		9A2D5C5B259F7B31005682ED /* Materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C58259F7B31005682ED /* Materialize.swift */; };
+		9A2D5C5C259F7B31005682ED /* Materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C58259F7B31005682ED /* Materialize.swift */; };
+		9A2D5C63259F7B47005682ED /* MaterializeAsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C62259F7B47005682ED /* MaterializeAsResult.swift */; };
+		9A2D5C64259F7B47005682ED /* MaterializeAsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C62259F7B47005682ED /* MaterializeAsResult.swift */; };
+		9A2D5C65259F7B47005682ED /* MaterializeAsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C62259F7B47005682ED /* MaterializeAsResult.swift */; };
+		9A2D5C66259F7B47005682ED /* MaterializeAsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C62259F7B47005682ED /* MaterializeAsResult.swift */; };
+		9A2D5C77259F7D3D005682ED /* AttemptMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C76259F7D3D005682ED /* AttemptMap.swift */; };
+		9A2D5C78259F7D3D005682ED /* AttemptMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C76259F7D3D005682ED /* AttemptMap.swift */; };
+		9A2D5C79259F7D3D005682ED /* AttemptMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C76259F7D3D005682ED /* AttemptMap.swift */; };
+		9A2D5C7A259F7D3D005682ED /* AttemptMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C76259F7D3D005682ED /* AttemptMap.swift */; };
 		9A67963B1F6056B90058C5B4 /* UninhabitedTypeGuards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */; };
 		9A67963C1F6059420058C5B4 /* UninhabitedTypeGuards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */; };
 		9A67963D1F6059430058C5B4 /* UninhabitedTypeGuards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */; };
@@ -264,6 +280,10 @@
 		9A1A4F981E16961C006F3039 /* ValidatingPropertySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidatingPropertySpec.swift; sourceTree = "<group>"; };
 		9A1B824020835EEC00EB7C09 /* ResultExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultExtensions.swift; sourceTree = "<group>"; };
 		9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnidirectionalBindingSpec.swift; sourceTree = "<group>"; };
+		9A2D5C4E259F7B21005682ED /* MapError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapError.swift; sourceTree = "<group>"; };
+		9A2D5C58259F7B31005682ED /* Materialize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Materialize.swift; sourceTree = "<group>"; };
+		9A2D5C62259F7B47005682ED /* MaterializeAsResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaterializeAsResult.swift; sourceTree = "<group>"; };
+		9A2D5C76259F7D3D005682ED /* AttemptMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttemptMap.swift; sourceTree = "<group>"; };
 		9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UninhabitedTypeGuards.swift; sourceTree = "<group>"; };
 		9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationSpec.swift; sourceTree = "<group>"; };
 		9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidatingProperty.swift; sourceTree = "<group>"; };
@@ -417,6 +437,10 @@
 				9AFA491A24E9A925003D263C /* Filter.swift */,
 				9AFA491F24E9A988003D263C /* CompactMap.swift */,
 				9AFA492424E9B15C003D263C /* Operators.swift */,
+				9A2D5C4E259F7B21005682ED /* MapError.swift */,
+				9A2D5C58259F7B31005682ED /* Materialize.swift */,
+				9A2D5C62259F7B47005682ED /* MaterializeAsResult.swift */,
+				9A2D5C76259F7D3D005682ED /* AttemptMap.swift */,
 			);
 			path = Observers;
 			sourceTree = "<group>";
@@ -914,10 +938,12 @@
 				9A9100E21E0E6E680093E346 /* ValidatingProperty.swift in Sources */,
 				57A4D1B91BA13D7A00F7D4B1 /* Action.swift in Sources */,
 				57A4D1BA1BA13D7A00F7D4B1 /* Property.swift in Sources */,
+				9A2D5C5C259F7B31005682ED /* Materialize.swift in Sources */,
 				9A090C171DA0309E00EE97CA /* Reactive.swift in Sources */,
 				57A4D1BB1BA13D7A00F7D4B1 /* Signal.swift in Sources */,
 				9AFA492824E9B15C003D263C /* Operators.swift in Sources */,
 				9A67963E1F6059440058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
+				9A2D5C66259F7B47005682ED /* MaterializeAsResult.swift in Sources */,
 				9AFA491424E9A196003D263C /* Map.swift in Sources */,
 				9AFA491E24E9A925003D263C /* Filter.swift in Sources */,
 				57A4D1BC1BA13D7A00F7D4B1 /* SignalProducer.swift in Sources */,
@@ -929,10 +955,12 @@
 				D85C652D1C0E70E5005A77AD /* Flatten.swift in Sources */,
 				9ABCB1881D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */,
 				EBCC7DBF1BBF01E200A2AE92 /* Signal.Observer.swift in Sources */,
+				9A2D5C7A259F7D3D005682ED /* AttemptMap.swift in Sources */,
 				C79B64801CD52E4E003F2376 /* EventLogger.swift in Sources */,
 				9AFA492324E9A988003D263C /* CompactMap.swift in Sources */,
 				4A0E11021D2A92720065D310 /* Lifetime.swift in Sources */,
 				BE9CF3981D751B71003AE479 /* UnidirectionalBinding.swift in Sources */,
+				9A2D5C52259F7B21005682ED /* MapError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -975,10 +1003,12 @@
 				9A9100E11E0E6E680093E346 /* ValidatingProperty.swift in Sources */,
 				A9B315C11B3940810001CB9C /* Action.swift in Sources */,
 				A9B315C21B3940810001CB9C /* Property.swift in Sources */,
+				9A2D5C5B259F7B31005682ED /* Materialize.swift in Sources */,
 				9A090C161DA0309E00EE97CA /* Reactive.swift in Sources */,
 				A9B315C31B3940810001CB9C /* Signal.swift in Sources */,
 				9AFA492724E9B15C003D263C /* Operators.swift in Sources */,
 				9A67963D1F6059430058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
+				9A2D5C65259F7B47005682ED /* MaterializeAsResult.swift in Sources */,
 				9AFA491324E9A196003D263C /* Map.swift in Sources */,
 				9AFA491D24E9A925003D263C /* Filter.swift in Sources */,
 				A9B315C41B3940810001CB9C /* SignalProducer.swift in Sources */,
@@ -990,10 +1020,12 @@
 				D85C652C1C0E70E4005A77AD /* Flatten.swift in Sources */,
 				9ABCB1871D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */,
 				EBCC7DBE1BBF01E200A2AE92 /* Signal.Observer.swift in Sources */,
+				9A2D5C79259F7D3D005682ED /* AttemptMap.swift in Sources */,
 				C79B647F1CD52E4D003F2376 /* EventLogger.swift in Sources */,
 				9AFA492224E9A988003D263C /* CompactMap.swift in Sources */,
 				4A0E11011D2A92720065D310 /* Lifetime.swift in Sources */,
 				BE9CF3971D751B71003AE479 /* UnidirectionalBinding.swift in Sources */,
+				9A2D5C51259F7B21005682ED /* MapError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1008,10 +1040,12 @@
 				EBCC7DBC1BBF010C00A2AE92 /* Signal.Observer.swift in Sources */,
 				D03B4A3D19F4C39A009E02AC /* FoundationExtensions.swift in Sources */,
 				9A090C141DA0309E00EE97CA /* Reactive.swift in Sources */,
+				9A2D5C59259F7B31005682ED /* Materialize.swift in Sources */,
 				D08C54B31A69A2AE00AD8286 /* Signal.swift in Sources */,
 				D85C652A1C0D84C7005A77AD /* Flatten.swift in Sources */,
 				9AFA492524E9B15C003D263C /* Operators.swift in Sources */,
 				9A67963B1F6056B90058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
+				9A2D5C63259F7B47005682ED /* MaterializeAsResult.swift in Sources */,
 				9AFA491124E9A196003D263C /* Map.swift in Sources */,
 				9AFA491B24E9A925003D263C /* Filter.swift in Sources */,
 				D0C312CF19EF2A5800984962 /* Bag.swift in Sources */,
@@ -1023,10 +1057,12 @@
 				D08C54BA1A69C54300AD8286 /* Property.swift in Sources */,
 				D0D11AB91A6AE87700C1F8B1 /* Action.swift in Sources */,
 				C79B647C1CD52E23003F2376 /* EventLogger.swift in Sources */,
+				9A2D5C77259F7D3D005682ED /* AttemptMap.swift in Sources */,
 				9ABCB1851D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */,
 				9AFA492024E9A988003D263C /* CompactMap.swift in Sources */,
 				D08C54B81A69A9D000AD8286 /* SignalProducer.swift in Sources */,
 				BE9CF3951D751B6B003AE479 /* UnidirectionalBinding.swift in Sources */,
+				9A2D5C4F259F7B21005682ED /* MapError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1069,10 +1105,12 @@
 				9A9100E01E0E6E670093E346 /* ValidatingProperty.swift in Sources */,
 				9ABCB1861D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */,
 				EBCC7DBD1BBF01E100A2AE92 /* Signal.Observer.swift in Sources */,
+				9A2D5C5A259F7B31005682ED /* Materialize.swift in Sources */,
 				9A090C151DA0309E00EE97CA /* Reactive.swift in Sources */,
 				D85C652B1C0E70E3005A77AD /* Flatten.swift in Sources */,
 				9AFA492624E9B15C003D263C /* Operators.swift in Sources */,
 				9A67963C1F6059420058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
+				9A2D5C64259F7B47005682ED /* MaterializeAsResult.swift in Sources */,
 				9AFA491224E9A196003D263C /* Map.swift in Sources */,
 				9AFA491C24E9A925003D263C /* Filter.swift in Sources */,
 				4A0E11001D2A92720065D310 /* Lifetime.swift in Sources */,
@@ -1084,10 +1122,12 @@
 				C79B647D1CD52E4A003F2376 /* EventLogger.swift in Sources */,
 				D0C312CE19EF2A5800984962 /* Atomic.swift in Sources */,
 				D0C312E819EF2A5800984962 /* Scheduler.swift in Sources */,
+				9A2D5C78259F7D3D005682ED /* AttemptMap.swift in Sources */,
 				D0C312D019EF2A5800984962 /* Bag.swift in Sources */,
 				9AFA492124E9A988003D263C /* CompactMap.swift in Sources */,
 				D0D11ABA1A6AE87700C1F8B1 /* Action.swift in Sources */,
 				BE9CF3961D751B70003AE479 /* UnidirectionalBinding.swift in Sources */,
+				9A2D5C50259F7B21005682ED /* MapError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -85,6 +85,14 @@
 		9A2D5C78259F7D3D005682ED /* AttemptMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C76259F7D3D005682ED /* AttemptMap.swift */; };
 		9A2D5C79259F7D3D005682ED /* AttemptMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C76259F7D3D005682ED /* AttemptMap.swift */; };
 		9A2D5C7A259F7D3D005682ED /* AttemptMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C76259F7D3D005682ED /* AttemptMap.swift */; };
+		9A2D5C81259F7E3E005682ED /* DematerializeResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C80259F7E3E005682ED /* DematerializeResults.swift */; };
+		9A2D5C82259F7E3E005682ED /* DematerializeResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C80259F7E3E005682ED /* DematerializeResults.swift */; };
+		9A2D5C83259F7E3E005682ED /* DematerializeResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C80259F7E3E005682ED /* DematerializeResults.swift */; };
+		9A2D5C84259F7E3E005682ED /* DematerializeResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C80259F7E3E005682ED /* DematerializeResults.swift */; };
+		9A2D5C8B259F7ED5005682ED /* Dematerialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C8A259F7ED5005682ED /* Dematerialize.swift */; };
+		9A2D5C8C259F7ED5005682ED /* Dematerialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C8A259F7ED5005682ED /* Dematerialize.swift */; };
+		9A2D5C8D259F7ED5005682ED /* Dematerialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C8A259F7ED5005682ED /* Dematerialize.swift */; };
+		9A2D5C8E259F7ED5005682ED /* Dematerialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5C8A259F7ED5005682ED /* Dematerialize.swift */; };
 		9A67963B1F6056B90058C5B4 /* UninhabitedTypeGuards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */; };
 		9A67963C1F6059420058C5B4 /* UninhabitedTypeGuards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */; };
 		9A67963D1F6059430058C5B4 /* UninhabitedTypeGuards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */; };
@@ -284,6 +292,8 @@
 		9A2D5C58259F7B31005682ED /* Materialize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Materialize.swift; sourceTree = "<group>"; };
 		9A2D5C62259F7B47005682ED /* MaterializeAsResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaterializeAsResult.swift; sourceTree = "<group>"; };
 		9A2D5C76259F7D3D005682ED /* AttemptMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttemptMap.swift; sourceTree = "<group>"; };
+		9A2D5C80259F7E3E005682ED /* DematerializeResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DematerializeResults.swift; sourceTree = "<group>"; };
+		9A2D5C8A259F7ED5005682ED /* Dematerialize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dematerialize.swift; sourceTree = "<group>"; };
 		9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UninhabitedTypeGuards.swift; sourceTree = "<group>"; };
 		9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationSpec.swift; sourceTree = "<group>"; };
 		9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidatingProperty.swift; sourceTree = "<group>"; };
@@ -440,6 +450,8 @@
 				9A2D5C4E259F7B21005682ED /* MapError.swift */,
 				9A2D5C58259F7B31005682ED /* Materialize.swift */,
 				9A2D5C62259F7B47005682ED /* MaterializeAsResult.swift */,
+				9A2D5C80259F7E3E005682ED /* DematerializeResults.swift */,
+				9A2D5C8A259F7ED5005682ED /* Dematerialize.swift */,
 				9A2D5C76259F7D3D005682ED /* AttemptMap.swift */,
 			);
 			path = Observers;
@@ -945,6 +957,7 @@
 				9A67963E1F6059440058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
 				9A2D5C66259F7B47005682ED /* MaterializeAsResult.swift in Sources */,
 				9AFA491424E9A196003D263C /* Map.swift in Sources */,
+				9A2D5C8E259F7ED5005682ED /* Dematerialize.swift in Sources */,
 				9AFA491E24E9A925003D263C /* Filter.swift in Sources */,
 				57A4D1BC1BA13D7A00F7D4B1 /* SignalProducer.swift in Sources */,
 				57A4D1BD1BA13D7A00F7D4B1 /* Atomic.swift in Sources */,
@@ -960,6 +973,7 @@
 				9AFA492324E9A988003D263C /* CompactMap.swift in Sources */,
 				4A0E11021D2A92720065D310 /* Lifetime.swift in Sources */,
 				BE9CF3981D751B71003AE479 /* UnidirectionalBinding.swift in Sources */,
+				9A2D5C84259F7E3E005682ED /* DematerializeResults.swift in Sources */,
 				9A2D5C52259F7B21005682ED /* MapError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1010,6 +1024,7 @@
 				9A67963D1F6059430058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
 				9A2D5C65259F7B47005682ED /* MaterializeAsResult.swift in Sources */,
 				9AFA491324E9A196003D263C /* Map.swift in Sources */,
+				9A2D5C8D259F7ED5005682ED /* Dematerialize.swift in Sources */,
 				9AFA491D24E9A925003D263C /* Filter.swift in Sources */,
 				A9B315C41B3940810001CB9C /* SignalProducer.swift in Sources */,
 				A9B315C51B3940810001CB9C /* Atomic.swift in Sources */,
@@ -1025,6 +1040,7 @@
 				9AFA492224E9A988003D263C /* CompactMap.swift in Sources */,
 				4A0E11011D2A92720065D310 /* Lifetime.swift in Sources */,
 				BE9CF3971D751B71003AE479 /* UnidirectionalBinding.swift in Sources */,
+				9A2D5C83259F7E3E005682ED /* DematerializeResults.swift in Sources */,
 				9A2D5C51259F7B21005682ED /* MapError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1047,6 +1063,7 @@
 				9A67963B1F6056B90058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
 				9A2D5C63259F7B47005682ED /* MaterializeAsResult.swift in Sources */,
 				9AFA491124E9A196003D263C /* Map.swift in Sources */,
+				9A2D5C8B259F7ED5005682ED /* Dematerialize.swift in Sources */,
 				9AFA491B24E9A925003D263C /* Filter.swift in Sources */,
 				D0C312CF19EF2A5800984962 /* Bag.swift in Sources */,
 				4A0E10FF1D2A92720065D310 /* Lifetime.swift in Sources */,
@@ -1062,6 +1079,7 @@
 				9AFA492024E9A988003D263C /* CompactMap.swift in Sources */,
 				D08C54B81A69A9D000AD8286 /* SignalProducer.swift in Sources */,
 				BE9CF3951D751B6B003AE479 /* UnidirectionalBinding.swift in Sources */,
+				9A2D5C81259F7E3E005682ED /* DematerializeResults.swift in Sources */,
 				9A2D5C4F259F7B21005682ED /* MapError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1112,6 +1130,7 @@
 				9A67963C1F6059420058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
 				9A2D5C64259F7B47005682ED /* MaterializeAsResult.swift in Sources */,
 				9AFA491224E9A196003D263C /* Map.swift in Sources */,
+				9A2D5C8C259F7ED5005682ED /* Dematerialize.swift in Sources */,
 				9AFA491C24E9A925003D263C /* Filter.swift in Sources */,
 				4A0E11001D2A92720065D310 /* Lifetime.swift in Sources */,
 				D08C54BB1A69C54400AD8286 /* Property.swift in Sources */,
@@ -1127,6 +1146,7 @@
 				9AFA492124E9A988003D263C /* CompactMap.swift in Sources */,
 				D0D11ABA1A6AE87700C1F8B1 /* Action.swift in Sources */,
 				BE9CF3961D751B70003AE479 /* UnidirectionalBinding.swift in Sources */,
+				9A2D5C82259F7E3E005682ED /* DematerializeResults.swift in Sources */,
 				9A2D5C50259F7B21005682ED /* MapError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -374,49 +374,16 @@ extension Signal.Event {
 
 extension Signal.Event where Value: EventProtocol, Error == Never {
 	internal static var dematerialize: Transformation<Value.Value, Value.Error> {
-		return { action, _ in
-			return Signal.Observer { event in
-				switch event {
-				case let .value(innerEvent):
-					action(innerEvent.event)
-
-				case .failed:
-					fatalError("Never is impossible to construct")
-
-				case .completed:
-					action(.completed)
-
-				case .interrupted:
-					action(.interrupted)
-				}
-			}
+		return { downstream, _ in
+			Operators.Dematerialize(downstream: downstream)
 		}
 	}
 }
 
 extension Signal.Event where Value: ResultProtocol, Error == Never {
 	internal static var dematerializeResults: Transformation<Value.Success, Value.Failure> {
-		return { action, _ in
-			return Signal.Observer { event in
-				let event = event.map { $0.result }
-
-				switch event {
-				case .value(.success(let value)):
-					action(.value(value))
-
-				case .value(.failure(let error)):
-					action(.failed(error))
-
-				case .failed:
-					fatalError("Never is impossible to construct")
-
-				case .completed:
-					action(.completed)
-
-				case .interrupted:
-					action(.interrupted)
-				}
-			}
+		return { downstream, _ in
+			Operators.DematerializeResults(downstream: downstream)
 		}
 	}
 }

--- a/Sources/Observers/AttemptMap.swift
+++ b/Sources/Observers/AttemptMap.swift
@@ -1,0 +1,24 @@
+extension Operators {
+	internal final class AttemptMap<InputValue, OutputValue, Error: Swift.Error>: Observer<InputValue, Error> {
+		let downstream: Observer<OutputValue, Error>
+		let transform: (InputValue) -> Result<OutputValue, Error>
+
+		init(downstream: Observer<OutputValue, Error>, transform: @escaping (InputValue) -> Result<OutputValue, Error>) {
+			self.downstream = downstream
+			self.transform = transform
+		}
+
+		override func receive(_ value: InputValue) {
+			switch transform(value) {
+			case let .success(value):
+				downstream.receive(value)
+			case let .failure(error):
+				downstream.terminate(.failed(error))
+			}
+		}
+
+		override func terminate(_ termination: Termination<Error>) {
+			downstream.terminate(termination)
+		}
+	}
+}

--- a/Sources/Observers/Dematerialize.swift
+++ b/Sources/Observers/Dematerialize.swift
@@ -1,0 +1,31 @@
+extension Operators {
+	internal final class Dematerialize<Event>: Observer<Event, Never> where Event: EventProtocol {
+		let downstream: Observer<Event.Value, Event.Error>
+
+		init(downstream: Observer<Event.Value, Event.Error>) {
+			self.downstream = downstream
+		}
+
+		override func receive(_ event: Event) {
+			switch event.event {
+			case let .value(value):
+				downstream.receive(value)
+			case .completed:
+				downstream.terminate(.completed)
+			case .interrupted:
+				downstream.terminate(.interrupted)
+			case let .failed(error):
+				downstream.terminate(.failed(error))
+			}
+		}
+
+		override func terminate(_ termination: Termination<Never>) {
+			switch termination {
+			case .completed:
+				downstream.terminate(.completed)
+			case .interrupted:
+				downstream.terminate(.interrupted)
+			}
+		}
+	}
+}

--- a/Sources/Observers/DematerializeResults.swift
+++ b/Sources/Observers/DematerializeResults.swift
@@ -1,0 +1,27 @@
+extension Operators {
+	internal final class DematerializeResults<Result>: Observer<Result, Never> where Result: ResultProtocol {
+		let downstream: Observer<Result.Success, Result.Failure>
+
+		init(downstream: Observer<Result.Success, Result.Failure>) {
+			self.downstream = downstream
+		}
+
+		override func receive(_ value: Result) {
+			switch value.result {
+			case let .success(value):
+				downstream.receive(value)
+			case let .failure(error):
+				downstream.terminate(.failed(error))
+			}
+		}
+
+		override func terminate(_ termination: Termination<Never>) {
+			switch termination {
+			case .completed:
+				downstream.terminate(.completed)
+			case .interrupted:
+				downstream.terminate(.interrupted)
+			}
+		}
+	}
+}

--- a/Sources/Observers/MapError.swift
+++ b/Sources/Observers/MapError.swift
@@ -1,0 +1,26 @@
+extension Operators {
+	internal final class MapError<Value, InputError: Swift.Error, OutputError: Swift.Error>: Observer<Value, InputError> {
+		let downstream: Observer<Value, OutputError>
+		let transform: (InputError) -> OutputError
+
+		init(downstream: Observer<Value, OutputError>, transform: @escaping (InputError) -> OutputError) {
+			self.downstream = downstream
+			self.transform = transform
+		}
+
+		override func receive(_ value: Value) {
+			downstream.receive(value)
+		}
+
+		override func terminate(_ termination: Termination<InputError>) {
+			switch termination {
+			case .completed:
+				downstream.terminate(.completed)
+			case let .failed(error):
+				downstream.terminate(.failed(transform(error)))
+			case .interrupted:
+				downstream.terminate(.interrupted)
+			}
+		}
+	}
+}

--- a/Sources/Observers/Materialize.swift
+++ b/Sources/Observers/Materialize.swift
@@ -1,0 +1,24 @@
+extension Operators {
+	internal final class Materialize<Value, Error: Swift.Error>: Observer<Value, Error> {
+		let downstream: Observer<Signal<Value, Error>.Event, Never>
+
+		init(downstream: Observer<Signal<Value, Error>.Event, Never>) {
+			self.downstream = downstream
+		}
+
+		override func receive(_ value: Value) {
+			downstream.receive(.value(value))
+		}
+
+		override func terminate(_ termination: Termination<Error>) {
+			downstream.receive(Signal<Value, Error>.Event(termination))
+
+			switch termination {
+			case .completed, .failed:
+				downstream.terminate(.completed)
+			case .interrupted:
+				downstream.terminate(.interrupted)
+			}
+		}
+	}
+}

--- a/Sources/Observers/MaterializeAsResult.swift
+++ b/Sources/Observers/MaterializeAsResult.swift
@@ -1,0 +1,25 @@
+extension Operators {
+	internal final class MaterializeAsResult<Value, Error: Swift.Error>: Observer<Value, Error> {
+		let downstream: Observer<Result<Value, Error>, Never>
+
+		init(downstream: Observer<Result<Value, Error>, Never>) {
+			self.downstream = downstream
+		}
+
+		override func receive(_ value: Value) {
+			downstream.receive(.success(value))
+		}
+
+		override func terminate(_ termination: Termination<Error>) {
+			switch termination {
+			case .completed:
+				downstream.terminate(.completed)
+			case let .failed(error):
+				downstream.receive(.failure(error))
+				downstream.terminate(.completed)
+			case .interrupted:
+				downstream.terminate(.interrupted)
+			}
+		}
+	}
+}

--- a/Sources/Observers/Observer.swift
+++ b/Sources/Observers/Observer.swift
@@ -33,3 +33,16 @@ public enum Termination<Error: Swift.Error> {
 	case completed
 	case interrupted
 }
+
+extension Signal.Event {
+	init(_ termination: Termination<Error>) {
+		switch termination {
+		case .completed:
+			self = .completed
+		case .interrupted:
+			self = .interrupted
+		case let .failed(error):
+			self = .failed(error)
+		}
+	}
+}


### PR DESCRIPTION
The new abstraction was introduced in #799.

Migrated operators in this PR include:
MapError, Materialize, MaterializeAsResult, AttemptMap, Dematerialize, DematerializeResults 

#### Checklist
- ~~Updated CHANGELOG.md.~~
