### PR TITLE
Fix typo ("conjuncion" --> "conjunction")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. Fixed spelling error in `Token` class documentation.
+
 # 6.6.1
 1. Updated Carthage xcconfig dependency to 1.1 for proper building arm64 macOS variants. (#826, kudos to @MikeChugunov)
 

--- a/Sources/Lifetime.swift
+++ b/Sources/Lifetime.swift
@@ -88,7 +88,7 @@ extension Lifetime {
 	/// A token object which completes its associated `Lifetime` when
 	/// it deinitializes, or when `dispose()` is called.
 	///
-	/// It is generally used in conjuncion with `Lifetime` as a private
+	/// It is generally used in conjunction with `Lifetime` as a private
 	/// deinitialization trigger.
 	///
 	/// ```


### PR DESCRIPTION
Just a small typo fix in the documentation for `Token` in `Lifetime.swift`.

#### Checklist
- [x] Updated CHANGELOG.md.
