### PR TITLE
Bump Minimums OSes to suppress Xcode 14 warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please add new entries at the top.*
 
+1. Bumped deployment target to iOS 11, tvOS 11, watchOS 4, macOS 10.13, per Xcode 14 warnings
+
 # 7.1.0
 1. Add CI Release jobs on tag push (#862, kudos to @p4checo)
 1. Fix some issues related to locking, bumped min OS versions to iOS 10, macOS 10.12, tvOS 10, watchOS 3 (#859, kudos to @mluisbrown)

--- a/Documentation/RxCheatsheet.md
+++ b/Documentation/RxCheatsheet.md
@@ -7,7 +7,7 @@ Inspired by the [RxSwift to Combine cheatsheet](https://github.com/CombineCommun
 
 |                       | RxSwift                          | ReactiveSwift                              |
 |-----------------------|----------------------------------|--------------------------------------------|
-| Deployment Target     | iOS 8.0+                         | iOS 9.0+
+| Deployment Target     | iOS 9.0+                         | iOS 11.0+
 | Platforms supported   | iOS, macOS, tvOS, watchOS, Linux | iOS, macOS, tvOS, watchOS, Linux
 | Spec                  | Reactive Extensions (ReactiveX)  | Originally ReactiveX, with significant divergence
 | Framework Consumption | Third-party                      | Third-party

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "ReactiveSwift",
     platforms: [
-        .macOS(.v10_12), .iOS(.v10), .tvOS(.v10), .watchOS(.v3)
+        .macOS(.v10_13), .iOS(.v11), .tvOS(.v11), .watchOS(.v4)
     ],
     products: [
         .library(name: "ReactiveSwift", targets: ["ReactiveSwift"]),

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ code and state to bridge the gap.
 
 ## Installation
 
-ReactiveSwift supports macOS 10.9+, iOS 9.0+, watchOS 2.0+, tvOS 9.0+ and Linux.
+ReactiveSwift supports macOS 10.13+, iOS 11.0+, watchOS 4.0+, tvOS 11.0+ and Linux.
 
 #### Carthage
 

--- a/ReactiveSwift.podspec
+++ b/ReactiveSwift.podspec
@@ -11,9 +11,10 @@ Pod::Spec.new do |s|
   s.author       = "ReactiveCocoa"
 
   s.ios.deployment_target = "10.0"
-  s.osx.deployment_target = "10.12"
-  s.watchos.deployment_target = "3.0"
-  s.tvos.deployment_target = "10.0"
+  s.osx.deployment_target = "10.13"
+  s.watchos.deployment_target = "4.0"
+  s.tvos.deployment_target = "11.0"
+
   s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveSwift.git", :tag => "#{s.version}" }
   # Directory glob for all Swift files
   s.source_files  = ["Sources/*.{swift}", "Sources/**/*.{swift}"]

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -362,7 +362,6 @@ public final class QueueScheduler: DateScheduler {
 	///   - name: A name for the queue in the form of reverse domain.
 	///   - targeting: (Optional) The queue on which this scheduler's work is
 	///     targeted
-	@available(OSX 10.10, *)
 	public convenience init(
 		qos: DispatchQoS = .default,
 		name: String = "org.reactivecocoa.ReactiveSwift.QueueScheduler",

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -186,25 +186,23 @@ class ActionSpec: QuickSpec {
 				action1.apply().start()
 			}
 
-			if #available(macOS 10.10, *) {
-				it("should not loop indefinitely") {
-					let condition = MutableProperty(1)
+            it("should not loop indefinitely") {
+                let condition = MutableProperty(1)
 
-					let action = Action<Void, Void, Never>(state: condition, enabledIf: { $0 == 0 }) { _, _ in
-						return .empty
-					}
+                let action = Action<Void, Void, Never>(state: condition, enabledIf: { $0 == 0 }) { _, _ in
+                    return .empty
+                }
 
-					var count = 0
+                var count = 0
 
-					action.isExecuting.producer
-						.startWithValues { _ in
-							condition.value = 10
+                action.isExecuting.producer
+                    .startWithValues { _ in
+                        condition.value = 10
 
-							count += 1
-							expect(count) == 1
-						}
-				}
-			}
+                        count += 1
+                        expect(count) == 1
+                    }
+            }
 
 			describe("completed") {
 				beforeEach {

--- a/Tests/ReactiveSwiftTests/ActionSpec.swift
+++ b/Tests/ReactiveSwiftTests/ActionSpec.swift
@@ -186,23 +186,23 @@ class ActionSpec: QuickSpec {
 				action1.apply().start()
 			}
 
-            it("should not loop indefinitely") {
-                let condition = MutableProperty(1)
-
-                let action = Action<Void, Void, Never>(state: condition, enabledIf: { $0 == 0 }) { _, _ in
-                    return .empty
-                }
-
-                var count = 0
-
-                action.isExecuting.producer
-                    .startWithValues { _ in
-                        condition.value = 10
-
-                        count += 1
-                        expect(count) == 1
-                    }
-            }
+			it("should not loop indefinitely") {
+				let condition = MutableProperty(1)
+				
+				let action = Action<Void, Void, Never>(state: condition, enabledIf: { $0 == 0 }) { _, _ in
+					return .empty
+				}
+				
+				var count = 0
+				
+				action.isExecuting.producer
+					.startWithValues { _ in
+						condition.value = 10
+						
+						count += 1
+						expect(count) == 1
+					}
+			}
 
 			describe("completed") {
 				beforeEach {

--- a/Tests/ReactiveSwiftTests/PropertySpec.swift
+++ b/Tests/ReactiveSwiftTests/PropertySpec.swift
@@ -272,14 +272,7 @@ class PropertySpec: QuickSpec {
 			}
 
 			it("should not deadlock") {
-				let queue: DispatchQueue
-
-				if #available(macOS 10.10, *) {
-					queue = DispatchQueue.global(qos: .userInteractive)
-				} else {
-					queue = DispatchQueue.global(priority: .high)
-				}
-
+				let queue = DispatchQueue.global(qos: .userInteractive)
 				let setup = DispatchGroup()
 				let workers = DispatchGroup()
 

--- a/Tests/ReactiveSwiftTests/QueueScheduler+Factory.swift
+++ b/Tests/ReactiveSwiftTests/QueueScheduler+Factory.swift
@@ -6,14 +6,6 @@ extension QueueScheduler {
 		let file = URL(string: file)?.lastPathComponent ?? "<unknown>"
 		let label = "reactiveswift:\(file):\(line)"
 
-		#if targetEnvironment(macCatalyst)
 		return QueueScheduler(name: label)
-		#else
-		if #available(OSX 10.10, iOS 8.0, *) {
-			return QueueScheduler(name: label)
-		} else {
-			return QueueScheduler()
-		}
-		#endif
 	}
 }

--- a/Tests/ReactiveSwiftTests/SchedulerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SchedulerSpec.swift
@@ -41,13 +41,7 @@ class SchedulerSpec: QuickSpec {
 		describe("UIScheduler") {
 			func dispatchSyncInBackground(_ action: @escaping () -> Void) {
 				let group = DispatchGroup()
-
-				let globalQueue: DispatchQueue
-				if #available(*, OSX 10.10) {
-					globalQueue = DispatchQueue.global()
-				} else {
-					globalQueue = DispatchQueue.global(priority: .default)
-				}
+				let globalQueue = DispatchQueue.global()
 
 				globalQueue.async(group: group, execute: action)
 				group.wait()

--- a/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalProducerSpec.swift
@@ -3087,13 +3087,7 @@ class SignalProducerSpec: QuickSpec {
 				var result: Result<Int, Never>?
 
 				let group = DispatchGroup()
-
-				let globalQueue: DispatchQueue
-				if #available(*, OSX 10.10) {
-					globalQueue = DispatchQueue.global()
-				} else {
-					globalQueue = DispatchQueue.global(priority: .default)
-				}
+				let globalQueue = DispatchQueue.global()
 
 				globalQueue.async(group: group, flags: []) {
 					result = producer.last()
@@ -3135,13 +3129,7 @@ class SignalProducerSpec: QuickSpec {
 				var result: Result<(), Never>?
 
 				let group = DispatchGroup()
-
-				let globalQueue: DispatchQueue
-				if #available(*, OSX 10.10) {
-					globalQueue = DispatchQueue.global()
-				} else {
-					globalQueue = DispatchQueue.global(priority: .default)
-				}
+				let globalQueue = DispatchQueue.global()
 
 				globalQueue.async(group: group, flags: []) {
 					result = producer.wait()

--- a/Tests/ReactiveSwiftTests/SignalSpec.swift
+++ b/Tests/ReactiveSwiftTests/SignalSpec.swift
@@ -314,13 +314,7 @@ class SignalSpec: QuickSpec {
 
 		describe("interruption") {
 			it("should not send events after sending an interrupted event") {
-				let queue: DispatchQueue
-
-				if #available(macOS 10.10, *) {
-					queue = DispatchQueue.global(qos: .userInitiated)
-				} else {
-					queue = DispatchQueue.global(priority: .high)
-				}
+				let queue = DispatchQueue.global(qos: .userInitiated)
 
 				let (signal, observer) = Signal<Int, Never>.pipe()
 
@@ -362,15 +356,9 @@ class SignalSpec: QuickSpec {
 			}
 
 			it("should interrupt concurrently") {
-				let queue: DispatchQueue
+				let queue = DispatchQueue.global(qos: .userInitiated)
 				let counter = Atomic<Int>(0)
 				let executionCounter = Atomic<Int>(0)
-
-				if #available(macOS 10.10, *) {
-					queue = DispatchQueue.global(qos: .userInitiated)
-				} else {
-					queue = DispatchQueue.global(priority: .high)
-				}
 
 				let iterations = 1000
 				let group = DispatchGroup()


### PR DESCRIPTION
This updates all deployment target minimums to the values supported by Xcode 14.
It removes spurious warnings of the form:

```
The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.2.99.
```

#### Checklist
- [x] Updated CHANGELOG.md.
