### PR TITLE
Fix CI release git tag push trigger

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -3,7 +3,8 @@ on:
     branches:
       - master
     tags:
-      - '[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)*'
+      - '[0-9]+\.[0-9]+\.[0-9]+'
+      - '[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+'
   pull_request:
     types: [labeled]
     branches:
@@ -63,7 +64,7 @@ jobs:
           pod lib lint --use-libraries
 
   release-github:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
     name: GitHub Release
     runs-on: macos-12
     needs: [swiftpm-macos, cocoapods, carthage]
@@ -74,7 +75,7 @@ jobs:
         uses: softprops/action-gh-release@v1
 
   release-cocoapods:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
     name: CocoaPods Release
     runs-on: macos-12
     needs: [swiftpm-macos, cocoapods, carthage]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 *Please add new entries at the top.*
 
 1. Fix minimum deployment target of iOS 11 in CocoaPods
+1. Fix CI release git tag push trigger (#869, kudos to @p4checo)
 
 # 7.1.1
 1. Bumped deployment target to iOS 11, tvOS 11, watchOS 4, macOS 10.13, per Xcode 14 warnings (#865, kudos to @lickel)


### PR DESCRIPTION
Apparently GH action's push event filters accept glob patterns and *not* regexes :facepalm:

Source:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore

That means that the existing tag filter string being a regex wasn't working properly and as such wasn't triggering the expected builds on tag push.

To address this, the `on.push.tags` were updated to have separate entries for normal vs `rc` tags, and also tweaked the tag-only jobs' filters to rely on `github.ref_type` instead of inspecting `github.ref`.


#### Checklist
- [x] Updated CHANGELOG.md.
