### PR TITLE
Migrate ObserveOn, LazyMap and Delay to the new abstraction, while unifying delicate logic in these operators.

### DIFF
--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -69,6 +69,22 @@
 		9A1D067D1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */; };
 		9A1D067E1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */; };
 		9A1D067F1D948A2300ACF44C /* UnidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */; };
+		9A2D5D1C259F9228005682ED /* UnaryAsyncOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D1B259F9228005682ED /* UnaryAsyncOperator.swift */; };
+		9A2D5D1D259F9228005682ED /* UnaryAsyncOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D1B259F9228005682ED /* UnaryAsyncOperator.swift */; };
+		9A2D5D1E259F9228005682ED /* UnaryAsyncOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D1B259F9228005682ED /* UnaryAsyncOperator.swift */; };
+		9A2D5D1F259F9228005682ED /* UnaryAsyncOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D1B259F9228005682ED /* UnaryAsyncOperator.swift */; };
+		9A2D5D26259F9373005682ED /* ObserveOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D25259F9373005682ED /* ObserveOn.swift */; };
+		9A2D5D27259F9373005682ED /* ObserveOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D25259F9373005682ED /* ObserveOn.swift */; };
+		9A2D5D28259F9373005682ED /* ObserveOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D25259F9373005682ED /* ObserveOn.swift */; };
+		9A2D5D29259F9373005682ED /* ObserveOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D25259F9373005682ED /* ObserveOn.swift */; };
+		9A2D5D30259F942B005682ED /* LazyMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D2F259F942B005682ED /* LazyMap.swift */; };
+		9A2D5D31259F942B005682ED /* LazyMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D2F259F942B005682ED /* LazyMap.swift */; };
+		9A2D5D32259F942B005682ED /* LazyMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D2F259F942B005682ED /* LazyMap.swift */; };
+		9A2D5D33259F942B005682ED /* LazyMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D2F259F942B005682ED /* LazyMap.swift */; };
+		9A2D5D3A259F985B005682ED /* Delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D39259F985B005682ED /* Delay.swift */; };
+		9A2D5D3B259F985B005682ED /* Delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D39259F985B005682ED /* Delay.swift */; };
+		9A2D5D3C259F985B005682ED /* Delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D39259F985B005682ED /* Delay.swift */; };
+		9A2D5D3D259F985B005682ED /* Delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D5D39259F985B005682ED /* Delay.swift */; };
 		9A67963B1F6056B90058C5B4 /* UninhabitedTypeGuards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */; };
 		9A67963C1F6059420058C5B4 /* UninhabitedTypeGuards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */; };
 		9A67963D1F6059430058C5B4 /* UninhabitedTypeGuards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */; };
@@ -264,6 +280,10 @@
 		9A1A4F981E16961C006F3039 /* ValidatingPropertySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidatingPropertySpec.swift; sourceTree = "<group>"; };
 		9A1B824020835EEC00EB7C09 /* ResultExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultExtensions.swift; sourceTree = "<group>"; };
 		9A1D067C1D948A2200ACF44C /* UnidirectionalBindingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnidirectionalBindingSpec.swift; sourceTree = "<group>"; };
+		9A2D5D1B259F9228005682ED /* UnaryAsyncOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnaryAsyncOperator.swift; sourceTree = "<group>"; };
+		9A2D5D25259F9373005682ED /* ObserveOn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserveOn.swift; sourceTree = "<group>"; };
+		9A2D5D2F259F942B005682ED /* LazyMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyMap.swift; sourceTree = "<group>"; };
+		9A2D5D39259F985B005682ED /* Delay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Delay.swift; sourceTree = "<group>"; };
 		9A67963A1F6056B90058C5B4 /* UninhabitedTypeGuards.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UninhabitedTypeGuards.swift; sourceTree = "<group>"; };
 		9A681A9D1E5A241B00B097CF /* DeprecationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationSpec.swift; sourceTree = "<group>"; };
 		9A9100DE1E0E6E620093E346 /* ValidatingProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidatingProperty.swift; sourceTree = "<group>"; };
@@ -413,10 +433,14 @@
 			isa = PBXGroup;
 			children = (
 				9AFA490B24E9A0C4003D263C /* Observer.swift */,
+				9A2D5D1B259F9228005682ED /* UnaryAsyncOperator.swift */,
 				9AFA491024E9A196003D263C /* Map.swift */,
 				9AFA491A24E9A925003D263C /* Filter.swift */,
 				9AFA491F24E9A988003D263C /* CompactMap.swift */,
 				9AFA492424E9B15C003D263C /* Operators.swift */,
