### PR TITLE
Add primary associated types to property and binding protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 1. Add dynamic library support for SPM (#886 kudos to @mluisbrown)
 
 # 7.2.0
-*Please add new entries at the top.*
-
 1. Change `QueueScheduler` to use unspecified QoS when QoS parameter is defaulted (#880, kudos to @jamieQ)
 1. Add support for visionOS (#875, kudos to @NachoSoto)
 1. Fix CI release git tag push trigger (#869, kudos to @p4checo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 *Please add new entries at the top.*
+1. Add primary associated types to property and binding protocols (#888, kudos to @braker1nine)
 1. Fix the Carthage build checks (kudos to @mluisbrown)
 1. Add dynamic library support for SPM (#886 kudos to @mluisbrown)
 

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -10,17 +10,31 @@ precedencegroup BindingPrecedence {
 
 infix operator <~ : BindingPrecedence
 
+#if swift(>=5.7)
+/// Describes a source which can be bound.
+public protocol BindingSource<Value>: SignalProducerConvertible where Error == Never {}
+#else
 /// Describes a source which can be bound.
 public protocol BindingSource: SignalProducerConvertible where Error == Never {}
+#endif
 extension Signal: BindingSource where Error == Never {}
 extension SignalProducer: BindingSource where Error == Never {}
 
+#if swift(>=5.7)
+/// Describes an entity which be bond towards.
+public protocol BindingTargetProvider<Value> {
+	associatedtype Value
+	
+	var bindingTarget: BindingTarget<Value> { get }
+}
+#else
 /// Describes an entity which be bond towards.
 public protocol BindingTargetProvider {
 	associatedtype Value
 
 	var bindingTarget: BindingTarget<Value> { get }
 }
+#endif
 
 extension BindingTargetProvider {
 	/// Binds a source to a target, updating the target's value to the latest

--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -21,14 +21,14 @@ extension Signal: BindingSource where Error == Never {}
 extension SignalProducer: BindingSource where Error == Never {}
 
 #if swift(>=5.7)
-/// Describes an entity which be bond towards.
+/// Describes an entity which be bound towards.
 public protocol BindingTargetProvider<Value> {
 	associatedtype Value
 	
 	var bindingTarget: BindingTarget<Value> { get }
 }
 #else
-/// Describes an entity which be bond towards.
+/// Describes an entity which be bound towards.
 public protocol BindingTargetProvider {
 	associatedtype Value
 
@@ -60,7 +60,7 @@ extension BindingTargetProvider {
 	/// ````
 	///
 	/// - parameters:
-	///   - target: A target to be bond to.
+	///   - target: A target to be bound to.
 	///   - source: A source to bind.
 	///
 	/// - returns: A disposable that can be used to terminate binding before the
@@ -100,7 +100,7 @@ extension BindingTargetProvider {
 	/// ````
 	///
 	/// - parameters:
-	///   - target: A target to be bond to.
+	///   - target: A target to be bound to.
 	///   - source: A source to bind.
 	///
 	/// - returns: A disposable that can be used to terminate binding before the
@@ -125,7 +125,7 @@ extension Signal.Observer {
 	///         deinitialized, or when the source sends a `completed` event.
 	///
 	/// - parameters:
-	///   - target: A target to be bond to.
+	///   - target: A target to be bound to.
 	///   - source: A source to bind.
 	///
 	/// - returns: A disposable that can be used to terminate binding before the


### PR DESCRIPTION
Including the following protocols 
- PropertyProtocol
- MutablePropertyProtocol
- ComposableMutablePropertyProtocol
- BindingSource
- BindingTargetProvider


#### Checklist
- [x] Updated CHANGELOG.md.
