### PR TITLE
Fix "'value' is inaccessible due to 'internal' protection level" in SignalProducer playground

### DIFF
--- a/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveSwift.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -135,7 +135,7 @@ with the Signal, and prevent any future callbacks from being invoked.
 scopedExample("`startWithResult`") {
 	SignalProducer<Int, Never>(value: 42)
 		.startWithResult { result in
-			print(result.value)
+			print(result)
 		}
 }
 


### PR DESCRIPTION
This fixes the `'value' is inaccessible due to 'internal' protection level` of the SignalProducer playground page

```
error: SignalProducer.xcplaygroundpage:138:17: error: 'value' is inaccessible due to 'internal' protection level
                        print(result.value)
                                     ^~~~~
```

<img width="650" alt="value' is inaccessible due to 'internal' protection level" src="https://user-images.githubusercontent.com/118770/139581109-8bfcc4b2-15eb-4c65-bf13-adf9bf9ba5b1.png">]

Caused by #733

#### Checklist
- [ ] Updated CHANGELOG.md.