+				9A2D5D25259F9373005682ED /* ObserveOn.swift */,
+				9A2D5D2F259F942B005682ED /* LazyMap.swift */,
+				9A2D5D39259F985B005682ED /* Delay.swift */,
 			);
 			path = Observers;
 			sourceTree = "<group>";
@@ -915,10 +939,13 @@
 				57A4D1B91BA13D7A00F7D4B1 /* Action.swift in Sources */,
 				57A4D1BA1BA13D7A00F7D4B1 /* Property.swift in Sources */,
 				9A090C171DA0309E00EE97CA /* Reactive.swift in Sources */,
+				9A2D5D1F259F9228005682ED /* UnaryAsyncOperator.swift in Sources */,
+				9A2D5D3D259F985B005682ED /* Delay.swift in Sources */,
 				57A4D1BB1BA13D7A00F7D4B1 /* Signal.swift in Sources */,
 				9AFA492824E9B15C003D263C /* Operators.swift in Sources */,
 				9A67963E1F6059440058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
 				9AFA491424E9A196003D263C /* Map.swift in Sources */,
+				9A2D5D33259F942B005682ED /* LazyMap.swift in Sources */,
 				9AFA491E24E9A925003D263C /* Filter.swift in Sources */,
 				57A4D1BC1BA13D7A00F7D4B1 /* SignalProducer.swift in Sources */,
 				57A4D1BD1BA13D7A00F7D4B1 /* Atomic.swift in Sources */,
@@ -931,6 +958,7 @@
 				EBCC7DBF1BBF01E200A2AE92 /* Signal.Observer.swift in Sources */,
 				C79B64801CD52E4E003F2376 /* EventLogger.swift in Sources */,
 				9AFA492324E9A988003D263C /* CompactMap.swift in Sources */,
+				9A2D5D29259F9373005682ED /* ObserveOn.swift in Sources */,
 				4A0E11021D2A92720065D310 /* Lifetime.swift in Sources */,
 				BE9CF3981D751B71003AE479 /* UnidirectionalBinding.swift in Sources */,
 			);
@@ -976,10 +1004,13 @@
 				A9B315C11B3940810001CB9C /* Action.swift in Sources */,
 				A9B315C21B3940810001CB9C /* Property.swift in Sources */,
 				9A090C161DA0309E00EE97CA /* Reactive.swift in Sources */,
+				9A2D5D1E259F9228005682ED /* UnaryAsyncOperator.swift in Sources */,
+				9A2D5D3C259F985B005682ED /* Delay.swift in Sources */,
 				A9B315C31B3940810001CB9C /* Signal.swift in Sources */,
 				9AFA492724E9B15C003D263C /* Operators.swift in Sources */,
 				9A67963D1F6059430058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
 				9AFA491324E9A196003D263C /* Map.swift in Sources */,
+				9A2D5D32259F942B005682ED /* LazyMap.swift in Sources */,
 				9AFA491D24E9A925003D263C /* Filter.swift in Sources */,
 				A9B315C41B3940810001CB9C /* SignalProducer.swift in Sources */,
 				A9B315C51B3940810001CB9C /* Atomic.swift in Sources */,
@@ -992,6 +1023,7 @@
 				EBCC7DBE1BBF01E200A2AE92 /* Signal.Observer.swift in Sources */,
 				C79B647F1CD52E4D003F2376 /* EventLogger.swift in Sources */,
 				9AFA492224E9A988003D263C /* CompactMap.swift in Sources */,
+				9A2D5D28259F9373005682ED /* ObserveOn.swift in Sources */,
 				4A0E11011D2A92720065D310 /* Lifetime.swift in Sources */,
 				BE9CF3971D751B71003AE479 /* UnidirectionalBinding.swift in Sources */,
 			);
@@ -1009,10 +1041,13 @@
 				D03B4A3D19F4C39A009E02AC /* FoundationExtensions.swift in Sources */,
 				9A090C141DA0309E00EE97CA /* Reactive.swift in Sources */,
 				D08C54B31A69A2AE00AD8286 /* Signal.swift in Sources */,
+				9A2D5D1C259F9228005682ED /* UnaryAsyncOperator.swift in Sources */,
+				9A2D5D3A259F985B005682ED /* Delay.swift in Sources */,
 				D85C652A1C0D84C7005A77AD /* Flatten.swift in Sources */,
 				9AFA492524E9B15C003D263C /* Operators.swift in Sources */,
 				9A67963B1F6056B90058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
 				9AFA491124E9A196003D263C /* Map.swift in Sources */,
