### PR TITLE
Add take(until:) operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
     When debugging your application, the call stacks involving ReactiveSwift may now look cleaner, without the clutter of compiler-generated reabstraction thunks. See #799 for an example.
 
+1. New operator `SignalProducer.take(until:)` that forwards any values until `shouldContinue` returns `false`. Equivalent to `take(while:)`, except it also forwards the last value that failed the check. (#839, kudos to @nachosoto)
+
 # 6.6.1
 1. Updated Carthage xcconfig dependency to 1.1 for proper building arm64 macOS variants. (#826, kudos to @MikeChugunov)
 

--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		4A0E11041D2A95200065D310 /* LifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E11031D2A95200065D310 /* LifetimeSpec.swift */; };
 		4A0E11051D2A95200065D310 /* LifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E11031D2A95200065D310 /* LifetimeSpec.swift */; };
 		4A0E11061D2A95200065D310 /* LifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E11031D2A95200065D310 /* LifetimeSpec.swift */; };
+		5792972826DE7623007A9F64 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5792972726DE7623007A9F64 /* TakeUntil.swift */; };
+		5792972926DE7623007A9F64 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5792972726DE7623007A9F64 /* TakeUntil.swift */; };
+		5792972A26DE7623007A9F64 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5792972726DE7623007A9F64 /* TakeUntil.swift */; };
+		5792972B26DE7623007A9F64 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5792972726DE7623007A9F64 /* TakeUntil.swift */; };
 		579504331BB8A34200A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
 		579504341BB8A34300A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
 		57A4D1B11BA13D7A00F7D4B1 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = D871D69E1B3B29A40070F16C /* Optional.swift */; };
@@ -393,6 +397,7 @@
 		4A0AB6711DC28EFF00AA1E81 /* ReactiveExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveExtensionsSpec.swift; sourceTree = "<group>"; };
 		4A0E10FE1D2A92720065D310 /* Lifetime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lifetime.swift; sourceTree = "<group>"; };
 		4A0E11031D2A95200065D310 /* LifetimeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifetimeSpec.swift; sourceTree = "<group>"; };
+		5792972726DE7623007A9F64 /* TakeUntil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TakeUntil.swift; sourceTree = "<group>"; };
 		57A4D2411BA13D7A00F7D4B1 /* ReactiveSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		57A4D2441BA13F9700F7D4B1 /* tvOS-Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Application.xcconfig"; sourceTree = "<group>"; };
 		57A4D2451BA13F9700F7D4B1 /* tvOS-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Base.xcconfig"; sourceTree = "<group>"; };
@@ -578,6 +583,7 @@
 				9A2D5C9E259F8059005682ED /* TakeFirst.swift */,
 				9A2D5CAD259F8112005682ED /* TakeLast.swift */,
 				9A2D5CB7259F8199005682ED /* TakeWhile.swift */,
+				5792972726DE7623007A9F64 /* TakeUntil.swift */,
 				9A2D5CC1259F81FC005682ED /* SkipFirst.swift */,
 				9A2D5CCB259F8263005682ED /* SkipWhile.swift */,
 				9A2D5C4E259F7B21005682ED /* MapError.swift */,
@@ -1051,6 +1057,7 @@
 				57A4D1B81BA13D7A00F7D4B1 /* Scheduler.swift in Sources */,
 				9A9100E21E0E6E680093E346 /* ValidatingProperty.swift in Sources */,
 				9A2D5CF2259F85AE005682ED /* SkipRepeats.swift in Sources */,
+				5792972B26DE7623007A9F64 /* TakeUntil.swift in Sources */,
 				9A2D5CBB259F8199005682ED /* TakeWhile.swift in Sources */,
 				57A4D1B91BA13D7A00F7D4B1 /* Action.swift in Sources */,
 				57A4D1BA1BA13D7A00F7D4B1 /* Property.swift in Sources */,
@@ -1153,6 +1160,7 @@
 				9AFA491324E9A196003D263C /* Map.swift in Sources */,
 				9A2D5CFB259F8634005682ED /* UniqueValues.swift in Sources */,
 				9A2D5C65259F7B47005682ED /* MaterializeAsResult.swift in Sources */,
+				5792972A26DE7623007A9F64 /* TakeUntil.swift in Sources */,
 				9A2D5D55259FA000005682ED /* Throttle.swift in Sources */,
 				9A67963D1F6059430058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
 				9A2D5D5F259FA0DD005682ED /* Debounce.swift in Sources */,
@@ -1196,6 +1204,7 @@
 				9A9100DF1E0E6E620093E346 /* ValidatingProperty.swift in Sources */,
 				EBCC7DBC1BBF010C00A2AE92 /* Signal.Observer.swift in Sources */,
 				9A2D5CEF259F85AE005682ED /* SkipRepeats.swift in Sources */,
