### PR TITLE
Guard use of OSAllocatedUnfairLock with a Swift 5.7 version check to allow building on Xcode 13.x

### DIFF
--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -137,29 +137,31 @@ internal class Lock: LockProtocol {
 	#endif
 
 	#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-	@available(iOS 16.0, *)
-	@available(macOS 13.0, *)
-	@available(tvOS 16.0, *)
-	@available(watchOS 9.0, *)
-	internal final class AllocatedUnfairLock: Lock {
-		private let _lock = OSAllocatedUnfairLock()
+		#if swift(>=5.7)
+		@available(iOS 16.0, *)
+		@available(macOS 13.0, *)
+		@available(tvOS 16.0, *)
+		@available(watchOS 9.0, *)
+		internal final class AllocatedUnfairLock: Lock {
+			private let _lock = OSAllocatedUnfairLock()
 
-		override init() {
-			super.init()
-		}
+			override init() {
+				super.init()
+			}
 
-		override func lock() {
-			_lock.lock()
-		}
+			override func lock() {
+				_lock.lock()
+			}
 
-		override func unlock() {
-			_lock.unlock()
-		}
+			override func unlock() {
+				_lock.unlock()
+			}
 
-		override func `try`() -> Bool {
-			_lock.lockIfAvailable()
+			override func `try`() -> Bool {
+				_lock.lockIfAvailable()
+			}
 		}
-	}
+		#endif
 	#endif
 
 	internal final class PthreadLock: Lock {
@@ -221,11 +223,15 @@ internal class Lock: LockProtocol {
 
 	static func make() -> Self {
 		#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+			#if swift(>=5.7)
 			guard #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) else {
 				return UnfairLock() as! Self
 			}
 
 			return AllocatedUnfairLock() as! Self
+			#else
+				return UnfairLock() as! Self
+			#endif
 		#else
 			return PthreadLock() as! Self
 		#endif

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -769,7 +769,7 @@ public final class TestScheduler: DateScheduler {
 		while lock.sync({ _currentDate }) <= newDate {
 			await Task.megaYield()
 
-			let `return` = lock.sync {
+			let `return`: Bool = lock.sync { () -> Bool in
 				guard
 					let next = scheduledActions.first,
 					newDate >= next.date


### PR DESCRIPTION
The changes made in #859 went a little too far in removing the Swift version check, without which building fails on Xcode 13.x, so I added it back. 