+				9A2D5D30259F942B005682ED /* LazyMap.swift in Sources */,
 				9AFA491B24E9A925003D263C /* Filter.swift in Sources */,
 				D0C312CF19EF2A5800984962 /* Bag.swift in Sources */,
 				4A0E10FF1D2A92720065D310 /* Lifetime.swift in Sources */,
@@ -1025,6 +1060,7 @@
 				C79B647C1CD52E23003F2376 /* EventLogger.swift in Sources */,
 				9ABCB1851D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */,
 				9AFA492024E9A988003D263C /* CompactMap.swift in Sources */,
+				9A2D5D26259F9373005682ED /* ObserveOn.swift in Sources */,
 				D08C54B81A69A9D000AD8286 /* SignalProducer.swift in Sources */,
 				BE9CF3951D751B6B003AE479 /* UnidirectionalBinding.swift in Sources */,
 			);
@@ -1070,10 +1106,13 @@
 				9ABCB1861D2A5B5A00BCA243 /* Deprecations+Removals.swift in Sources */,
 				EBCC7DBD1BBF01E100A2AE92 /* Signal.Observer.swift in Sources */,
 				9A090C151DA0309E00EE97CA /* Reactive.swift in Sources */,
+				9A2D5D1D259F9228005682ED /* UnaryAsyncOperator.swift in Sources */,
+				9A2D5D3B259F985B005682ED /* Delay.swift in Sources */,
 				D85C652B1C0E70E3005A77AD /* Flatten.swift in Sources */,
 				9AFA492624E9B15C003D263C /* Operators.swift in Sources */,
 				9A67963C1F6059420058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
 				9AFA491224E9A196003D263C /* Map.swift in Sources */,
+				9A2D5D31259F942B005682ED /* LazyMap.swift in Sources */,
 				9AFA491C24E9A925003D263C /* Filter.swift in Sources */,
 				4A0E11001D2A92720065D310 /* Lifetime.swift in Sources */,
 				D08C54BB1A69C54400AD8286 /* Property.swift in Sources */,
@@ -1086,6 +1125,7 @@
 				D0C312E819EF2A5800984962 /* Scheduler.swift in Sources */,
 				D0C312D019EF2A5800984962 /* Bag.swift in Sources */,
 				9AFA492124E9A988003D263C /* CompactMap.swift in Sources */,
+				9A2D5D27259F9373005682ED /* ObserveOn.swift in Sources */,
 				D0D11ABA1A6AE87700C1F8B1 /* Action.swift in Sources */,
 				BE9CF3961D751B70003AE479 /* UnidirectionalBinding.swift in Sources */,
 			);

--- a/Sources/Observers/Delay.swift
+++ b/Sources/Observers/Delay.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+extension Operators {
+	internal final class Delay<Value, Error: Swift.Error>: UnaryAsyncOperator<Value, Value, Error> {
+		let interval: TimeInterval
+		let targetWithClock: DateScheduler
+
+		init(
+			downstream: Observer<Value, Error>,
+			downstreamLifetime: Lifetime,
+			target: DateScheduler,
+			interval: TimeInterval
+		) {
+			precondition(interval >= 0)
+
+			self.interval = interval
+			self.targetWithClock = target
+			super.init(downstream: downstream, downstreamLifetime: downstreamLifetime, target: target)
+		}
+
+		
+		override func receive(_ value: Value) {
+			guard isActive else { return }
+
+			targetWithClock.schedule(after: computeNextDate()) {
+				self.unscheduledSend(value)
+			}
+		}
+
+		override func terminate(_ termination: Termination<Error>) {
+			if case .completed = termination {
+				targetWithClock.schedule(after: computeNextDate()) {
+					super.terminate(.completed)
+				}
+			} else {
+				super.terminate(termination)
+			}
+		}
+
+		private func computeNextDate() -> Date {
+			targetWithClock.currentDate.addingTimeInterval(interval)
+		}
+	}
+}

