### PR TITLE
UnidirectionalBinding should return non optionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. The UnidirectionalBinding operator `<~` returns non optional values.
+
 # 6.6.1
 1. Updated Carthage xcconfig dependency to 1.1 for proper building arm64 macOS variants. (#826, kudos to @MikeChugunov)
 

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -120,7 +120,7 @@ extension Signal.Observer {
 	@discardableResult
 	public static func <~
 		<Source: BindingSource>
-		(observer: Signal<Value, Error>.Observer, source: Source) -> Disposable?
+		(observer: Signal<Value, Error>.Observer, source: Source) -> Disposable
 		where Source.Value == Value
 	{
 		return source.producer.startWithValues { [weak observer] in


### PR DESCRIPTION
This fixes the `<~` operator returning optional values even though it should be able to just return non optional ones.

#### Checklist
- [x] Updated CHANGELOG.md.