+				5792972826DE7623007A9F64 /* TakeUntil.swift in Sources */,
 				9A2D5CB8259F8199005682ED /* TakeWhile.swift in Sources */,
 				D03B4A3D19F4C39A009E02AC /* FoundationExtensions.swift in Sources */,
 				9A090C141DA0309E00EE97CA /* Reactive.swift in Sources */,
@@ -1298,6 +1307,7 @@
 				9AFA491224E9A196003D263C /* Map.swift in Sources */,
 				9A2D5CFA259F8634005682ED /* UniqueValues.swift in Sources */,
 				9A2D5C64259F7B47005682ED /* MaterializeAsResult.swift in Sources */,
+				5792972926DE7623007A9F64 /* TakeUntil.swift in Sources */,
 				9A2D5D54259FA000005682ED /* Throttle.swift in Sources */,
 				9A67963C1F6059420058C5B4 /* UninhabitedTypeGuards.swift in Sources */,
 				9A2D5D5E259FA0DD005682ED /* Debounce.swift in Sources */,

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -289,6 +289,12 @@ extension Signal.Event {
 			Operators.TakeWhile(downstream: downstream, shouldContinue: shouldContinue)
 		}
 	}
+	
+	internal static func take(until shouldContinue: @escaping (Value) -> Bool) -> Transformation<Value, Error> {
+		return { downstream, _ in
+			Operators.TakeUntil(downstream: downstream, shouldContinue: shouldContinue)
+		}
+	}
 
 	internal static func skip(first count: Int) -> Transformation<Value, Error> {
 		return { downstream, _ in

--- a/Sources/Observers/TakeUntil.swift
+++ b/Sources/Observers/TakeUntil.swift
@@ -1,0 +1,23 @@
+extension Operators {
+	internal final class TakeUntil<Value, Error: Swift.Error>: Observer<Value, Error> {
+		let downstream: Observer<Value, Error>
+		let shouldContinue: (Value) -> Bool
+
+		init(downstream: Observer<Value, Error>, shouldContinue: @escaping (Value) -> Bool) {
+			self.downstream = downstream
+			self.shouldContinue = shouldContinue
+		}
+
+		override func receive(_ value: Value) {
+			downstream.receive(value)
+			
+			if !shouldContinue(value) {
+				downstream.terminate(.completed)
+			}
+		}
+
+		override func terminate(_ termination: Termination<Error>) {
+			downstream.terminate(termination)
+		}
+	}
+}

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -1595,8 +1595,22 @@ extension Signal {
 	///                     continue.
 	///
 	/// - returns: A signal which conditionally forwards values from `self`.
+	/// - seealso: `take(until:)`
 	public func take(while shouldContinue: @escaping (Value) -> Bool) -> Signal<Value, Error> {
 		return flatMapEvent(Signal.Event.take(while: shouldContinue))
+	}
+	
+	/// Forward any values from `self` until `shouldContinue` returns `false`, at which
+	/// point the returned signal forwards the last value and then it completes.
+	/// This is equivalent to `take(while:)`, except it also forwards the last value that failed the check.
+	///
+	/// - parameters:
+	///   - shouldContinue: A closure to determine whether the forwarding of values should
+	///                     continue.
+	///
+	/// - returns: A signal which conditionally forwards values from `self`.
+	public func take(until shouldContinue: @escaping (Value) -> Bool) -> Signal<Value, Error> {
+		return flatMapEvent(Signal.Event.take(until: shouldContinue))
 	}
 }
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -1631,6 +1631,19 @@ extension SignalProducer {
 	}
 
 	/// Forward any values from `self` until `shouldContinue` returns `false`, at which
+	/// point the returned signal forwards the last value and then it completes.
+	/// This is equivalent to `take(while:)`, except it also forwards the last value that failed the check.
+	///
+	/// - parameters:
+	///   - shouldContinue: A closure to determine whether the forwarding of values should
+	///                     continue.
+	///
+	/// - returns: A signal which conditionally forwards values from `self`.
+	public func take(until shouldContinue: @escaping (Value) -> Bool) -> SignalProducer<Value, Error> {
+		return core.flatMapEvent(Signal.Event.take(until: shouldContinue))
+	}
+	
+	/// Forward any values from `self` until `shouldContinue` returns `false`, at which
 	/// point the produced `Signal` would complete.
 	///
 	/// - parameters:


### PR DESCRIPTION
Forward any values until `shouldContinue` returns `false`, at which point the returned signal forwards the last value and then it completes.

This is equivalent to `take(while:)`, except it also forwards the last value that failed the check.

I was going to add this to my own project as an extension, but a consequence of #799 is that it's not "impossible" (not as trivial as before) to add these operators, since things like `flatMapEvent` and `Event.Transformation` aren't `public`.

So I wanted this PR to serve as a conversation. I think this operator can be useful, but also it might be worth exploring how we can make it easier to declare outside of ReactiveSwift, maybe exposing some of these new types?

#### Checklist
- [x] Updated CHANGELOG.md.
