### PR TITLE
Add extension to ScopedDisposable for SerialDisposable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 1. Fix minimum deployment target of iOS 11 in CocoaPods
 1. Fix CI release git tag push trigger (#869, kudos to @p4checo)
-2. Add extension to `ScopedDisposable` for inner `SerialDisposable` (#873, kudos to @sirnacud)
+2. Add extension to `ScopedDisposable` for inner `SerialDisposable` (#873, kudos to @sirnacnud)
 
 # 7.1.1
 1. Bumped deployment target to iOS 11, tvOS 11, watchOS 4, macOS 10.13, per Xcode 14 warnings (#865, kudos to @lickel)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 1. Fix minimum deployment target of iOS 11 in CocoaPods
 1. Fix CI release git tag push trigger (#869, kudos to @p4checo)
+2. Add extension to `ScopedDisposable` for inner `SerialDisposable` (#873, kudos to @sirnacud)
 
 # 7.1.1
 1. Bumped deployment target to iOS 11, tvOS 11, watchOS 4, macOS 10.13, per Xcode 14 warnings (#865, kudos to @lickel)

--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -378,3 +378,19 @@ public final class SerialDisposable: Disposable {
 		state.deinitialize()
 	}
 }
+
+extension ScopedDisposable where Inner == SerialDisposable {
+	/// The current inner disposable of the `SerialDisposable` wrapped
+	/// in the `ScopedDisposable` to dispose of.
+	///
+	/// Whenever this property is set (even to the same value!), the previous
+	/// disposable is automatically disposed.
+	public var inner: Disposable? {
+		get {
+			return inner.inner
+		}
+		set {
+			inner.inner = newValue
+		}
+	}
+}


### PR DESCRIPTION
This adds an extension on `ScopedDisposable` where the inner is a `SerialDisposable`. This allows you to easily update the `inner` of the `SerialDisposable` wrapped in the `ScopedDisposable`.

Example:
```
let scopedDisposable = ScopedDisposable(SerialDisposable())
scopedDisposable.inner = someDisposble
```

#### Checklist
- [x] Updated CHANGELOG.md.
