### PR TITLE
Change keypath `BindingTarget.init` to solve source breaking change in SE-0481 

### DIFF
--- a/Sources/UnidirectionalBinding.swift
+++ b/Sources/UnidirectionalBinding.swift
@@ -185,7 +185,7 @@ public struct BindingTarget<Value>: BindingTargetProvider {
 	///   - lifetime: The expected lifetime of any bindings towards `self`.
 	///   - object: The object to consume values.
 	///   - keyPath: The key path of the object that consumes values.
-	public init<Object: AnyObject>(on scheduler: Scheduler = ImmediateScheduler(), lifetime: Lifetime, object: Object, keyPath: WritableKeyPath<Object, Value>) {
+	public init<Object: AnyObject>(on scheduler: Scheduler = ImmediateScheduler(), lifetime: Lifetime, object: Object, keyPath: ReferenceWritableKeyPath<Object, Value>) {
 		self.init(on: scheduler, lifetime: lifetime) { [weak object] in object?[keyPath: keyPath] = $0 }
 	}
 }


### PR DESCRIPTION
Fixes: #889 

[SE-0481](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0481-weak-let.md) would break the current version of the `BindingTarget.init` that takes a keypath. Changing the keypath type from `WritableKeyPath` to `ReferenceWritableKeyPath` fixes this, and is probably what the type should always have been, since `Object` will always be a reference type.

Despite the signature of the initalizer changing, this is unlikely to break existing code using it, as the keypath is almost always passed using keypath notation (eg : `\.property`) and not using an explicit keypath type.

#### Checklist
- [x] Updated CHANGELOG.md.
