### PR TITLE
Remove requirement for Swift 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # master
+
+1. Fixed issue with `SignalProducer.Type.interval()` making Swift 5.3 a requirement. (#823 kudos to @mluisbrown) 
+
 *Please add new entries at the top.*
 
 # 6.6.0

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -3081,7 +3081,9 @@ extension SignalProducer where Error == Never {
 			)
 		}
 	}
+}
 
+extension SignalProducer where Error == Never, Value == Int {
 	/// Creates a producer that will send the sequence of all integers
 	/// from 0 to infinity, or until disposed.
 	///
@@ -3098,7 +3100,7 @@ extension SignalProducer where Error == Never {
 	public static func interval(
 		_ interval: DispatchTimeInterval,
 		on scheduler: DateScheduler
-	) -> SignalProducer where Value == Int {
+	) -> SignalProducer {
 		.interval(0..., interval: interval, on: scheduler)
 	}
 }


### PR DESCRIPTION
Make the code compatible with Swift 5.1 and 5.2 again. Resolves #822

Prior to Swift 5.3 a `where` clause could not be used in a function that is itself not generic, even if used within a generic context. The only way to do this is to use a specific extension and put the `where` clause in the extension.

#### Checklist
- [x] Updated CHANGELOG.md.