--- a/Sources/Observers/LazyMap.swift
+++ b/Sources/Observers/LazyMap.swift
@@ -1,0 +1,43 @@
+extension Operators {
+	internal final class LazyMap<Value, NewValue, Error: Swift.Error>: UnaryAsyncOperator<Value, NewValue, Error> {
+		let transform: (Value) -> NewValue
+		let box = Atomic<Value?>(nil)
+	  let valueDisposable = SerialDisposable()
+
+		init(
+			downstream: Observer<NewValue, Error>,
+			downstreamLifetime: Lifetime,
+			target: Scheduler,
+			transform: @escaping (Value) -> NewValue
+		) {
+			self.transform = transform
+			super.init(downstream: downstream, downstreamLifetime: downstreamLifetime, target: target)
+
+			downstreamLifetime += valueDisposable
+		}
+
+		override func receive(_ value: Value) {
+			// Schedule only when there is no prior outstanding value.
+			if box.swap(value) == nil {
+				valueDisposable.inner = target.schedule {
+					if let value = self.box.swap(nil) {
+						self.unscheduledSend(self.transform(value))
+					}
+				}
+			}
+		}
+
+		override func terminate(_ termination: Termination<Error>) {
+			if case .interrupted = termination {
+				// `interrupted` immediately cancels any scheduled value.
+				//
+				// On the other hand, completion and failure does not cancel anything, and is scheduled to run after any
+				// scheduled value. `valueDisposable` will naturally be disposed by `downstreamLifetime` as soon as the
+				// downstream has processed the termination.
+				valueDisposable.dispose()
+			}
+
+			super.terminate(termination)
+		}
+	}
+}

--- a/Sources/Observers/ObserveOn.swift
+++ b/Sources/Observers/ObserveOn.swift
@@ -1,0 +1,10 @@
+extension Operators {
+	internal final class ObserveOn<Value, Error: Swift.Error>: UnaryAsyncOperator<Value, Value, Error> {
+		override func receive(_ value: Value) {
+			target.schedule {
+				guard !self.downstreamLifetime.hasEnded else { return }
+				self.unscheduledSend(value)
+			}
+		}
+	}
+}

--- a/Sources/Observers/UnaryAsyncOperator.swift
+++ b/Sources/Observers/UnaryAsyncOperator.swift
@@ -1,0 +1,64 @@
+internal class UnaryAsyncOperator<InputValue, OutputValue, Error: Swift.Error>: Observer<InputValue, Error> {
+	let downstreamLifetime: Lifetime
+	let target: Scheduler
+
+	/// Whether or not the downstream observer can still receive values or termination.
+	///
+	/// - note: This is a thread-safe atomic read. So you can use it in any part of `receive(_:)` or `terminate(_:)` to
+	///         attempt to early out before expensive scheduling or computation.
+	var isActive: Bool { state.is(.active) }
+
+	// Direct access is discouraged for subclasses by keeping this private.
+	private let downstream: Observer<OutputValue, Error>
+	private let state: UnsafeAtomicState<AsyncOperatorState>
+
+	public init(
+		downstream: Observer<OutputValue, Error>,
+		downstreamLifetime: Lifetime,
+		target: Scheduler
+	) {
+		self.downstream = downstream
+		self.downstreamLifetime = downstreamLifetime
+		self.target = target
+		self.state = UnsafeAtomicState(.active)
+
+		super.init()
+
+		downstreamLifetime.observeEnded {
+			if self.state.tryTransition(from: .active, to: .terminated) {
+				target.schedule {
+						downstream.terminate(.interrupted)
+				}
+			}
+		}
+	}
+
+	deinit {
+		state.deinitialize()
+	}
+
+	open override func receive(_ value: InputValue) { fatalError() }
+
+	/// Send a value to the downstream without any implicit scheduling on `target`.
+	///
+	/// - important: Subclasses must invoke this only after having hopped onto the target scheduler.
+	final func unscheduledSend(_ value: OutputValue) {
+		downstream.receive(value)
+	}
+
+	open override func terminate(_ termination: Termination<Error>) {
+		// The atomic transition here must happen **after** we hop onto the target scheduler. This is to preserve the timing
+		// behaviour observed in previous versions of ReactiveSwift.
+
+		target.schedule {
+			if self.state.tryTransition(from: .active, to: .terminated) {
+				self.downstream.terminate(termination)
+			}
+		}
+	}
+}
+
+private enum AsyncOperatorState: Int32 {
+	case active
+	case terminated
+}


### PR DESCRIPTION
The new abstraction was introduced in #799.

Migrated operators in this PR include: ObserveOn, LazyMap, Delay.

A new base class `UnaryAsyncOperator` has been introduced to unify the delicate termination handling in all unary async operators, that was once replicated across all individual implementations. The logic has also be strengthened to guarantee that double termination is impossible, by tracking a binary active/terminated state per operator instance using atomics.


#### Checklist
- ~~Updated CHANGELOG.md.~~
