### PR TITLE
Signal.Event: changed to `@frozen`

### DIFF
--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -6,6 +6,7 @@ extension Signal {
 	///
 	/// Signals must conform to the grammar:
 	/// `value* (failed | completed | interrupted)?`
+	@frozen
 	public enum Event {
 		/// A value provided by the signal.
 		case value(Value)


### PR DESCRIPTION
This `enum` isn't expected to change. It's important to mark it as `@frozen`
so that clients don't get warnings whem compiling with `BUILD_LIBRARY_FOR_DISTRIBUTION`,
which might be required in a future version of Carthage supporting Catalyst.
(See https://github.com/Carthage/Carthage/pull/3235).


#### Checklist
- [ ] Updated CHANGELOG.md.
