### PR TITLE
Add primary associated types to SignalProducerConvertible & SignalProducerProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 *Please add new entries at the top.*
 
+1. Add primary associated types to SignalProducerConvertible & SignalProducerProtocol (#855, kudos to @braker1nine)
 1. Refactor Github Actions to cover more swift versions (#858, kudos to @braker1nine)
 1.Use `OSAllocatedUnfairLock` instead of `os_unfair_lock` on supported Apple platforms (#856, kudos to @mluisbrown)
 

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -538,6 +538,7 @@ extension SignalProducer where Error == Swift.Error {
 	}
 }
 
+#if swift(>=5.7)
 /// Represents reactive primitives that can be represented by `SignalProducer`.
 public protocol SignalProducerConvertible<Value, Error> {
 	/// The type of values being sent by `self`.
@@ -549,7 +550,21 @@ public protocol SignalProducerConvertible<Value, Error> {
 	/// The `SignalProducer` representation of `self`.
 	var producer: SignalProducer<Value, Error> { get }
 }
+#else
+/// Represents reactive primitives that can be represented by `SignalProducer`.
+public protocol SignalProducerConvertible {
+	/// The type of values being sent by `self`.
+	associatedtype Value
 
+	/// The type of error that can occur on `self`.
+	associatedtype Error: Swift.Error
+
+	/// The `SignalProducer` representation of `self`.
+	var producer: SignalProducer<Value, Error> { get }
+}
+#endif
+
+#if swift(>=5.7)
 /// A protocol for constraining associated types to `SignalProducer`.
 public protocol SignalProducerProtocol<Value, Error> {
 	/// The type of values being sent by `self`.
@@ -561,6 +576,19 @@ public protocol SignalProducerProtocol<Value, Error> {
 	/// The materialized `self`.
 	var producer: SignalProducer<Value, Error> { get }
 }
+#else
+/// A protocol for constraining associated types to `SignalProducer`.
+public protocol SignalProducerProtocol {
+	/// The type of values being sent by `self`.
+	associatedtype Value
+
+	/// The type of error that can occur on `self`.
+	associatedtype Error: Swift.Error
+
+	/// The materialized `self`.
+	var producer: SignalProducer<Value, Error> { get }
+}
+#endif
 
 extension SignalProducer: SignalProducerConvertible, SignalProducerProtocol {
 	public var producer: SignalProducer {

--- a/Sources/SignalProducer.swift
+++ b/Sources/SignalProducer.swift
@@ -539,7 +539,7 @@ extension SignalProducer where Error == Swift.Error {
 }
 
 /// Represents reactive primitives that can be represented by `SignalProducer`.
-public protocol SignalProducerConvertible {
+public protocol SignalProducerConvertible<Value, Error> {
 	/// The type of values being sent by `self`.
 	associatedtype Value
 
@@ -551,7 +551,7 @@ public protocol SignalProducerConvertible {
 }
 
 /// A protocol for constraining associated types to `SignalProducer`.
-public protocol SignalProducerProtocol {
+public protocol SignalProducerProtocol<Value, Error> {
 	/// The type of values being sent by `self`.
 	associatedtype Value
 


### PR DESCRIPTION
Adds [primary associated types](https://github.com/apple/swift-evolution/blob/main/proposals/0346-light-weight-same-type-syntax.md) to `SignalProducerConvertible` and `SignalProducerProtocol`

#### Checklist
- [x] Updated CHANGELOG.md.
