### PR TITLE
Fixed a deprecation warning where some protocols were inheriting from class instead of AnyObject per Xcode's suggestion

### DIFF
--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -8,7 +8,7 @@
 
 /// Represents something that can be “disposed”, usually associated with freeing
 /// resources or canceling work.
-public protocol Disposable: class {
+public protocol Disposable: AnyObject {
 	/// Whether this disposable has been disposed already.
 	var isDisposed: Bool { get }
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -12,7 +12,7 @@ import Glibc
 ///
 /// Only classes can conform to this protocol, because having a signal
 /// for changes over time implies the origin must have a unique identity.
-public protocol PropertyProtocol: class, BindingSource {
+public protocol PropertyProtocol: AnyObject, BindingSource {
 	/// The current value of the property.
 	var value: Value { get }
 

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -14,7 +14,7 @@ import Foundation
 #endif
 
 /// Represents a serial queue of work items.
-public protocol Scheduler: class {
+public protocol Scheduler: AnyObject {
 	/// Enqueues an action on the scheduler.
 	///
 	/// When the work is executed depends on the scheduler in use.

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -415,7 +415,7 @@ extension Signal {
 	}
 }
 
-public protocol SignalProtocol: class {
+public protocol SignalProtocol: AnyObject {
 	/// The type of values being sent by `self`.
 	associatedtype Value
 
@@ -1662,7 +1662,7 @@ private enum ThrottleWhileState<Value> {
 	}
 }
 
-private protocol SignalAggregateStrategy: class {
+private protocol SignalAggregateStrategy: AnyObject {
 	/// Update the latest value of the signal at `position` to be `value`.
 	///
 	/// - parameters:


### PR DESCRIPTION
This is only to remove five compiler warnings.

I was updating my iOS app to be able to run on Xcode 12.5 (beta) and noticed that Apple is now flagging the use of class inherited protocols as deprecated in favor of inheriting from AnyObject. In my iOS app, we flag warnings as errors so now our app won't compile. I wanted to be able to pitch in and help modernize the code so I went ahead and fixed this deprecation here.

After a little bit of research, I came across this forum Swift.org [post](https://forums.swift.org/t/class-only-protocols-class-vs-anyobject/11507/4) which seems to point to the discussion where this deprecation discussion started.