### PR TITLE
Explicit extension safety flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 *Please add new entries at the top.*
 
 1. Bumped deployment target to iOS 11, tvOS 11, watchOS 4, macOS 10.13, per Xcode 14 warnings
-1. Explicitly declare `APPLICATION_EXTENSION_API_ONLY`
+1. Explicitly declare `APPLICATION_EXTENSION_API_ONLY` for CocoaPods
 
 # 7.1.0
 1. Add CI Release jobs on tag push (#862, kudos to @p4checo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 *Please add new entries at the top.*
 
 1. Bumped deployment target to iOS 11, tvOS 11, watchOS 4, macOS 10.13, per Xcode 14 warnings
+1. Explicitly declare `APPLICATION_EXTENSION_API_ONLY`
 
 # 7.1.0
 1. Add CI Release jobs on tag push (#862, kudos to @p4checo)

--- a/ReactiveSwift.podspec
+++ b/ReactiveSwift.podspec
@@ -19,7 +19,10 @@ Pod::Spec.new do |s|
   # Directory glob for all Swift files
   s.source_files  = ["Sources/*.{swift}", "Sources/**/*.{swift}"]
 
-  s.pod_target_xcconfig = {"OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
+  s.pod_target_xcconfig = {
+    'APPLICATION_EXTENSION_API_ONLY' => 'YES',
+    "OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings"
+  }
 
   s.cocoapods_version = ">= 1.7.0"
   s.swift_versions = ["5.2", "5.3" "5.4", "5.5", "5.6", "5.7"]

--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -1512,7 +1512,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047262919E49FE8006002AA /* Debug.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1534,7 +1533,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047262B19E49FE8006002AA /* Release.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1637,7 +1635,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047262A19E49FE8006002AA /* Profile.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1699,7 +1696,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047262C19E49FE8006002AA /* Test.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 1;

--- a/ReactiveSwift.xcodeproj/project.pbxproj
+++ b/ReactiveSwift.xcodeproj/project.pbxproj
@@ -1512,6 +1512,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047262919E49FE8006002AA /* Debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1533,6 +1534,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047262B19E49FE8006002AA /* Release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1635,6 +1637,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047262A19E49FE8006002AA /* Profile.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1696,6 +1699,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047262C19E49FE8006002AA /* Test.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
This explicitly declares that ReactiveSwift only uses extension safe APIs (and/or APIs in an extension-safe way).
The code was already extension safe; this just forward declares it and enforces it at compile time.

If I can enforce this here, then I can enforce it in [Workflow](https://github.com/square/Workflow-swift) which is heavily dependent on this library.
Without this explicit conformance, it is not straightforward to write CI validation that these libraries remain extension safe.

There is zero harm in explicit conformance. Non-extension applications can call into extension-safe libraries without any restrictions.

#### Checklist
- [x] Updated CHANGELOG.md.
