### PR TITLE
Make advance by TimeInterval in TestScheduler possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+1. `TestScheduler` can `advance` by `TimeInterval`. (#828)
+
 1. Fixed issue with `SignalProducer.Type.interval()` making Swift 5.3 a requirement. (#823 kudos to @mluisbrown) 
 
 *Please add new entries at the top.*

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -563,6 +563,17 @@ public final class TestScheduler: DateScheduler {
 		lock.unlock()
 	}
 
+	/// Advances the virtualized clock by the given interval, dequeuing and
+	/// executing any actions along the way.
+	///
+	/// - parameters:
+	///   - interval: Interval by which the current date will be advanced.
+	public func advance(by interval: TimeInterval) {
+		lock.lock()
+		advance(to: currentDate.addingTimeInterval(interval))
+		lock.unlock()
+	}
+
 	/// Advances the virtualized clock to the given future date, dequeuing and
 	/// executing any actions up until that point.
 	///

--- a/Tests/ReactiveSwiftTests/SchedulerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SchedulerSpec.swift
@@ -355,6 +355,15 @@ class SchedulerSpec: QuickSpec {
 				expect(scheduler.currentDate) == Date.distantFuture
 				expect(string) == "fuzzbuzzfoobar"
 			}
+
+			it("should advance by DispatchTimeInterval same as by TimeInterval") {
+				let schedulerB = TestScheduler(startDate: startDate)
+
+				scheduler.advance(by: .milliseconds(300))
+				schedulerB.advance(by: 0.3)
+
+				expect(scheduler.currentDate).to(equal(schedulerB.currentDate))
+			}
 		}
 	}
 }


### PR DESCRIPTION
The `currentDate` in `TestScheduler` could already be advanced by
`DispatchTimeInterval`. In unit tests the developer might want to
reuse an existing constant, which often is a `Double`/`TimeInterval`.

This PR adds a second method with exactly the same signature as the
existing one; only the type of the argument is different.


#### Checklist
- [x] Updated CHANGELOG.md.
