### PR TITLE
Fix "No such module 'ReactiveSwift'" in Playground pages by enabling "buildActiveScheme"

### DIFF
--- a/ReactiveSwift.playground/contents.xcplayground
+++ b/ReactiveSwift.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='macos' display-mode='rendered'>
+<playground version='6.0' target-platform='macos' display-mode='rendered' buildActiveScheme='true'>
     <pages>
         <page name='Sandbox'/>
         <page name='SignalProducer'/>


### PR DESCRIPTION
Before|After
-|-
<img width="1122" alt="No such module ReactiveSwift before" src="https://user-images.githubusercontent.com/118770/139581690-e17261c8-7d07-4d73-8c94-90cef5b79625.png">|<img width="1121" alt="No such module ReactiveSwift after" src="https://user-images.githubusercontent.com/118770/139581698-454e0b83-3ce9-45fd-aa07-0ecc08569c53.png">

Checked with Xcode 13.1.0

#### Checklist
- [ ] Updated CHANGELOG.md.
