### PR TITLE
Use unspecified QoS in QueueScheduler when QoS is unspecified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 *Please add new entries at the top.*
 
+1. Change `QueueScheduler` to use unspecified QoS when QoS parameter is defaulted
 1. Add support for VisionOS (#875, kudos to @NachoSoto)
 1. Fix minimum deployment target of iOS 11 in CocoaPods
 1. Fix CI release git tag push trigger (#869, kudos to @p4checo)

--- a/Sources/Scheduler.swift
+++ b/Sources/Scheduler.swift
@@ -363,7 +363,7 @@ public final class QueueScheduler: DateScheduler {
 	///   - targeting: (Optional) The queue on which this scheduler's work is
 	///     targeted
 	public convenience init(
-		qos: DispatchQoS = .default,
+		qos: DispatchQoS = .unspecified,
 		name: String = "org.reactivecocoa.ReactiveSwift.QueueScheduler",
 		targeting targetQueue: DispatchQueue? = nil
 	) {


### PR DESCRIPTION
#### Issue

after doing a bit of research on how libdispatch's 'quality of service' (QoS) propagation logic works, i noticed that the default behavior of `QueueScheduler` is slightly different than what one would get if just using a `DispatchQueue`. i'm not sure if this was intentional, but in practice the consequence is that if you do something like this:

```swift
// assume we're on the main dispatch queue, i.e. QoS is 'user interactive'
let scheduler = QueueScheduler()
scheduler.schedule {
    // do something...
}
```

you end up with the inferred QoS of the scheduled block being set to 'default' QoS, whereas it would be 'user initiated' if using a vanilla `DispatchQueue`. this patch changes the default `qos` parameter from `.default` to `.unspecified` to match `DispatchQueue`'s default behavior. this change might alter behavior of existing code; hopefully not in a detrimental way, but rather will apply the appropriate QoS propagation that one would assume would occur by default. unfortunately, i realize it's probably impossible to determine if this will cause undesirable changes in existing client code, so i'm open to a different approach or not making this change (though IMO it is semantically more appropriate).

#### Description

- changes the default value of the `QueueScheduler`'s `qos` parameter from `.default` to `.unspecified`
- adds a unit test to validate QoS propagation works as expected with the change

#### Checklist
- [x] Updated CHANGELOG.md.
