### PR TITLE
Fix shared state in retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@
 
 1. Fixed issue with `SignalProducer.Type.interval()` making Swift 5.3 a requirement. (#823 kudos to @mluisbrown) 
 
-*Please add new entries at the top.*
-
 # 6.6.0
 
 1. Added the `SignalProducer.Type.interval()` operator for emitting values on a regular schedule. (#810, kudos to @mluisbrown)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 1. Fixed issue with `SignalProducer.Type.interval()` making Swift 5.3 a requirement. (#823 kudos to @mluisbrown) 
 
+1. Fixed issue where `SingalProducer.try(upTo:interval:count:)` shares state between invocation of `start` on the same producer.
+
 *Please add new entries at the top.*
 
 # 6.6.0

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -2340,9 +2340,10 @@ extension SignalProducer {
 			return producer
 		}
 
-		var retries = count
+		return SignalProducer { observer, lifetime in
+			var retries = count
 
-		return flatMapError { error -> SignalProducer<Value, Error> in
+			lifetime += flatMapError { error -> SignalProducer<Value, Error> in
 				// The final attempt shouldn't defer the error if it fails
 				var producer = SignalProducer<Value, Error>(error: error)
 				if retries > 0 {
@@ -2355,6 +2356,8 @@ extension SignalProducer {
 				return producer
 			}
 			.retry(upTo: count)
+			.start(observer)
+		}
 	}
 
 	/// Wait for completion of `self`, *then* forward all events from


### PR DESCRIPTION
This fixes an issue where state is shared between different `start` invocations of the same producer.

```swift
let p = someProducer.retry(upTo: 1, interval: interval, on:scheduler)

p.start(...) // This consumes retries for the purpose of delaying errors
...
p.start(...) // Retries for the purpose of delaying errors can be negative here, resulting in the last error not being sent immediately.
```

#### Checklist
- [x] Updated CHANGELOG.md.
